### PR TITLE
Saturn rings: shader with specular, scatter, and analytical shadows

### DIFF
--- a/js/reify.js
+++ b/js/reify.js
@@ -48,4 +48,8 @@ export default function reifyMeasures(obj) {
     reify(atm, 'rayleighScaleHeight', name)
     reify(atm, 'mieScaleHeight', name)
   }
+  if (obj['rings']) {
+    reify(obj['rings'], 'innerRadius', name)
+    reify(obj['rings'], 'outerRadius', name)
+  }
 }

--- a/js/scene/Planet.js
+++ b/js/scene/Planet.js
@@ -3,7 +3,6 @@ import {
   AxesHelper,
   BufferGeometry,
   EllipseCurve,
-  FrontSide,
   Group,
   LOD,
   Line,
@@ -20,9 +19,9 @@ import SpriteSheet from './SpriteSheet.js'
 import {
   ellipseSemiMinorAxisCurve,
   point,
-  rings,
   sphere,
 } from './shapes.js'
+import Rings from './rings/Rings.js'
 import {newAtmosphere} from './atmos/Atmosphere'
 import * as Material from './material.js'
 import {ASTRO_UNIT_METER, FAR_OBJ, labelTextColor, halfPi, toRad} from '../shared.js'
@@ -252,15 +251,10 @@ export default class Planet extends Object {
     if (this.props.texture_atmosphere && !this.props.atmosphere) {
       surface.add(this.newClouds())
     }
-    if (this.props.name === 'saturn') {
-      // surface.add(rings('saturn', false))
-      // surface.castShadow = true
-      // surface.receiveShadow = true
-      surface.add(rings('saturn', true, FrontSide))
-      const underRings = rings('saturn', true, FrontSide)
-      underRings.position.setY(-0.01)
-      underRings.rotateX(Math.PI)
-      surface.add(underRings)
+    if (this.props.rings && this.props.rings.texture) {
+      const ringsObj = new Rings(this.props)
+      ringsObj.injectPlanetShadow(surfaceMaterial)
+      surface.add(ringsObj)
     }
     const group = new Group
     group.add(surface)

--- a/js/scene/rings/Rings.js
+++ b/js/scene/rings/Rings.js
@@ -1,0 +1,270 @@
+import {
+  BufferAttribute,
+  DoubleSide,
+  Mesh,
+  Quaternion,
+  RingGeometry,
+  ShaderMaterial,
+  Vector3,
+} from 'three'
+import * as Material from '../material.js'
+import {VERT} from './rings-vert.js'
+import {FRAG} from './rings-frag.js'
+
+
+/**
+ * Compute the ring UV u-coordinate for a vertex at radius r.
+ * u=0 at inner edge, u=1 at outer edge.
+ *
+ * @param {number} r Distance from planet center in meters.
+ * @param {number} innerR Inner ring radius in meters.
+ * @param {number} outerR Outer ring radius in meters.
+ * @returns {number}
+ */
+export function computeRingUv(r, innerR, outerR) {
+  return (r - innerR) / (outerR - innerR)
+}
+
+
+/**
+ * Returns true if a point at fragPos is in the planet's shadow
+ * (i.e. a ray from fragPos toward sunDir intersects the planet sphere).
+ *
+ * Mirrors the GLSL shadow test in rings-frag.js for unit testing.
+ *
+ * @param {Vector3} fragPos  World position of the ring fragment.
+ * @param {Vector3} sunDir   Unit vector toward the sun (world space).
+ * @param {Vector3} center   Planet center in world space.
+ * @param {number}  radius   Planet radius in meters.
+ * @returns {boolean}
+ */
+export function sphereInShadow(fragPos, sunDir, center, radius) {
+  const ocX = fragPos.x - center.x
+  const ocY = fragPos.y - center.y
+  const ocZ = fragPos.z - center.z
+  const b = (ocX * sunDir.x) + (ocY * sunDir.y) + (ocZ * sunDir.z)
+  const c = (ocX * ocX) + (ocY * ocY) + (ocZ * ocZ) - (radius * radius)
+  const disc = (b * b) - c
+  return disc > 0 && b < 0
+}
+
+
+/**
+ * Returns the ring-plane shadow factor (0 = fully shadowed, 1 = fully lit)
+ * for a planet surface point. Mirrors the GLSL injection in injectPlanetShadow.
+ *
+ * @param {Vector3} surfPos    Planet surface point in world space.
+ * @param {Vector3} sunDir     Unit vector toward sun (world space).
+ * @param {Vector3} ringCenter Ring/planet center in world space.
+ * @param {Vector3} ringNormal Ring plane normal in world space.
+ * @param {number}  innerR     Inner ring radius in meters.
+ * @param {number}  outerR     Outer ring radius in meters.
+ * @param {Function} alphaAt   alphaAt(u) -> [0,1] ring opacity at UV u.
+ * @returns {number} Multiplier for surface light (0.1 to 1.0).
+ */
+export function ringPlaneShadow(surfPos, sunDir, ringCenter, ringNormal, innerR, outerR, alphaAt) {
+  const denom = sunDir.dot(ringNormal)
+  if (Math.abs(denom) < 1e-6) {
+    return 1.0
+  }
+  const diff = new Vector3().subVectors(ringCenter, surfPos)
+  const t = diff.dot(ringNormal) / denom
+  if (t <= 0) {
+    return 1.0
+  }
+  const hitX = surfPos.x + (t * sunDir.x)
+  const hitY = surfPos.y + (t * sunDir.y)
+  const hitZ = surfPos.z + (t * sunDir.z)
+  const hit = new Vector3(hitX, hitY, hitZ)
+  const r = hit.distanceTo(ringCenter)
+  if (r < innerR || r > outerR) {
+    return 1.0
+  }
+  const u = (r - innerR) / (outerR - innerR)
+  const ringAlpha = alphaAt(u)
+  return 1.0 - (ringAlpha * 0.9)
+}
+
+
+/**
+ * Planetary ring system rendered with a custom GLSL shader.
+ *
+ * Features:
+ *   - Radial UV mapping using real inner/outer radii from planet JSON.
+ *   - Alpha-texture transparency (ring gaps like Cassini Division).
+ *   - Blinn-Phong specular for ice-particle glint.
+ *   - Henyey-Greenstein forward scatter (backlit brightening).
+ *   - Analytical planet-shadow-on-rings (sphere test in fragment shader).
+ *   - Ring-shadow-on-planet via injectPlanetShadow(surfaceMaterial).
+ *
+ * Planet JSON "rings" block (Measure strings, same convention as "radius"):
+ *   "rings": {
+ *     "innerRadius": "66900e3 m",
+ *     "outerRadius": "140210e3 m",
+ *     "texture": "saturn"
+ *   }
+ *
+ * reify.js must reify rings.innerRadius and rings.outerRadius before this
+ * constructor is called (see reify.js).
+ */
+export default class Rings extends Mesh {
+  /** @param {object} props Reified planet props (props.rings already reified). */
+  constructor(props) {
+    const {innerRadius, outerRadius, texture} = props.rings
+    const innerR = innerRadius.scalar
+    const outerR = outerRadius.scalar
+
+    const geometry = new RingGeometry(innerR, outerR, 128)
+
+    // Three.js RingGeometry does not produce correct radial UVs by default.
+    // u=0 at inner edge, u=1 at outer edge; v=0.5 (texture is a 1-D strip).
+    const pos = geometry.attributes.position
+    const uvs = new Float32Array(pos.count * 2)
+    const v3 = new Vector3()
+    for (let i = 0; i < pos.count; i++) {
+      v3.fromBufferAttribute(pos, i)
+      const r = v3.length()
+      uvs[i * 2] = computeRingUv(r, innerR, outerR)
+      uvs[(i * 2) + 1] = 0.5
+    }
+    geometry.setAttribute('uv', new BufferAttribute(uvs, 2))
+
+    const material = new ShaderMaterial({
+      uniforms: {
+        uColorMap: {value: Material.pathTexture(`${texture}ringcolor`, '.png')},
+        uAlphaMap: {value: Material.pathTexture(`${texture}ringalpha`, '.png')},
+        // Updated each frame in onBeforeRender.
+        uSunDir: {value: new Vector3(1, 0, 0)},
+        uPlanetCenter: {value: new Vector3()},
+        uPlanetRadius: {value: props.radius.scalar},
+        uInnerRadius: {value: innerR},
+        uOuterRadius: {value: outerR},
+        uSunIntensity: {value: props.atmosphere ? (props.atmosphere.sunIntensity || 1.0) : 1.0},
+      },
+      vertexShader: VERT,
+      fragmentShader: FRAG,
+      transparent: true,
+      side: DoubleSide,
+      depthTest: true,
+      depthWrite: false,
+    })
+
+    super(geometry, material)
+    this.renderOrder = 2
+    // Rotate ring into the XZ plane (equatorial): RingGeometry is in XY plane by default.
+    this.rotateX(Math.PI / 2)
+
+    this._innerR = innerR
+    this._outerR = outerR
+    this._texture = texture
+    this._planetMaterial = null
+    this._tmpWorldPos = new Vector3()
+    this._tmpQuat = new Quaternion()
+    this._tmpNormal = new Vector3()
+
+    this.onBeforeRender = () => {
+      this.getWorldPosition(this._tmpWorldPos)
+      // Sun is at world origin (0, 0, 0); sunDir points from planet toward sun.
+      const sunDir = this._tmpWorldPos.clone().negate().normalize()
+      this.material.uniforms.uSunDir.value.copy(sunDir)
+      this.material.uniforms.uPlanetCenter.value.copy(this._tmpWorldPos)
+
+      if (this._planetMaterial && this._planetMaterial.userData.ringShadowShader) {
+        const rs = this._planetMaterial.userData.ringShadowShader
+        // Ring plane normal = parent surface mesh's world-space Y axis (planet pole).
+        // rotateX(PI/2) on this mesh puts the ring in XZ, so the parent's Y is the normal.
+        if (this.parent) {
+          this.parent.getWorldQuaternion(this._tmpQuat)
+          this._tmpNormal.set(0, 1, 0).applyQuaternion(this._tmpQuat)
+          rs.uniforms.uRingCenter.value.copy(this._tmpWorldPos)
+          rs.uniforms.uRingSunDir.value.copy(sunDir)
+          rs.uniforms.uRingNormal.value.copy(this._tmpNormal)
+        }
+      }
+    }
+  }
+
+
+  /**
+   * Inject ring-shadow code into a planet surface material via onBeforeCompile.
+   * Must be called before the material's first render (before first compile).
+   * The Rings mesh then updates the shadow uniforms each frame in onBeforeRender.
+   *
+   * Injection adds:
+   *   - A world-position varying (vRingWorldPos) computed in the vertex shader.
+   *   - Six uniforms (uRingSunDir, uRingNormal, uRingCenter, uRingInner,
+   *     uRingOuter, uRingAlphaMap) updated per frame.
+   *   - A shadow multiply on gl_FragColor before tone mapping.
+   *
+   * @param {object} planetMaterial Three.js MeshPhysicalMaterial instance.
+   */
+  injectPlanetShadow(planetMaterial) {
+    const innerR = this._innerR
+    const outerR = this._outerR
+    const alphaMap = Material.pathTexture(`${this._texture}ringalpha`, '.png')
+
+    // Chain any previously set onBeforeCompile (e.g. Earth's ocean roughness patch).
+    const prevCompile = planetMaterial.onBeforeCompile
+    planetMaterial.onBeforeCompile = (shader, renderer) => {
+      if (prevCompile) {
+        prevCompile(shader, renderer)
+      }
+
+      // Store shader reference for per-frame uniform updates in onBeforeRender.
+      planetMaterial.userData.ringShadowShader = shader
+
+      shader.uniforms.uRingSunDir = {value: new Vector3(0, 1, 0)}
+      shader.uniforms.uRingNormal = {value: new Vector3(0, 1, 0)}
+      shader.uniforms.uRingCenter = {value: new Vector3()}
+      shader.uniforms.uRingInner = {value: innerR}
+      shader.uniforms.uRingOuter = {value: outerR}
+      shader.uniforms.uRingAlphaMap = {value: alphaMap}
+
+      // Inject world-position varying into vertex shader.
+      shader.vertexShader = `varying vec3 vRingWorldPos;\n${shader.vertexShader}`
+      shader.vertexShader = shader.vertexShader.replace(
+          '#include <begin_vertex>',
+          `#include <begin_vertex>
+        vRingWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;`,
+      )
+
+      // Inject uniforms, varying declaration, and shadow multiply into fragment shader.
+      const ringUniforms = `uniform vec3 uRingSunDir;
+uniform vec3 uRingNormal;
+uniform vec3 uRingCenter;
+uniform float uRingInner;
+uniform float uRingOuter;
+uniform sampler2D uRingAlphaMap;
+varying vec3 vRingWorldPos;
+`
+      shader.fragmentShader = `${ringUniforms}${shader.fragmentShader}`
+
+      // Multiply gl_FragColor by ring shadow factor before tone mapping so the
+      // attenuation happens in linear light space (output_fragment sets gl_FragColor,
+      // tonemapping_fragment follows immediately after).
+      const shadowBlock = `{
+  float _denom = dot(uRingSunDir, uRingNormal);
+  if (abs(_denom) > 1e-6) {
+    float _t = dot(uRingCenter - vRingWorldPos, uRingNormal) / _denom;
+    if (_t > 0.0) {
+      vec3 _hit = vRingWorldPos + _t * uRingSunDir;
+      float _r = length(_hit - uRingCenter);
+      if (_r >= uRingInner && _r <= uRingOuter) {
+        float _u = (_r - uRingInner) / (uRingOuter - uRingInner);
+        float _ringA = texture2D(uRingAlphaMap, vec2(_u, 0.5)).r;
+        gl_FragColor.rgb *= 1.0 - _ringA * 0.9;
+      }
+    }
+  }
+}
+#include <tonemapping_fragment>
+`
+      shader.fragmentShader = shader.fragmentShader.replace(
+          '#include <tonemapping_fragment>',
+          shadowBlock,
+      )
+    }
+    planetMaterial.needsUpdate = true
+    this._planetMaterial = planetMaterial
+  }
+}

--- a/js/scene/rings/Rings.test.js
+++ b/js/scene/rings/Rings.test.js
@@ -1,0 +1,116 @@
+import {describe, expect, test} from 'bun:test'
+import {Vector3} from 'three'
+import {
+  computeRingUv,
+  ringPlaneShadow,
+  sphereInShadow,
+} from './Rings.js'
+
+
+describe('computeRingUv', () => {
+  const innerR = 66900e3
+  const outerR = 140210e3
+
+  test('inner edge maps to u=0', () => {
+    expect(computeRingUv(innerR, innerR, outerR)).toBe(0)
+  })
+
+  test('outer edge maps to u=1', () => {
+    expect(computeRingUv(outerR, innerR, outerR)).toBe(1)
+  })
+
+  test('midpoint maps to u=0.5', () => {
+    const mid = (innerR + outerR) / 2
+    expect(computeRingUv(mid, innerR, outerR)).toBeCloseTo(0.5, 10)
+  })
+
+  test('quarter point maps to u=0.25', () => {
+    const q = innerR + ((outerR - innerR) * 0.25)
+    expect(computeRingUv(q, innerR, outerR)).toBeCloseTo(0.25, 10)
+  })
+})
+
+
+describe('sphereInShadow', () => {
+  const planetCenter = new Vector3(0, 0, 0)
+  const radius = 1e7 // 10,000 km
+  // Sun in the +X direction.
+  const sunDir = new Vector3(1, 0, 0)
+
+  test('fragment on shadow side is in shadow', () => {
+    // Fragment behind planet along the sun ray (sun at +X, fragment at -X).
+    const frag = new Vector3(-2e7, 0, 0)
+    expect(sphereInShadow(frag, sunDir, planetCenter, radius)).toBe(true)
+  })
+
+  test('fragment on lit side is not in shadow', () => {
+    const frag = new Vector3(2e7, 0, 0)
+    expect(sphereInShadow(frag, sunDir, planetCenter, radius)).toBe(false)
+  })
+
+  test('fragment perpendicular to sun is not in shadow', () => {
+    const frag = new Vector3(0, 2e7, 0)
+    expect(sphereInShadow(frag, sunDir, planetCenter, radius)).toBe(false)
+  })
+
+  test('fragment behind planet but outside shadow cylinder is not in shadow', () => {
+    // Slightly behind and well above the shadow cylinder.
+    const frag = new Vector3(-1e6, 5e7, 0)
+    expect(sphereInShadow(frag, sunDir, planetCenter, radius)).toBe(false)
+  })
+})
+
+
+describe('ringPlaneShadow', () => {
+  const innerR = 6.69e7
+  const outerR = 1.4021e8
+  const ringCenter = new Vector3(0, 0, 0)
+  // Ring plane is XZ (normal = Y).
+  const ringNormal = new Vector3(0, 1, 0)
+  // Sun at 45 deg above the equatorial plane so sunDir has a Y component.
+  // denom = dot(sunDir, ringNormal) = 1/sqrt(2) != 0, so the ray intersects the plane.
+  const sunDir = new Vector3(1, 1, 0).normalize()
+  // Opaque ring: alpha = 1.0 everywhere.
+  const opaqueAlpha = (_u) => 1.0
+  // Transparent gap: alpha = 0.0 everywhere.
+  const gapAlpha = (_u) => 0.0
+
+  test('surface point below opaque ring in shadow returns < 1', () => {
+    // Surface point below the equatorial plane (y < 0) at ring-system radius.
+    // sunDir=(1,1,0)/sqrt(2): ray toward sun crosses the ring plane (y=0) at t > 0.
+    // hit.y = 0 confirms intersection; hit.xz radius is within [innerR, outerR].
+    const surfPos = new Vector3(0, -5e6, 8e7)
+    const factor = ringPlaneShadow(surfPos, sunDir, ringCenter, ringNormal, innerR, outerR, opaqueAlpha)
+    // Opaque ring: 1 - 1.0 * 0.9 = 0.1
+    expect(factor).toBeCloseTo(0.1, 5)
+  })
+
+  test('surface point below transparent gap returns 1.0', () => {
+    const surfPos = new Vector3(0, -5e6, 8e7)
+    const factor = ringPlaneShadow(surfPos, sunDir, ringCenter, ringNormal, innerR, outerR, gapAlpha)
+    expect(factor).toBe(1.0)
+  })
+
+  test('surface point at radius inside innerR returns 1.0', () => {
+    // Ray hits ring plane but at r < innerR (inside the planet gap).
+    const surfPos = new Vector3(0, -5e6, 1e6)
+    const factor = ringPlaneShadow(surfPos, sunDir, ringCenter, ringNormal, innerR, outerR, opaqueAlpha)
+    expect(factor).toBe(1.0)
+  })
+
+  test('sun ray parallel to ring plane returns 1.0', () => {
+    // Sun direction lies in the ring plane: no intersection (denom ~ 0).
+    const parallelSunDir = new Vector3(1, 0, 0)
+    const surfPos = new Vector3(0, -5e6, 8e7)
+    const factor = ringPlaneShadow(surfPos, parallelSunDir, ringCenter, ringNormal, innerR, outerR, opaqueAlpha)
+    expect(factor).toBe(1.0)
+  })
+
+  test('surface point on lit side: t <= 0 returns 1.0', () => {
+    // Fragment above the ring plane (y > 0) with sunDir going further above:
+    // the ring plane intersection t is negative (ring is on the far side from the sun).
+    const surfPos = new Vector3(0, 5e6, 8e7)
+    const factor = ringPlaneShadow(surfPos, sunDir, ringCenter, ringNormal, innerR, outerR, opaqueAlpha)
+    expect(factor).toBe(1.0)
+  })
+})

--- a/js/scene/rings/rings-frag.js
+++ b/js/scene/rings/rings-frag.js
@@ -1,0 +1,65 @@
+// Fragment shader for planetary rings.
+// Features:
+//   - Alpha-texture transparency for ring gaps (Cassini Division etc.)
+//   - Blinn-Phong specular for ice-particle glint
+//   - Henyey-Greenstein forward scatter (rings brighten when backlit)
+//   - Analytical planet-shadow-on-rings: sphere intersection test
+export const FRAG = /* glsl */`
+uniform sampler2D uColorMap;
+uniform sampler2D uAlphaMap;
+// Direction from planet toward sun, world space, updated per frame.
+uniform vec3 uSunDir;
+// Planet center in world space, updated per frame.
+uniform vec3 uPlanetCenter;
+uniform float uPlanetRadius;
+uniform float uInnerRadius;
+uniform float uOuterRadius;
+uniform float uSunIntensity;
+
+varying vec2 vUv;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+  float alpha = texture2D(uAlphaMap, vUv).r;
+  if (alpha < 0.01) discard;
+  vec3 color = texture2D(uColorMap, vUv).rgb;
+
+  // Diffuse: rings receive light on both faces.
+  vec3 norm = normalize(vWorldNormal);
+  float nDotL = abs(dot(norm, uSunDir));
+  float diffuse = max(nDotL, 0.05);
+
+  // Specular ice glint (Blinn-Phong, high shininess for icy particles).
+  vec3 viewDir = normalize(cameraPosition - vWorldPos);
+  vec3 halfVec = normalize(uSunDir + viewDir);
+  float spec = pow(max(dot(norm, halfVec), 0.0), 60.0);
+  // Also check the back face normal so both faces glint.
+  spec = max(spec, pow(max(dot(-norm, halfVec), 0.0), 60.0));
+  vec3 specular = vec3(spec) * 0.25;
+
+  // Forward scatter (Henyey-Greenstein, g=0.7).
+  // Rings are brightest when the camera looks toward the sun through them.
+  // cosTheta is negative when camera is between sun and rings.
+  float cosTheta = dot(-uSunDir, viewDir);
+  const float g = 0.7;
+  float hg = (1.0 - g * g) / pow(max(1.0 + g * g - 2.0 * g * cosTheta, 0.001), 1.5);
+  float scatter = hg * 0.15;
+
+  // Planet shadow on rings: ray from ring fragment toward sun, sphere test.
+  // oc = vector from planet center to ring fragment.
+  vec3 oc = vWorldPos - uPlanetCenter;
+  // b = projection of oc onto sunDir (negative when planet is sunward of fragment).
+  float b = dot(oc, uSunDir);
+  // c = |oc|^2 - R^2  (positive when fragment is outside the planet).
+  float c = dot(oc, oc) - uPlanetRadius * uPlanetRadius;
+  float disc = b * b - c;
+  // disc > 0: ray hits planet sphere; b < 0: planet is between fragment and sun.
+  float inShadow = (disc > 0.0 && b < 0.0) ? 1.0 : 0.0;
+  // 15% ambient leaks into the shadow umbra.
+  float shadowFactor = 1.0 - inShadow * 0.85;
+
+  vec3 lit = (color * diffuse + specular + color * scatter) * shadowFactor * uSunIntensity;
+  gl_FragColor = vec4(lit, alpha);
+}
+`

--- a/js/scene/rings/rings-vert.js
+++ b/js/scene/rings/rings-vert.js
@@ -1,0 +1,22 @@
+// Vertex shader for planetary rings.
+// Computes radial UV from geometry position (ring is in XY plane before mesh rotation).
+// Passes world position and world normal to fragment shader for lighting/shadow.
+export const VERT = /* glsl */`
+uniform float uInnerRadius;
+uniform float uOuterRadius;
+
+varying vec2 vUv;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+  // Ring geometry lies in XY plane; radius is distance from center in that plane.
+  float r = length(position.xy);
+  // u = 0 at inner edge, u = 1 at outer edge; v = 0.5 (texture is a 1-D strip).
+  vUv = vec2((r - uInnerRadius) / (uOuterRadius - uInnerRadius), 0.5);
+  vec4 worldPos4 = modelMatrix * vec4(position, 1.0);
+  vWorldPos = worldPos4.xyz;
+  vWorldNormal = normalize(mat3(modelMatrix) * normal);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`

--- a/js/scene/rings/rings.md
+++ b/js/scene/rings/rings.md
@@ -1,0 +1,347 @@
+# Planetary Rings Plan
+
+## Current state and problems
+
+`js/scene/shapes.js:523` exports a `rings()` function used only in `Planet.js:255`:
+
+- **Hardcoded geometry**: `RingGeometry(3, 6, 64)` in arbitrary units, not meters.
+- **Broken UV mapping**: binary inner/outer UV hack; the code comment says "I still don't understand UVs".
+- **Hardcoded to Saturn**: `if (this.props.name === 'saturn')` block in Planet.js.
+- **Two-mesh double-side hack**: a second flipped mesh offset by 0.01 to see rings from below.
+- **Shadows disabled**: `renderer.shadowMap.enabled` is commented out in ThreeUI.js. Even if enabled, Three.js PCF shadow maps cannot work at cosmic scale — the sun PointLight is 1.43 × 10¹² m from Saturn, and the shadow camera would need near=6e8 m, far=1.5e12 m, giving dynamic range ~2500:1 but the ring detail itself requires sub-1000 km shadow-map texels against an object that is ~100,000 km across. Shadow maps are a dead end here.
+- **No shader**: plain `MeshStandardMaterial` with no specular glint, no forward scatter.
+- **`depthTest: false`, `depthWrite: false`**: hacks around the broken double-face rendering.
+
+---
+
+## Goal
+
+A self-contained `js/scene/rings/` module that:
+
+1. Renders correct, data-driven ring geometry for any planet that declares a `rings` block in its JSON.
+2. Has proper radial UV mapping so the color and alpha textures map cleanly across the ring width.
+3. Uses a custom GLSL shader for:
+   - **Transparency** from the alpha texture — ring gaps (Cassini Division, etc.) are genuinely transparent.
+   - **Specular ice glint** — icy ring particles catch the sun at high angles.
+   - **Forward scatter** — rings brighten when backlit (as seen from the lit side looking toward the sun).
+   - **Planet shadow on rings** (analytical sphere intersection in ring frag shader).
+   - **Ring shadow on planet** (analytical ring-plane intersection injected into planet's surface shader via `onBeforeCompile`).
+4. Is abstracted enough to work for Saturn (rich textures), Uranus (thin, dark), Neptune (thin, dark), and Jupiter (very faint) — and future parametric planets.
+
+---
+
+## Ring data format
+
+Add a `rings` block to each ringed planet's JSON, using Measure strings (same convention as `radius`):
+
+```json
+"rings": {
+  "innerRadius": "66900e3 m",
+  "outerRadius": "140210e3 m",
+  "texture": "saturn"
+}
+```
+
+- `innerRadius` / `outerRadius`: distance from planet center in meters.
+- `texture`: base name used to load `${texture}ringcolor.png` and `${texture}ringalpha.png`.
+  If `texture` is omitted, skip the rings mesh entirely (allows future procedural rings).
+
+`reify.js` must be extended to reify `obj.rings.innerRadius` and `obj.rings.outerRadius` via `Measure.parse(val).convertToUnit()`, following the same pattern as `obj.atmosphere.height`.
+
+### Values per planet
+
+| Planet  | innerRadius | outerRadius | texture |
+|---------|-------------|-------------|---------|
+| Saturn  | 66900e3 m   | 140210e3 m  | saturn  |
+| Uranus  | 38000e3 m   | 51150e3 m   | uranus  |
+| Neptune | 41900e3 m   | 62932e3 m   | neptune |
+| Jupiter | 122500e3 m  | 129000e3 m  | jupiter |
+
+Uranus, Neptune, and Jupiter have no textures yet. Stubs go in the JSON; ring mesh is skipped until textures exist (guard: `if (!texture) return null`).
+
+---
+
+## Files
+
+### New files
+
+```
+js/scene/rings/rings.md        — this document
+js/scene/rings/Rings.js        — Rings class
+js/scene/rings/rings-vert.js   — GLSL vertex shader (exported as a string)
+js/scene/rings/rings-frag.js   — GLSL fragment shader (exported as a string)
+js/scene/rings/Rings.test.js   — unit tests
+```
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `js/scene/shapes.js` | Remove the `rings()` function entirely |
+| `js/scene/Planet.js` | Replace `if (name === 'saturn')` with `if (props.rings) surface.add(new Rings(props))` |
+| `js/reify.js` | Add `rings` sub-object reification |
+| `public/data/saturn.json` | Add `rings` block |
+| `public/data/uranus.json` | Add `rings` stub (no texture yet) |
+| `public/data/neptune.json` | Add `rings` stub (no texture yet) |
+| `public/data/jupiter.json` | Add `rings` stub (no texture yet) |
+
+---
+
+## Phase 1 — Geometry, UV, transparency
+
+**Goal:** visually better than the current hack, no custom shader yet.
+
+### Geometry
+
+```js
+new RingGeometry(innerRadius, outerRadius, 128)
+```
+
+Real meters, sourced from `props.rings.innerRadius.scalar` and `props.rings.outerRadius.scalar`.
+
+### UV mapping
+
+Three.js `RingGeometry` does not produce radial UVs. Fix in the constructor after geometry creation:
+
+```js
+const pos = geometry.attributes.position
+const uvs = new Float32Array(pos.count * 2)
+const v3 = new Vector3()
+for (let i = 0; i < pos.count; i++) {
+  v3.fromBufferAttribute(pos, i)
+  const r = v3.length()
+  uvs[i * 2] = (r - innerR) / (outerR - innerR)  // u: 0 at inner edge, 1 at outer
+  uvs[i * 2 + 1] = 0.5                             // v: constant (texture is a 1D strip)
+}
+geometry.setAttribute('uv', new BufferAttribute(uvs, 2))
+```
+
+### Material (Phase 1)
+
+`MeshStandardMaterial` with:
+- `map`: `saturnringcolor.png`
+- `alphaMap`: `saturnringalpha.png`
+- `transparent: true`
+- `side: DoubleSide` — eliminates the flipped-mesh hack
+- `depthTest: true`, `depthWrite: false` — correct for transparent objects
+- `renderOrder: 2` — renders after planet surface (`renderOrder: 1`)
+
+### Orientation
+
+The ring plane must lie in the planet's equatorial plane. Saturn's `axialInclination` tilts the planet within its `planetTilt` group, so the rings (added as children of the surface) automatically tilt with it. The ring mesh lies in the XZ plane of Three.js object space by default from `RingGeometry` — that is correct.
+
+---
+
+## Phase 2 — Custom GLSL shader
+
+Replace `MeshStandardMaterial` with `ShaderMaterial`. All Phase 1 UV logic moves into the vertex shader.
+
+### Vertex shader (`rings-vert.js`)
+
+```glsl
+uniform float uInnerRadius;
+uniform float uOuterRadius;
+
+varying vec2  vUv;
+varying vec3  vWorldPos;
+varying vec3  vWorldNormal;
+
+void main() {
+  float r = length(position.xy);
+  vUv = vec2((r - uInnerRadius) / (uOuterRadius - uInnerRadius), 0.5);
+  vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
+  vWorldNormal = normalize(mat3(modelMatrix) * normal);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+```
+
+### Fragment shader (`rings-frag.js`)
+
+Uniforms:
+
+| Uniform | Type | Description |
+|---------|------|-------------|
+| `uColorMap` | sampler2D | Ring color texture |
+| `uAlphaMap` | sampler2D | Ring alpha/opacity texture |
+| `uSunDir` | vec3 | Unit vector from planet center toward sun (world space) |
+| `uPlanetCenter` | vec3 | Planet center in world space |
+| `uPlanetRadius` | float | Planet radius in meters |
+| `uInnerRadius` | float | Ring inner radius in meters |
+| `uOuterRadius` | float | Ring outer radius in meters |
+| `uSunIntensity` | float | Sun brightness scalar (from planet's atmosphere.sunIntensity or 1.0) |
+
+Fragment logic:
+
+1. **Sample and discard**
+   ```glsl
+   float alpha = texture2D(uAlphaMap, vUv).r;
+   if (alpha < 0.01) discard;
+   vec3 color = texture2D(uColorMap, vUv).rgb;
+   ```
+
+2. **Diffuse lighting** — rings are lit on both faces; use `abs(dot(...))`:
+   ```glsl
+   float nDotL = abs(dot(normalize(vWorldNormal), uSunDir));
+   float diffuse = max(nDotL, 0.05);  // 0.05 ambient floor
+   ```
+
+3. **Specular ice glint** — icy ring particles produce a specular highlight:
+   ```glsl
+   vec3 viewDir = normalize(cameraPosition - vWorldPos);
+   vec3 halfVec = normalize(uSunDir + viewDir);
+   float spec = pow(max(dot(vWorldNormal, halfVec), 0.0), 60.0);
+   // Apply on both faces
+   spec = max(spec, pow(max(dot(-vWorldNormal, halfVec), 0.0), 60.0));
+   vec3 specular = vec3(spec) * 0.25;
+   ```
+
+4. **Forward scatter (Henyey–Greenstein)** — rings are brightest when backlit:
+   ```glsl
+   // cosTheta negative when camera is between sun and rings
+   float cosTheta = dot(-uSunDir, viewDir);
+   float g = 0.7;
+   float hg = (1.0 - g * g) / pow(1.0 + g * g - 2.0 * g * cosTheta, 1.5);
+   float scatter = hg * 0.15;
+   ```
+
+5. **Planet shadow on rings** — analytical sphere intersection:
+   ```glsl
+   // Ray from ring fragment toward sun; does it hit the planet?
+   vec3 oc = vWorldPos - uPlanetCenter;
+   float b = dot(oc, uSunDir);
+   float c = dot(oc, oc) - uPlanetRadius * uPlanetRadius;
+   float disc = b * b - c;
+   float inShadow = (disc > 0.0 && b < 0.0) ? 1.0 : 0.0;
+   // b < 0 means planet is between fragment and sun
+   float shadowFactor = 1.0 - inShadow * 0.85;  // 15% ambient in shadow
+   ```
+
+6. **Combine**
+   ```glsl
+   vec3 lit = (color * diffuse + specular + color * scatter) * shadowFactor * uSunIntensity;
+   gl_FragColor = vec4(lit, alpha);
+   ```
+
+### Ring shadow on planet (`onBeforeCompile` injection)
+
+Inject a shadow test into the planet's surface fragment shader. The ring plane in planet-local space is y = 0. The ring shadow attenuates the direct sunlight reaching the planet surface.
+
+Uniforms injected into the planet material:
+- `uRingSunDir` (vec3) — sun direction in world space
+- `uRingNormal` (vec3) — ring plane normal in world space (same as planet pole direction)
+- `uRingPlanePoint` (vec3) — any point on the ring plane (planet center)
+- `uRingInner` (float)
+- `uRingOuter` (float)
+- `uRingAlphaMap` (sampler2D)
+- `uRingInnerRadius` and `uRingOuterRadius` for UV computation
+
+Shader injection: replace `#include <lights_fragment_begin>` to prepend a shadow multiplier:
+
+```glsl
+// Ray from surface fragment toward sun; intersect with ring plane
+float denom = dot(uRingSunDir, uRingNormal);
+float ringShadow = 1.0;
+if (abs(denom) > 1e-6) {
+  float t = dot(uRingPlanePoint - vWorldPosition, uRingNormal) / denom;
+  if (t > 0.0) {  // intersection is between fragment and sun
+    vec3 hit = vWorldPosition + t * uRingSunDir;
+    float r = length(hit - uRingPlanePoint);
+    if (r >= uRingInner && r <= uRingOuter) {
+      float u = (r - uRingInner) / (uRingOuter - uRingInner);
+      float ringAlpha = texture2D(uRingAlphaMap, vec2(u, 0.5)).r;
+      ringShadow = 1.0 - ringAlpha * 0.9;  // 10% ambient leaks through
+    }
+  }
+}
+// Multiply direct light by ringShadow before it is used
+directLight.color *= ringShadow;
+```
+
+The `uRingSunDir`, `uRingNormal`, and `uRingPlanePoint` uniforms must be updated each frame in `Animation.animate()` (or a new per-frame hook on the planet object), since the planet's orbital position changes the geometry.
+
+---
+
+## Rings.js class sketch
+
+```js
+export default class Rings extends Mesh {
+  constructor(props) {
+    const {innerRadius, outerRadius, texture} = props.rings
+    const innerR = innerRadius.scalar
+    const outerR = outerRadius.scalar
+
+    const geometry = new RingGeometry(innerR, outerR, 128)
+    // ... fix UVs (Phase 1) or let vertex shader handle it (Phase 2)
+
+    const material = new ShaderMaterial({
+      uniforms: {
+        uColorMap:     {value: Material.pathTexture(`${texture}ringcolor`, '.png')},
+        uAlphaMap:     {value: Material.pathTexture(`${texture}ringalpha`, '.png')},
+        uSunDir:       {value: new Vector3(1, 0, 0)},  // updated per frame
+        uPlanetCenter: {value: new Vector3},            // updated per frame
+        uPlanetRadius: {value: props.radius.scalar},
+        uInnerRadius:  {value: innerR},
+        uOuterRadius:  {value: outerR},
+        uSunIntensity: {value: props.atmosphere?.sunIntensity ?? 1.0},
+      },
+      vertexShader: VERT,
+      fragmentShader: FRAG,
+      transparent: true,
+      side: DoubleSide,
+      depthTest: true,
+      depthWrite: false,
+    })
+
+    super(geometry, material)
+    this.renderOrder = 2
+  }
+
+  // Called from Animation or Planet each frame with sun position in world space
+  updateSunDir(sunWorldPos, planetWorldPos) {
+    const dir = new Vector3().subVectors(sunWorldPos, planetWorldPos).normalize()
+    this.material.uniforms.uSunDir.value.copy(dir)
+    this.material.uniforms.uPlanetCenter.value.copy(planetWorldPos)
+  }
+}
+```
+
+---
+
+## Rings.test.js
+
+Unit tests to cover:
+- UV computation: vertex at `innerR` → u=0, vertex at `outerR` → u=1, midpoint → u=0.5
+- `Rings` constructor: throws if `props.rings` is missing required fields
+- `Rings` constructor: geometry has correct `innerRadius` and `outerRadius` parameters
+- Shadow sphere test logic (pure math, no Three.js): given ray origin, direction, sphere — correct in-shadow / not-in-shadow results
+- Ring-plane intersection logic: sun ray from planet surface, intersects ring plane at expected r, maps to expected UV u
+
+---
+
+## Verification checklist
+
+Phase 1:
+- [ ] Rings are visible at Saturn from orbit view
+- [ ] Color and alpha textures map correctly across the ring width (no binary inner/outer jump)
+- [ ] Cassini Division gap is transparent (alpha texture shows through to space)
+- [ ] Rings visible from below and above Saturn
+- [ ] No z-fighting with planet surface
+
+Phase 2 (shader):
+- [ ] Ice specular glint visible at oblique sun angles
+- [ ] Rings brighten when camera looks toward the sun through the rings
+- [ ] Dark band on rings where Saturn's shadow falls (especially visible when Saturn is near equinox)
+- [ ] Dark band on Saturn's surface where ring shadow falls (especially visible from equatorial view)
+- [ ] Navigate to Saturn → press 'u' → shadow still renders correctly
+- [ ] Navigate Sun → Earth → Saturn: shadows correct on first and return visit
+- [ ] Check at Saturn equinox geometry (axial tilt ≈ 0 mod 90°): shadow band crosses full ring width
+- [ ] No regression on planets without rings (Earth, Mars, etc.)
+
+---
+
+## Known issues deferred
+
+- Uranus/Neptune/Jupiter ring textures: need to be created or sourced.
+- Ring self-shadowing (A ring shadows B ring): not modelled; single-plane treatment.
+- Ring system geometry: all rings treated as a single annulus. Separate band meshes (D, C, B, A) could give better detail but require multiple draw calls.
+- `uSunDir` update hook: currently proposed in Animation; exact integration point TBD during implementation.

--- a/js/scene/shapes.js
+++ b/js/scene/shapes.js
@@ -9,7 +9,6 @@ import {
   ConeGeometry,
   DoubleSide,
   EllipseCurve,
-  FrontSide,
   GridHelper,
   LOD,
   Line,
@@ -18,13 +17,11 @@ import {
   MeshBasicMaterial,
   MeshLambertMaterial,
   MeshPhongMaterial,
-  MeshStandardMaterial,
   Object3D,
   PlaneGeometry,
   Points,
   PointsMaterial,
   RepeatWrapping,
-  RingGeometry,
   ShaderMaterial,
   Shape,
   ShapeGeometry,
@@ -38,7 +35,6 @@ import {
   Vector3,
 } from 'three'
 import SpriteSheet from './SpriteSheet.js'
-import * as Material from './material.js'
 import * as Shared from '../shared.js'
 import {named} from '../utils.js'
 
@@ -512,43 +508,4 @@ function arc(rad, startAngle, arcAngle, materialOrOpts) {
   const geometry = new BufferGeometry().setFromPoints(points)
   const material = new LineBasicMaterial(opts)
   return new Line(geometry, material)
-}
-
-
-/**
- * Just Saturn for now.
- *
- * @returns {Mesh}
- */
-export function rings(name = 'saturn', shadows = true, side = FrontSide) {
-  const geometry = new RingGeometry(3, 6, 64)
-  const textureMap = Material.pathTexture(`${name}ringcolor`, '.png')
-  const alphaMap = Material.pathTexture(`${name}ringalpha`, '.png')
-  const material = new MeshStandardMaterial({
-    color: 0xffffff,
-    side: shadows ? side : DoubleSide,
-    map: textureMap,
-    alphaMap: alphaMap,
-    transparent: true,
-    depthTest: false,
-    depthWrite: false,
-  })
-  // I still don't understand UVs.
-  // https://discourse.threejs.org/t/applying-a-texture-to-a-ringgeometry/9990/3
-  const pos = geometry.attributes.position
-  geometry.setAttribute('uv', new BufferAttribute(new Float32Array(pos.count * 4), 4))
-  const v3 = new Vector3()
-  for (let i = 0; i < pos.count; i++) {
-    v3.fromBufferAttribute(pos, i)
-    geometry.attributes.uv.setXY(i, v3.length() < 4 ? 1 : 0, 1)
-  }
-  const r = new Mesh(geometry, material)
-  /* if (shadows) {
-    r.castShadow = true
-    r.receiveShadow = true
-  } */
-  r.scale.setScalar(0.4)
-  r.rotateY(Math.PI / 2)
-  r.rotateX(Math.PI / 2)
-  return r
 }

--- a/public/data/saturn.json
+++ b/public/data/saturn.json
@@ -34,6 +34,11 @@
     "siderealOrbitPeriod": 9.28656296928E8
   },
   "system": ["titan","rhea","dione","tethys","iapetus","hyperion","janus"],
+  "rings": {
+    "innerRadius": "66900e3 m",
+    "outerRadius": "140210e3 m",
+    "texture": "saturn"
+  },
   "atmosphere": {
     "height": "4e5 m",
     "sunIntensity": 4,


### PR DESCRIPTION
<img width="1470" height="881" alt="image" src="https://github.com/user-attachments/assets/2c27d428-06c2-4a72-a8db-4e98a3476080" />

http://localhost:8090/#sun/saturn@21.6445,-12.6257,215.888389Mm;t=9580.0073jd;cq=-0.0914,0.5421,0.0816,0.8314;fov=45deg

## Summary

- Replaces the broken rings hack (hardcoded non-metric scale, broken UVs, flipped-mesh double-side workaround, disabled shadows) with a self-contained `js/scene/rings/` module
- Custom GLSL shader: Blinn-Phong specular ice glint + Henyey-Greenstein forward scatter (rings brighten when backlit) + analytical planet-shadow-on-rings (sphere intersection test — no shadow maps needed at cosmic scale)
- Ring shadow on Saturn's surface: ring-plane intersection injected into the planet's `MeshPhysicalMaterial` via `onBeforeCompile`, applied before tone mapping
- Data-driven: `rings.innerRadius`/`outerRadius` Measure strings in `saturn.json`; `reify.js` extended; `Planet.js` uses `props.rings.texture` guard (ready for Uranus/Neptune/Jupiter once textures exist)
- 13 unit tests covering UV math, sphere shadow geometry, and ring-plane shadow edge cases

## Test plan

- [ ] Rings visible from orbit view above Saturn
- [ ] Color and alpha textures map correctly — Cassini Division gap is transparent
- [ ] Rings visible from below Saturn (DoubleSide, no flipped-mesh hack)
- [ ] Ice specular glint at oblique sun angles
- [ ] Rings brighten when camera looks toward sun through them
- [ ] Dark shadow band on rings where Saturn blocks sunlight
- [ ] Dark shadow band on Saturn's surface where rings block sunlight
- [ ] Navigate to Saturn → press 'u' → shadows still correct
- [ ] No regression on other planets (Earth, Mars, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)