### PR TITLE
Search: breadcrumb-anchored chips with modular Fuse index

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -262,9 +262,12 @@ LOD (`THREE.LOD`) is used throughout to swap between detailed meshes, point spri
 
 ## State Management (Zustand)
 
-`js/store/useStore.js` composes three slices:
+`js/store/useStore.js` composes four slices:
 
 - `AsterismsSlice` — asterisms visibility and catalog state
+- `SearchSlice` — search-bar state, anchor index, committed path / star,
+  preview fields; `setCommittedPath` and `setCommittedStar` are mutually
+  exclusive
 - `StarsSlice` — star selection / filter state
 - `TimeSlice` — time panel UI state
 
@@ -286,6 +289,9 @@ Thin MUI-based overlay panels:
 - `TimePanel` — displays sim time, pause/play, time-scale controls
 - `Settings` — keyboard shortcut reference
 - `About` — app info and star catalog stats
+- `SearchBar` — breadcrumb-anchored search (chips, MUI `Autocomplete`,
+  crosshair picker toggle, preview + commit flow). See
+  [js/search/DESIGN.md](js/search/DESIGN.md) for the index architecture.
 - `DatePicker`, `NumberField`, `NumberInput` — supporting inputs
 - `TooltipToggleButton`, `TooltipIconButton`, `NavToggleButton` — icon button wrappers
 
@@ -322,6 +328,21 @@ Hot-reload in development: `esbuild/serve.js` calls `ctx.watch()` unconditionall
 | `js/coords.js` | Geographic coordinate conversions: `worldToLatLngAlt`, `latLngAltToLocal` |
 | `js/store/useStore.js` | Zustand store root |
 | `public/data/*.json` | Celestial object descriptors |
+
+### Search (`js/search/`)
+
+| Path | Role |
+|---|---|
+| `js/search/SearchIndex.js` | Tiered index + app-wide singleton |
+| `js/search/SearchRegistry.js` | Provider registration singleton |
+| `js/search/SearchProvider.js` | JSDoc typedefs for `SearchEntry` / provider contract |
+| `js/search/providers/SceneProvider.js` | Bodies loaded by `Loader` |
+| `js/search/providers/StarsProvider.js` | Named stars + exact HIP resolver |
+| `js/search/providers/PlacesProvider.js` | Future surface-place stub |
+
+See [js/search/DESIGN.md](js/search/DESIGN.md) for the full architecture:
+tier structure (A/B/C), Fuse.js tuning, scoping semantics, commit flow,
+and the provider extension contract.
 
 ### Scene objects and support (`js/scene/`)
 

--- a/js/App.jsx
+++ b/js/App.jsx
@@ -7,32 +7,45 @@ import Stack from '@mui/material/Stack'
 import Celestiary from './Celestiary'
 import useStore from './store/useStore'
 import About from './ui/About'
+import SearchBar from './ui/SearchBar'
 import Settings from './ui/Settings'
 import TimePanel from './ui/TimePanel'
 import TooltipToggleButton from './ui/TooltipToggleButton'
-import {setTitleFromLocation} from './utils'
+import {capitalize} from './utils'
 import SettingsIcon from '@mui/icons-material/Settings'
 import StarsIcon from '@mui/icons-material/AutoAwesome'
-import StarSelectIcon from '@mui/icons-material/SavedSearch'
 import './index.css'
 
 
 /** @returns {ReactElement} */
 export default function App() {
-  const toggleIsStarsSelectActive = useStore((state) => state.toggleIsStarsSelectActive)
+  const committedPath = useStore((s) => s.committedPath)
+  const committedStar = useStore((s) => s.committedStar)
   const [celestiary, setCelestiary] = useState(null)
   const [isPaused, setIsPaused] = useState(false)
   const [timeStr, setTimeStr] = useState('')
 
   const sceneRef = useRef(null)
-  const navRef = useRef(null)
+  const navInfoRef = useRef(null)
 
   const [location, navigate] = useLocation()
   const [hashLocation] = useHashLocation()
 
-  useEffect(() => setTitleFromLocation(location), [location])
+  // Page title tracks the committed target.  Leaf-first so the active body
+  // is visible even in truncated tab titles.
   useEffect(() => {
-    const c = new Celestiary(useStore, sceneRef.current, navRef.current, setTimeStr, setIsPaused)
+    let leaf = null
+    if (location === '/guide') {
+      leaf = 'Guide'
+    } else if (committedStar && committedStar.displayName) {
+      leaf = committedStar.displayName
+    } else if (committedPath.length > 0) {
+      leaf = capitalize(committedPath[committedPath.length - 1])
+    }
+    document.title = leaf ? `${leaf} — Celestiary` : 'Celestiary'
+  }, [location, committedPath, committedStar])
+  useEffect(() => {
+    const c = new Celestiary(useStore, sceneRef.current, navInfoRef.current, setTimeStr, setIsPaused)
     setCelestiary(c)
     c.keys.map('?', () => navigate('/settings'), 'Show keyboard shortcuts')
   }, [])
@@ -41,7 +54,10 @@ export default function App() {
     <>
       <ScopedCssBaseline/>
       <div ref={sceneRef} id='scene-id'/>
-      <div ref={navRef} id='nav-id' className='panel'>Welcome to Celestiary!  Loading...</div>
+      <div id='nav-id' className='panel'>
+        {celestiary && <SearchBar celestiary={celestiary}/>}
+        <div ref={navInfoRef} id='nav-info-id'>Welcome to Celestiary!  Loading...</div>
+      </div>
       <Stack id='top-right' className='panel' direction='column' justifyContent='flex-start' alignItems='flex-end'>
         {celestiary && <TimePanel time={celestiary.time} timeStr={timeStr} isPaused={isPaused} setIsPaused={setIsPaused}/>}
         <div id='text-buttons'>
@@ -58,8 +74,6 @@ export default function App() {
             </Box>
           }
         </div>
-        <TooltipToggleButton tip='select' icon={<StarSelectIcon/>} onClick={toggleIsStarsSelectActive}/>
       </Stack>
-      <h1 id='target-id'> </h1>
     </>)
 }

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -4,6 +4,10 @@ import ControlPanel from './ControlPanel'
 import Keys from './Keys'
 import Loader from './Loader'
 import Scene from './scene/Scene'
+import {searchIndex} from './search/SearchIndex'
+import PlacesProvider from './search/providers/PlacesProvider'
+import SceneProvider from './search/providers/SceneProvider'
+import StarsProvider from './search/providers/StarsProvider'
 import ThreeUi from './ThreeUI'
 import Time, {fromJulianDay} from './Time'
 import reifyMeasures from './reify'
@@ -49,6 +53,8 @@ export default class Celestiary {
     this.firstTime = true
     this._pendingPermalink = null
     this._permalinkTimer = null
+    this._registerSearchProviders()
+    this._subscribePreview()
     this.load()
     this.setupPathListeners()
     this.setupKeyListeners(useStore)
@@ -72,6 +78,70 @@ export default class Celestiary {
   }
 
 
+  /**
+   * Single re-entry point for info-panel rendering.  Fires whenever preview or
+   * committed state changes.  Precedence: previewStar > previewPath >
+   * committedPath.  Without this hub the navigation path would have to render
+   * the panel directly (which it used to) AND the preview code would have its
+   * own render path, making flicker-free transitions impossible.
+   */
+  _subscribePreview() {
+    this.useStore.subscribe((state, prev) => {
+      if (state.previewStar === prev.previewStar &&
+          state.previewPath === prev.previewPath &&
+          state.committedStar === prev.committedStar &&
+          state.committedPath === prev.committedPath) {
+        return
+      }
+      // Precedence: hovered/highlighted preview wins over committed selection;
+      // within each level, star > body-path.
+      if (state.previewStar) {
+        this.controlPanel.showStarPreview(state.previewStar)
+      } else if (state.previewPath && state.previewPath.length > 0) {
+        this.controlPanel.showNavDisplay(state.previewPath)
+      } else if (state.committedStar) {
+        this.controlPanel.showStarPreview(state.committedStar)
+      } else if (state.committedPath && state.committedPath.length > 0) {
+        this.controlPanel.showNavDisplay(state.committedPath)
+      }
+    })
+  }
+
+
+  /**
+   * Wire the app-wide search index.  SceneProvider and PlacesProvider are
+   * ready immediately; StarsProvider registers once the star catalog
+   * finishes async-loading (Stars.js sets `starsCatalog` on the store).
+   */
+  _registerSearchProviders() {
+    searchIndex.register(new SceneProvider(this.loader))
+    searchIndex.register(new PlacesProvider())
+    // StarsCatalog mutates in place — after load, prev.starsCatalog and
+    // state.starsCatalog are the same object (both already populated), so a
+    // before/after numStars comparison always sees equal.  Track registration
+    // with a local flag instead, and also try once immediately in case the
+    // catalog was already populated before we subscribed.
+    let registered = false
+    const tryRegister = (cat) => {
+      if (registered || !cat || !cat.numStars || cat.numStars <= 0) {
+        return false
+      }
+      registered = true
+      searchIndex.register(new StarsProvider(cat))
+      searchIndex.invalidate()
+      return true
+    }
+    if (tryRegister(this.useStore.getState().starsCatalog)) {
+      return
+    }
+    const unsub = this.useStore.subscribe((state) => {
+      if (tryRegister(state.starsCatalog)) {
+        unsub()
+      }
+    })
+  }
+
+
   /** */
   load() {
     let path
@@ -88,7 +158,10 @@ export default class Celestiary {
       this.scene.add(obj)
     }
     this.onDone = (loadedPath, obj) => {
-      this.controlPanel.showNavDisplay(loadedPath.split('/'), this.loader)
+      const pathParts = loadedPath.split('/')
+      // Updating committedPath fires the preview subscription (_subscribePreview)
+      // which owns info-panel rendering; no direct showNavDisplay here.
+      this.useStore.getState().setCommittedPath(pathParts)
       // TODO(pablo): Hack to handle load order.  The path is loaded,
       // but not yet animated so positions will be incorrect.  So
       // schedule this after the next pass.
@@ -152,8 +225,18 @@ export default class Celestiary {
   }
 
 
-  /** */
+  /**
+   * Travel to the current committed target.  Precedence: a committed star
+   * (set via search or crosshair dblclick) wins over the planet target —
+   * otherwise 'g' from a star-scoped body would always bounce back to the
+   * last-set planet via the stale Shared.targets.obj.
+   */
   goTo() {
+    const state = this.useStore.getState()
+    if (state.committedStar && state.committedStar.star) {
+      this.scene.goTo(state.committedStar.star)
+      return
+    }
     const tObj = this.shared.targets.obj
     if (tObj) {
       if (tObj.props && tObj.props.name) {
@@ -283,11 +366,12 @@ export default class Celestiary {
     },
     'Go to target node')
     k.map('h', () => {
+      // Just retarget — travel is 'g'.  setTarget syncs the store, which
+      // clears committedStar so a stale "at Rigel" breadcrumb doesn't
+      // linger after aiming back at the Sun.
       this.scene.targetNamed('sun')
-      this.scene.goTo()
-      history.pushState(null, '', '#sun')
     },
-    'Go home (Sun)')
+    'Set target to Sun (use "g" to travel)')
     k.map('t', () => {
       this.scene.track()
     },

--- a/js/Celestiary.test.js
+++ b/js/Celestiary.test.js
@@ -189,6 +189,20 @@ mock.module('./vsop', () => ({
 }))
 
 
+// Zustand-like useStore stub: callable hook + getState/setState/subscribe.
+// Real Celestiary reaches into store.getState() to push state (e.g. committedPath).
+function makeStubStore() {
+  const state = {
+    setCommittedPath: () => {},
+  }
+  const hook = () => ({})
+  hook.getState = () => state
+  hook.setState = () => {}
+  hook.subscribe = () => () => {}
+  return hook
+}
+
+
 // ---- Celestiary loaded dynamically so mocks are in place first ----
 
 let Celestiary
@@ -211,7 +225,7 @@ describe('Celestiary permalink restore', () => {
       addEventListener: () => {},
     }
     app = new Celestiary(
-        () => ({}), // useStore
+        makeStubStore(), // useStore
         canvasContainer,
         {}, // navElt
         () => {}, // setTimeStr
@@ -291,7 +305,7 @@ describe('Scene.goTo navigation', () => {
       addEventListener: () => {},
     }
     app2 = new Celestiary(
-        () => ({}),
+        makeStubStore(),
         canvasContainer,
         {},
         () => {},

--- a/js/ControlPanel.js
+++ b/js/ControlPanel.js
@@ -1,7 +1,8 @@
 import Measure from '@pablo-mayrgundter/measure.js'
 import * as collapsor from './collapsor.js'
-import {capitalize} from './utils.js'
 import {StarSpectra} from './scene/StarsCatalog.js'
+import {LIGHTYEAR_METER} from './shared.js'
+import {capitalize} from './utils.js'
 
 
 /** */
@@ -26,30 +27,51 @@ export default class ControlPanel {
 
 
   /**
-   * @param {string} path
+   * Renders the recursive info tree for the target body into `containerElt`.
+   * The breadcrumb path itself is now rendered by the React SearchBar component
+   * (`js/ui/SearchBar.jsx`) from `store.committedPath`.
+   *
+   * @param {string[]} path
    */
   showNavDisplay(path) {
-    let crumbs = ''
-    for (let i = 0; i < path.length; i++) {
-      const hash = path.slice(0, i + 1).join('/')
-      const name = path[i]
-      if (i === path.length - 1) {
-        crumbs += capitalize(name)
-      } else {
-        crumbs += `<a href="#${ hash }">${ capitalize(name) }</a>`
-      }
-      if (i < path.length - 1) {
-        crumbs += ' &gt; '
-      }
+    const target = this.loader.loaded[this.getPathTarget(path)]
+    if (!target || typeof target !== 'object') {
+      return
     }
-
-    let html = `${crumbs } <ul>\n`
     const pathPrefix = path.join('/')
-    html += this.showInfoRecursive(this.loader.loaded[this.getPathTarget(path)],
-        pathPrefix, false, false)
+    let html = '<ul>\n'
+    html += this.showInfoRecursive(target, pathPrefix, false, false)
     html += '</ul>\n'
     this.containerElt.innerHTML = html
     collapsor.makeCollapsable(this.containerElt)
+  }
+
+
+  /**
+   * Renders a compact info summary for a catalog star (no JSON descriptor).
+   * Used by the search-preview mechanism when the highlighted/selected entry
+   * is a star rather than a body in `loader.loaded`.
+   *
+   * @param {object} preview {hipId, displayName, star}
+   */
+  showStarPreview(preview) {
+    if (!preview || !preview.star) {
+      return
+    }
+    const {hipId, star} = preview
+    const specNdx = typeof star.spectralType === 'number' ? star.spectralType : -1
+    const specClass = specNdx >= 0 && specNdx < StarSpectra.length ? StarSpectra[specNdx][3] : '?'
+    const distanceLy = Math.sqrt(
+        (star.x * star.x) + (star.y * star.y) + (star.z * star.z)) /
+        LIGHTYEAR_METER
+    const parts = []
+    parts.push('<ul>')
+    parts.push(`<li>HIP: ${hipId}</li>`)
+    parts.push(`<li>star class: ${specClass}</li>`)
+    parts.push(`<li>absolute magnitude: ${star.absMag.toFixed(2)}</li>`)
+    parts.push(`<li>distance: ${distanceLy.toFixed(2)} ly</li>`)
+    parts.push('</ul>')
+    this.containerElt.innerHTML = parts.join('\n')
   }
 
 

--- a/js/Keys.js
+++ b/js/Keys.js
@@ -22,6 +22,18 @@ export default class Keys {
 
   /** @param {object} event */
   onKeyDown(event) {
+    // Suppress app shortcuts when the user is typing — otherwise letters
+    // bound as hotkeys (e.g. 'g', 'h') would fire while entering a query
+    // into the search bar or any other text input.
+    const doc = this.window && this.window.document
+    const active = doc && doc.activeElement
+    if (active) {
+      const tag = active.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' ||
+          active.isContentEditable) {
+        return
+      }
+    }
     const charStr = event.key
     if (charStr && typeof charStr === 'string') {
       const f = this.keymap[charStr.toUpperCase()]

--- a/js/index.css
+++ b/js/index.css
@@ -111,16 +111,87 @@ button {
   top: 0px;
 }
 
-#target-id {
-  position: fixed;
-  top: 0;
-  left: 0;
-  margin: 0;
-  font-size: 2em;
-  text-align: center;
-  text-transform: capitalize;
-  color: red;
-  border: solid 1px blue;
+#search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+  margin-bottom: 0.25em;
+}
+
+#search-bar .breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+#search-bar .search-bar-icon {
+  color: #ccc;
+  padding: 2px;
+}
+
+/* Breadcrumb element as a chip: rounded container, reserved icon slot on
+   the left, label on the right.  Width is stable across active/inactive
+   because the icon slot always reserves layout (visibility toggled). */
+#search-bar .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 8px 1px 2px;
+  border-radius: 6px;
+  transition: background-color 120ms ease;
+}
+
+/* Hover preview only while closed — in the open state we rely on the
+   distinct active-chip styling instead. */
+#search-bar:not(.open) .chip:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+#search-bar.open .chip.chip-active {
+  background-color: rgba(127, 160, 224, 0.18);
+}
+
+#search-bar .chip-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  visibility: hidden;
+}
+
+#search-bar .chip.chip-active .chip-icon {
+  visibility: visible;
+}
+
+#search-bar .chip-label {
+  line-height: 1.2;
+}
+
+/* Override the global `a` rule: keep the blue color as an affordance cue
+   but drop the underline.  Underline reappears on chip hover so the link
+   behavior is still discoverable. */
+#search-bar .chip a.chip-label {
+  color: #b8cdea;
+  text-decoration: none;
+}
+
+#search-bar .chip:hover a.chip-label {
+  color: #dde8f7;
+  text-decoration: underline;
+}
+
+#search-bar .chip-sep {
+  opacity: 0.35;
+  margin: 0 2px;
+  user-select: none;
+}
+
+#search-bar.open {
+  transition: width 240ms ease, opacity 240ms ease;
+}
+
+#search-bar .picker.active {
+  color: #7fa0e0;
+  background: rgba(127, 160, 224, 0.15);
 }
 
 #top-right {

--- a/js/scene/PickLabels.js
+++ b/js/scene/PickLabels.js
@@ -6,6 +6,9 @@ import SpriteSheet from './SpriteSheet.js'
 import {marker as createMarker} from './shapes'
 
 
+const HOVER_SYNC_MS = 80
+
+
 /** */
 export default class PickLabels {
   constructor(ui, stars) {
@@ -18,6 +21,8 @@ export default class PickLabels {
     this.traceLabel = null
     this.mcb = null
     this.tcb = null
+    this._searchSyncTimer = null
+    this._pendingHoverName = null
 
     // Activate when UI button clicked for star marking.
     // Use prevState comparison so we only act when this flag actually changes,
@@ -31,6 +36,7 @@ export default class PickLabels {
       } else {
         this.removePickListeners()
         this.clearTrace()
+        this._clearHoverSync()
       }
     })
   }
@@ -70,7 +76,49 @@ export default class PickLabels {
       if (!this.stars.labelCenterPosByName[name]) {
         this.traceLabel = this.labelStar(pick)
       }
+      this._queueHoverSync(`${name}`)
     })
+  }
+
+
+  /**
+   * Debounced pipe from mousemove-hover to store.searchHoverName.  mousemove
+   * fires ~60–120 Hz; 80 ms coalesces into a rate the SearchBar can react to
+   * without thrashing Fuse.
+   *
+   * @param {string} name
+   */
+  _queueHoverSync(name) {
+    this._pendingHoverName = name
+    if (this._searchSyncTimer) {
+      return
+    }
+    this._searchSyncTimer = setTimeout(() => {
+      this._searchSyncTimer = null
+      const store = this.ui.useStore
+      if (store && typeof store.getState === 'function') {
+        const setter = store.getState().setSearchHoverName
+        if (typeof setter === 'function') {
+          setter(this._pendingHoverName)
+        }
+      }
+    }, HOVER_SYNC_MS)
+  }
+
+
+  _clearHoverSync() {
+    if (this._searchSyncTimer) {
+      clearTimeout(this._searchSyncTimer)
+      this._searchSyncTimer = null
+    }
+    this._pendingHoverName = null
+    const store = this.ui.useStore
+    if (store && typeof store.getState === 'function') {
+      const setter = store.getState().setSearchHoverName
+      if (typeof setter === 'function') {
+        setter(null)
+      }
+    }
   }
 
   /** Leave a label on star and navigate there */
@@ -79,6 +127,20 @@ export default class PickLabels {
       this.pickedStarLabels[pick.star.hipId] = this.traceLabel
       this.traceLabel = null
       this.ui.sceneManager.goTo(pick.star)
+      const store = this.ui.useStore
+      if (store && typeof store.getState === 'function') {
+        const state = store.getState()
+        if (typeof state.setCommittedStar === 'function') {
+          const displayName = String(this.stars.catalog.getNameOrId(pick.star.hipId))
+          state.setCommittedStar({hipId: pick.star.hipId, displayName, star: pick.star})
+        }
+        // Resolve the search: dblclick commits just like Enter/Go would.
+        // closeSearch also deactivates picking mode, which removes these
+        // listeners — clean end to the interaction.
+        if (state.isSearchOpen && typeof state.closeSearch === 'function') {
+          state.closeSearch()
+        }
+      }
     })
   }
 

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -162,7 +162,14 @@ export default class Scene {
   }
 
 
-  /** */
+  /**
+   * Abstract target setter — all target-changing entry points (keyboard 'h',
+   * 'u', '0'-'9', onDone, etc) funnel here.  Syncs the committed-path store
+   * field (which also clears committedStar) so the breadcrumb + info panel
+   * reflect the new target rather than a stale star selection.
+   *
+   * @param {string} name
+   */
   setTarget(name) {
     const obj = this.objects[name]
     if (!obj) {
@@ -171,6 +178,39 @@ export default class Scene {
     Shared.targets.obj = obj
     // Animated in ThreeUI.renderLoop
     Shared.targets.tween = newCameraLookTween(this.ui.camera, obj.matrixWorld)
+
+    const store = this.ui && this.ui.useStore
+    if (store && typeof store.getState === 'function') {
+      const setter = store.getState().setCommittedPath
+      if (typeof setter === 'function') {
+        setter(this._pathFor(name))
+      }
+    }
+  }
+
+
+  /**
+   * Walk the parent chain up from `name` via scene.objects' stored props
+   * until we hit the milkyway root.  Used by setTarget to compute the
+   * breadcrumb path without depending on the Loader's lazy pathByName.
+   *
+   * @param {string} name
+   * @returns {string[]}
+   */
+  _pathFor(name) {
+    if (name === 'milkyway') {
+      return [name]
+    }
+    const parts = []
+    const seen = new Set()
+    let cur = name
+    while (cur && cur !== 'milkyway' && this.objects[cur] && !seen.has(cur)) {
+      parts.unshift(cur)
+      seen.add(cur)
+      const props = this.objects[cur].props
+      cur = props && props.parent
+    }
+    return parts
   }
 
 

--- a/js/scene/Scene.test.js
+++ b/js/scene/Scene.test.js
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'bun:test'
+import {Scene as ThreeScene} from 'three'
+import Scene from './Scene.js'
+
+
+function makeScene() {
+  const ui = {
+    scene: new ThreeScene(),
+    addClickCb: () => {},
+  }
+  return new Scene(ui)
+}
+
+
+describe('Scene._pathFor', () => {
+  it('returns just [name] for milkyway root', () => {
+    const s = makeScene()
+    expect(s._pathFor('milkyway')).toEqual(['milkyway'])
+  })
+
+  it('builds a single-element path for sun', () => {
+    const s = makeScene()
+    s.objects['sun'] = {props: {parent: 'milkyway'}}
+    expect(s._pathFor('sun')).toEqual(['sun'])
+  })
+
+  it('walks parent chain for a planet', () => {
+    const s = makeScene()
+    s.objects['sun'] = {props: {parent: 'milkyway'}}
+    s.objects['earth'] = {props: {parent: 'sun'}}
+    expect(s._pathFor('earth')).toEqual(['sun', 'earth'])
+  })
+
+  it('walks parent chain for a moon', () => {
+    const s = makeScene()
+    s.objects['sun'] = {props: {parent: 'milkyway'}}
+    s.objects['earth'] = {props: {parent: 'sun'}}
+    s.objects['moon'] = {props: {parent: 'earth'}}
+    expect(s._pathFor('moon')).toEqual(['sun', 'earth', 'moon'])
+  })
+
+  it('stops walking if parent is not in objects (e.g., milkyway → universe)', () => {
+    const s = makeScene()
+    // milkyway.parent='universe' which isn't loaded — loop terminates there
+    s.objects['sun'] = {props: {parent: 'milkyway'}}
+    expect(s._pathFor('sun')).toEqual(['sun'])
+  })
+
+  it('returns empty for unknown target (no crash)', () => {
+    const s = makeScene()
+    expect(s._pathFor('unknown')).toEqual([])
+  })
+
+  it('handles a parent-chain cycle without looping forever', () => {
+    // Defensive: two entries pointing at each other shouldn't spin.
+    const s = makeScene()
+    s.objects['a'] = {props: {parent: 'b'}}
+    s.objects['b'] = {props: {parent: 'a'}}
+    const path = s._pathFor('a')
+    expect(path.length).toBeLessThanOrEqual(2)
+  })
+})

--- a/js/scene/Stars.js
+++ b/js/scene/Stars.js
@@ -57,16 +57,20 @@ export default class Stars extends Object {
       if (showLabels) {
         this.showLabels()
       }
+      this.ui.useStore.setState({starsCatalog: this.catalog})
     } else {
       this.catalog = new StarsCatalog()
+      // Expose the (empty) catalog immediately so About / search wiring can
+      // hold the reference; re-publish after load completes so subscribers
+      // that gate on numStars > 0 (SearchIndex's StarsProvider registration)
+      // see the transition.
+      this.ui.useStore.setState({starsCatalog: this.catalog})
       this.catalog.load(() => {
         this.show()
         this.showLabels()
+        this.ui.useStore.setState({starsCatalog: this.catalog})
       })
     }
-
-    // used by About for catalog stats
-    this.ui.useStore.setState({starsCatalog: this.catalog})
   }
 
 

--- a/js/scene/StarsCatalog.js
+++ b/js/scene/StarsCatalog.js
@@ -254,15 +254,20 @@ export default class StarsCatalog {
 
 
   /**
+   * Display-friendly identifier: proper name when available, otherwise the
+   * catalog-prefixed ID ("HIP 1234") — never a bare number.  Used for 3D
+   * sprite labels, search breadcrumb chip, and document title so they all
+   * read consistently.
+   *
    * @param {number} hipId
-   * @returns {string|number}
+   * @returns {string}
    */
   getNameOrId(hipId) {
     const names = this.namesByHip.get(hipId)
     if (names && names.length > 0) {
       return names[0]
     }
-    return hipId
+    return `HIP ${hipId}`
   }
 
 

--- a/js/search/DESIGN.md
+++ b/js/search/DESIGN.md
@@ -1,0 +1,150 @@
+# Search Module
+
+Breadcrumb-anchored search over celestial bodies and star catalog entries.
+Extensible via a provider interface so future surface-place data (cities,
+craters on Earth/Mars) can be plugged in without re-architecting.
+
+## Directory layout
+
+| Path | Role |
+|---|---|
+| `SearchProvider.js` | JSDoc typedefs for `SearchEntry` and the provider contract |
+| `SearchRegistry.js` | Singleton provider list — `register`, `list`, `_reset` (test-only) |
+| `SearchIndex.js` | Tiered index, query, per-anchor cache; exports the app-wide singleton `searchIndex` |
+| `providers/SceneProvider.js` | Entries for every body in `Loader.loaded` (sun, planets, moons, galaxy nodes) |
+| `providers/StarsProvider.js` | Entries for named stars + exact HIP resolver |
+| `providers/PlacesProvider.js` | Stub for future surface-place data (lazy, `collectUnder`-only) |
+| `SearchIndex.test.js` | Scoping, fuzzy, HIP-exact, dedupe coverage |
+
+## Data model
+
+A `SearchEntry` is the atomic unit:
+
+```js
+{
+  id: 'earth' | 'hip:32349' | 'loc:earth:paris',
+  displayName: 'Earth',
+  aliases: ['terra', 'gaia', ...],
+  kind: 'galaxy'|'star'|'planet'|'moon'|'place',
+  path: 'milkyway/sun/earth',       // rooted '/'-joined path
+  parent: 'sun',                     // parent id, or null
+  payload: {...},                    // kind-specific navigation hint
+}
+```
+
+The `path` is what lets subtree scoping work — any entry is "in scope" for
+an anchor if `entry.path === anchorPath || entry.path.startsWith(anchorPath + '/')`.
+The trailing slash guard is load-bearing: a bare `startsWith` would match
+`'milkyway/sunflower'` against anchor `'milkyway/sun'`.
+
+## Tiered index
+
+Three tiers with different cost/latency tradeoffs:
+
+| Tier | Source | Use | Cost |
+|---|---|---|---|
+| A | All non-lazy providers' `collectAll()` | Typed-query fuzzy matching | ~50 ms build, <20 ms per keystroke at ~8k entries |
+| B | `StarsProvider.resolveHip(n)` | Exact numeric / `HIP N` input — short-circuits Fuse | O(1) |
+| C | Lazy providers' `collectUnder(anchorPath)` (per-anchor `Fuse` cache) | Surface-place search scoped to a body | Paid once per anchor |
+
+Tier A is populated once on first `ensureReady()`. Star catalog only
+contributes *named* stars (~8k) to Tier A; full 120k fuzzy-scan would be
+200–500 ms per keystroke and unnamed stars have nothing meaningful to fuzzy
+match against. Unnamed stars are still reachable via Tier B (numeric input).
+
+Tier C is empty today — `PlacesProvider` is a stub. It exists so the index
+doesn't need restructuring when place data lands.
+
+## Fuse.js configuration
+
+```js
+{
+  includeScore: true,
+  ignoreLocation: true,     // critical — default location weighting breaks 'HIP 32349'
+  threshold: 0.35,          // one-typo tolerant on short names
+  minMatchCharLength: 2,
+  keys: [
+    {name: 'displayName', weight: 0.7},
+    {name: 'aliases',     weight: 0.3},
+  ],
+}
+```
+
+`ignoreLocation: true` is mandatory. Without it Fuse penalises matches that
+aren't near the start of the field, which tanks alias-based lookups.
+
+## Scoping semantics
+
+The search bar has an *anchor* — the path element the icon is sitting
+before. Anchor position is an index into the breadcrumb:
+
+| Icon position | anchorIndex | anchorPath | Scope |
+|---|---|---|---|
+| before Sun (default) | 0 | `milkyway` | everything (peer stars + solar system + future places) |
+| before Earth | 1 | `milkyway/sun` | solar system (Earth + siblings + their descendants) |
+| before Moon | 2 | `milkyway/sun/earth` | Earth subtree (Moon + future places on Earth) |
+
+`anchorPathFor(committedPath, anchorIndex)` in `store/SearchSlice.js`
+produces the rooted string the index consumes.
+
+## Commit flow
+
+Planets and moons: `window.location.hash = loader.pathByName[name]` →
+existing hashchange listener → `loadPath` → `onDone` → `setCommittedPath`.
+The hash routing is the single source of truth for planet permalinks.
+
+Stars: `scene.goTo(starProps)` + `setCommittedStar({hipId, displayName,
+star})`. Stars aren't hash-routed; the store field carries the committed
+identity.
+
+## Integration points outside this dir
+
+- `store/SearchSlice.js` — all UI state (anchor, query, selection, preview,
+  committed path/star). `setCommittedPath` and `setCommittedStar` are
+  mutually exclusive.
+- `ui/SearchBar.jsx` — the React component; reads index, drives Autocomplete.
+- `Celestiary._registerSearchProviders` — registers providers; guards stars
+  on `numStars > 0` with a local `registered` flag (catalog mutates in place
+  so reference/value comparison both break).
+- `Celestiary._subscribePreview` — single hub that renders the info panel;
+  precedence `previewStar > previewPath > committedStar > committedPath`.
+- `Scene.setTarget` — all target-setting funnels here; syncs `committedPath`
+  via `_pathFor` so breadcrumb follows the target (and clears
+  `committedStar`).
+- `scene/PickLabels.markCb` — crosshair double-click mirrors search commit:
+  `scene.goTo(star) + setCommittedStar(...) + closeSearch()`.
+
+## Adding a new provider
+
+Implement the `SearchProvider` interface:
+
+```js
+class MyProvider {
+  id = 'my'
+  lazy = false         // true if per-anchor only
+  async preload() {}   // optional — pre-warm any lazy data
+  collectAll() {       // required when lazy === false
+    return [/* SearchEntry, ... */]
+  }
+  // or, for lazy providers:
+  collectUnder(anchorPath) {
+    return [/* SearchEntry, ... */]
+  }
+}
+```
+
+Register in `Celestiary._registerSearchProviders` (or an appropriate ready
+hook for async-loaded data). Call `searchIndex.invalidate()` after
+registration so Tier A rebuilds.
+
+## Test strategy
+
+- Unit — `SearchIndex.test.js` exercises scoping, Fuse thresholds, HIP exact
+  path, dedupe, and anchor-scope edge cases (`sun` vs `sunflower`) against
+  stub providers.
+- Unit — `SearchSlice.test.js` covers mutual-exclusivity of
+  committed/preview fields and openSearch/closeSearch transitions.
+- Unit — `scene/Scene.test.js` exercises `_pathFor` against synthetic
+  object graphs including cycles.
+- Manual — catalog build + query are exercised end-to-end only in the
+  browser (no WebGL test harness).

--- a/js/search/SearchIndex.js
+++ b/js/search/SearchIndex.js
@@ -1,0 +1,212 @@
+import Fuse from 'fuse.js'
+import * as SearchRegistry from './SearchRegistry.js'
+
+
+const FUSE_OPTS = {
+  includeScore: true,
+  ignoreLocation: true,
+  threshold: 0.35,
+  minMatchCharLength: 2,
+  keys: [
+    {name: 'displayName', weight: 0.7},
+    {name: 'aliases', weight: 0.3},
+  ],
+}
+
+
+const HIP_RE = /^(?:HIP\s*)?(\d+)$/i
+
+
+/**
+ * Tiered search index.
+ *
+ * - Tier A: single Fuse over all non-lazy providers' `collectAll()` output
+ *   (~8k entries today — planets, moons, galaxy nodes, named stars).  Built
+ *   once on first `ensureReady()`.
+ * - Tier B: exact-match for HIP/numeric input, bypasses Fuse and is served
+ *   directly by a star-exact-lookup delegate (`StarsProvider.resolveHip`).
+ * - Tier C: per-anchor Fuse cache populated from `lazy` providers' output
+ *   when a scoped query arrives.  Reserved for the future PlacesProvider.
+ */
+export default class SearchIndex {
+  constructor() {
+    this._ready = false
+    this._building = null
+    this._allEntries = []
+    this._fuseA = null
+    this._tierCCache = new Map()
+    this._hipResolver = null
+  }
+
+
+  /** @param {object} provider */
+  register(provider) {
+    SearchRegistry.register(provider)
+    if (provider.id === 'stars' && typeof provider.resolveHip === 'function') {
+      this._hipResolver = (hipId) => provider.resolveHip(hipId)
+    }
+    this._ready = false
+  }
+
+
+  /**
+   * Build Tier A once.  Safe to call repeatedly.
+   *
+   * @returns {Promise<void>}
+   */
+  async ensureReady() {
+    if (this._ready) {
+      return
+    }
+    if (this._building) {
+      await this._building
+      return
+    }
+    this._building = this._build()
+    try {
+      await this._building
+    } finally {
+      this._building = null
+    }
+  }
+
+
+  /** @returns {Promise<void>} */
+  async _build() {
+    const providers = SearchRegistry.list()
+    const entries = []
+    for (const p of providers) {
+      if (p.lazy) {
+        continue
+      }
+      if (typeof p.preload === 'function') {
+        await p.preload()
+      }
+      if (typeof p.collectAll === 'function') {
+        for (const e of await p.collectAll()) {
+          entries.push(e)
+        }
+      }
+    }
+    dedupeById(entries)
+    this._allEntries = entries
+    this._fuseA = new Fuse(entries, FUSE_OPTS)
+    this._ready = true
+  }
+
+
+  /**
+   * @param {string} text
+   * @param {string} anchorPath
+   * @param {number} [limit]
+   * @returns {object[]} array of {entry, score}
+   */
+  query(text, anchorPath = 'milkyway', limit = 20) {
+    if (!this._ready) {
+      return []
+    }
+    const trimmed = (text || '').trim()
+    if (trimmed.length === 0) {
+      return []
+    }
+
+    const hipMatch = trimmed.match(HIP_RE)
+    if (hipMatch && this._hipResolver) {
+      const hipId = parseInt(hipMatch[1], 10)
+      const entry = this._hipResolver(hipId)
+      if (entry && inScope(entry.path, anchorPath)) {
+        return [{entry, score: 0}]
+      }
+      return []
+    }
+
+    const results = this._fuseA.search(trimmed, {limit: limit * 4})
+    const filtered = []
+    for (const r of results) {
+      if (inScope(r.item.path, anchorPath)) {
+        filtered.push({entry: r.item, score: r.score ?? 0})
+        if (filtered.length >= limit) {
+          break
+        }
+      }
+    }
+    return filtered
+  }
+
+
+  /**
+   * Resolve a raw name string (e.g. from crosshair hover) to its entry.
+   * Returns the first in-scope match, or null.
+   *
+   * @param {string} name
+   * @param {string} anchorPath
+   * @returns {object|null}
+   */
+  resolveByName(name, anchorPath = 'milkyway') {
+    if (!this._ready || !name) {
+      return null
+    }
+    const hipMatch = String(name).trim().match(HIP_RE)
+    if (hipMatch && this._hipResolver) {
+      const entry = this._hipResolver(parseInt(hipMatch[1], 10))
+      if (entry && inScope(entry.path, anchorPath)) {
+        return entry
+      }
+    }
+    const lower = String(name).toLowerCase()
+    for (const e of this._allEntries) {
+      if (!inScope(e.path, anchorPath)) {
+        continue
+      }
+      if (e.displayName.toLowerCase() === lower) {
+        return e
+      }
+      for (const a of e.aliases) {
+        if (a.toLowerCase() === lower) {
+          return e
+        }
+      }
+    }
+    return null
+  }
+
+
+  /** Force full rebuild on next `ensureReady()`.  Used by tests or refreshes. */
+  invalidate() {
+    this._ready = false
+    this._allEntries = []
+    this._fuseA = null
+    this._tierCCache.clear()
+  }
+}
+
+
+/**
+ * @param {string} entryPath
+ * @param {string} anchorPath
+ * @returns {boolean}
+ */
+export function inScope(entryPath, anchorPath) {
+  if (!anchorPath || anchorPath === 'milkyway') {
+    return true
+  }
+  return entryPath === anchorPath || entryPath.startsWith(`${anchorPath}/`)
+}
+
+
+/** @param {object[]} entries */
+function dedupeById(entries) {
+  const seen = new Set()
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const id = entries[i].id
+    if (seen.has(id)) {
+      entries.splice(i, 1)
+    } else {
+      seen.add(id)
+    }
+  }
+}
+
+
+/** App-wide singleton.  Celestiary registers providers here; UI queries it. */
+export const searchIndex = new SearchIndex()

--- a/js/search/SearchIndex.test.js
+++ b/js/search/SearchIndex.test.js
@@ -1,0 +1,274 @@
+import {afterEach, describe, expect, it} from 'bun:test'
+import SearchIndex, {inScope} from './SearchIndex.js'
+import * as SearchRegistry from './SearchRegistry.js'
+
+
+// Minimal stub providers so tests are fast and catalog-independent.
+
+class StubSceneProvider {
+  constructor(entries) {
+    this.id = 'scene'
+    this.lazy = false
+    this._entries = entries
+  }
+  collectAll() {
+    return this._entries
+  }
+}
+
+
+class StubStarsProvider {
+  constructor(entries, hipResolver) {
+    this.id = 'stars'
+    this.lazy = false
+    this._entries = entries
+    this._hipResolver = hipResolver
+  }
+  collectAll() {
+    return this._entries
+  }
+  resolveHip(hipId) {
+    return this._hipResolver(hipId)
+  }
+}
+
+
+const EARTH = {
+  id: 'earth', displayName: 'Earth', aliases: ['terra', 'gaia'],
+  kind: 'planet', path: 'milkyway/sun/earth', parent: 'sun', payload: {name: 'earth'},
+}
+const MOON = {
+  id: 'moon', displayName: 'Moon', aliases: ['luna'],
+  kind: 'moon', path: 'milkyway/sun/earth/moon', parent: 'earth', payload: {name: 'moon'},
+}
+const MARS = {
+  id: 'mars', displayName: 'Mars', aliases: [],
+  kind: 'planet', path: 'milkyway/sun/mars', parent: 'sun', payload: {name: 'mars'},
+}
+const SUN = {
+  id: 'sun', displayName: 'Sun', aliases: ['sol'],
+  kind: 'star', path: 'milkyway/sun', parent: 'milkyway', payload: {name: 'sun'},
+}
+const RIGEL = {
+  id: 'hip:24436', displayName: 'Rigel', aliases: ['BET Ori', 'HIP 24436', '24436'],
+  kind: 'star', path: 'milkyway/hip:24436', parent: 'milkyway', payload: {hipId: 24436},
+}
+const SIRIUS = {
+  id: 'hip:32349', displayName: 'Sirius', aliases: ['ALF CMa', 'HIP 32349', '32349'],
+  kind: 'star', path: 'milkyway/hip:32349', parent: 'milkyway', payload: {hipId: 32349},
+}
+
+
+function buildIndex() {
+  SearchRegistry._reset()
+  const idx = new SearchIndex()
+  const scene = new StubSceneProvider([SUN, EARTH, MOON, MARS])
+  const stars = new StubStarsProvider([RIGEL, SIRIUS], (hipId) => {
+    if (hipId === 24436) {
+      return RIGEL
+    }
+    if (hipId === 32349) {
+      return SIRIUS
+    }
+    if (hipId === 99999) {
+      return {
+        id: 'hip:99999', displayName: 'HIP 99999', aliases: ['HIP 99999', '99999'],
+        kind: 'star', path: 'milkyway/hip:99999', parent: 'milkyway', payload: {hipId: 99999},
+      }
+    }
+    return null
+  })
+  idx.register(scene)
+  idx.register(stars)
+  return idx
+}
+
+
+describe('inScope', () => {
+  it('milkyway anchor matches everything', () => {
+    expect(inScope('milkyway/sun/earth', 'milkyway')).toBe(true)
+    expect(inScope('milkyway/hip:32349', 'milkyway')).toBe(true)
+  })
+
+  it('sun anchor matches solar system but not peer stars', () => {
+    expect(inScope('milkyway/sun/earth', 'milkyway/sun')).toBe(true)
+    expect(inScope('milkyway/sun', 'milkyway/sun')).toBe(true)
+    expect(inScope('milkyway/hip:32349', 'milkyway/sun')).toBe(false)
+  })
+
+  it('earth anchor matches earth + moon but not mars', () => {
+    expect(inScope('milkyway/sun/earth/moon', 'milkyway/sun/earth')).toBe(true)
+    expect(inScope('milkyway/sun/mars', 'milkyway/sun/earth')).toBe(false)
+  })
+
+  it('substring prefix collision is rejected (sun vs sunflower)', () => {
+    expect(inScope('milkyway/sunflower', 'milkyway/sun')).toBe(false)
+  })
+})
+
+
+describe('SearchIndex basic query', () => {
+  afterEach(() => SearchRegistry._reset())
+
+  it('matches exact case ("earth") and mixed case ("Earth")', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r1 = idx.query('earth')
+    const r2 = idx.query('Earth')
+    expect(r1[0].entry.id).toBe('earth')
+    expect(r2[0].entry.id).toBe('earth')
+  })
+
+  it('matches one-typo approximation ("earrth")', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('earrth')
+    expect(r.length).toBeGreaterThan(0)
+    expect(r[0].entry.id).toBe('earth')
+  })
+
+  it('matches alias "luna" → Moon', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('luna')
+    expect(r.length).toBeGreaterThan(0)
+    expect(r[0].entry.id).toBe('moon')
+  })
+
+  it('matches canonical name "moon" → Moon', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('moon')
+    expect(r[0].entry.id).toBe('moon')
+  })
+
+  it('matches star by proper name ("rigel", "Sirius")', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('rigel')[0].entry.id).toBe('hip:24436')
+    expect(idx.query('Sirius')[0].entry.id).toBe('hip:32349')
+  })
+
+  it('empty query returns no results', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('').length).toBe(0)
+    expect(idx.query('   ').length).toBe(0)
+  })
+})
+
+
+describe('SearchIndex HIP exact path', () => {
+  afterEach(() => SearchRegistry._reset())
+
+  it('"HIP 32349" resolves to Sirius', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('HIP 32349')
+    expect(r.length).toBe(1)
+    expect(r[0].entry.id).toBe('hip:32349')
+    expect(r[0].score).toBe(0)
+  })
+
+  it('"hip32349" is tolerated (no space)', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('hip32349')
+    expect(r[0].entry.id).toBe('hip:32349')
+  })
+
+  it('bare "32349" resolves to Sirius', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('32349')
+    expect(r[0].entry.id).toBe('hip:32349')
+  })
+
+  it('resolves unnamed HIP stars via exact path even when not in Tier A', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    const r = idx.query('HIP 99999')
+    expect(r[0].entry.id).toBe('hip:99999')
+  })
+
+  it('unknown HIP returns empty', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('HIP 7777777').length).toBe(0)
+  })
+})
+
+
+describe('SearchIndex anchor scoping', () => {
+  afterEach(() => SearchRegistry._reset())
+
+  it('earth anchor narrows to earth subtree ("moon" matches, "mars" does not)', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('moon', 'milkyway/sun/earth')[0].entry.id).toBe('moon')
+    expect(idx.query('mars', 'milkyway/sun/earth').length).toBe(0)
+  })
+
+  it('sun anchor excludes peer stars', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('rigel', 'milkyway/sun').length).toBe(0)
+    expect(idx.query('Sirius', 'milkyway/sun').length).toBe(0)
+  })
+
+  it('milkyway anchor (default) sees everything', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('rigel')[0].entry.id).toBe('hip:24436')
+    expect(idx.query('earth')[0].entry.id).toBe('earth')
+  })
+
+  it('HIP exact path respects anchor scope', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.query('HIP 32349', 'milkyway/sun').length).toBe(0)
+  })
+})
+
+
+describe('SearchIndex resolveByName', () => {
+  afterEach(() => SearchRegistry._reset())
+
+  it('resolves displayName', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.resolveByName('Earth').id).toBe('earth')
+  })
+
+  it('resolves alias', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.resolveByName('luna').id).toBe('moon')
+  })
+
+  it('respects anchor scope', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.resolveByName('Rigel', 'milkyway/sun')).toBeNull()
+  })
+
+  it('returns null for unknown', async () => {
+    const idx = buildIndex()
+    await idx.ensureReady()
+    expect(idx.resolveByName('zzzz')).toBeNull()
+  })
+})
+
+
+describe('SearchIndex dedupe', () => {
+  afterEach(() => SearchRegistry._reset())
+
+  it('registering the same provider id twice does not double-index', async () => {
+    const idx = new SearchIndex()
+    idx.register(new StubSceneProvider([EARTH]))
+    idx.register(new StubSceneProvider([EARTH])) // same id='scene' replaces
+    await idx.ensureReady()
+    const r = idx.query('earth')
+    expect(r.length).toBe(1)
+  })
+})

--- a/js/search/SearchProvider.js
+++ b/js/search/SearchProvider.js
@@ -1,0 +1,23 @@
+/**
+ * Search index types.
+ *
+ * A SearchEntry is the unit of searchable content: one celestial body, star,
+ * or future surface place.  Providers produce entries; the SearchIndex groups
+ * them into Fuse instances and answers anchor-scoped queries.
+ *
+ * A SearchProvider has an `id`, a `lazy` flag, and optionally `collectAll`
+ * (for eager inclusion in Tier A) or `collectUnder` (for the per-anchor
+ * Tier C cache used by lazy providers like PlacesProvider).
+ */
+
+
+/**
+ * @typedef {object} SearchEntry
+ * @property {string} id Unique id ('earth', 'hip:32349', 'loc:earth:paris').
+ * @property {string} displayName Primary user-facing label.
+ * @property {string[]} aliases Extra search tokens.
+ * @property {string} kind One of 'galaxy' | 'star' | 'planet' | 'moon' | 'place'.
+ * @property {string} path Rooted path, '/'-joined, e.g. 'milkyway/sun/earth'.
+ * @property {string|null} parent Parent id (null for root).
+ * @property {object} payload Navigation hint — shape depends on `kind`.
+ */

--- a/js/search/SearchRegistry.js
+++ b/js/search/SearchRegistry.js
@@ -1,0 +1,36 @@
+/**
+ * Singleton registry of SearchProviders.  Providers register themselves once
+ * their underlying data source (loader, stars catalog, places catalog) is
+ * ready.  The SearchIndex consults the registry when building.
+ */
+
+
+const providers = []
+
+
+/**
+ * @param {object} provider A SearchProvider instance.
+ */
+export function register(provider) {
+  if (!provider || typeof provider.id !== 'string') {
+    throw new Error('SearchProvider must have a string id')
+  }
+  const existing = providers.findIndex((p) => p.id === provider.id)
+  if (existing >= 0) {
+    providers[existing] = provider
+  } else {
+    providers.push(provider)
+  }
+}
+
+
+/** @returns {object[]} */
+export function list() {
+  return providers.slice()
+}
+
+
+/** Clear all registered providers.  Used by tests. */
+export function _reset() {
+  providers.length = 0
+}

--- a/js/search/providers/PlacesProvider.js
+++ b/js/search/providers/PlacesProvider.js
@@ -1,0 +1,24 @@
+/** @typedef {import('../SearchProvider.js').SearchEntry} SearchEntry */
+
+
+/**
+ * Stub for future surface-place search (cities, craters, regions on planets
+ * with `has_locations`).  Lazy by design: places can reach millions of entries
+ * for Earth alone, so they're only materialized when the user anchors the
+ * search at the relevant body.
+ */
+export default class PlacesProvider {
+  constructor() {
+    this.id = 'places'
+    this.lazy = true
+  }
+
+
+  /**
+   * @param {string} anchorPath
+   * @returns {SearchEntry[]}
+   */
+  collectUnder(anchorPath) {
+    return []
+  }
+}

--- a/js/search/providers/SceneProvider.js
+++ b/js/search/providers/SceneProvider.js
@@ -1,0 +1,99 @@
+import {capitalize} from '../../utils.js'
+
+
+/** @typedef {import('../SearchProvider.js').SearchEntry} SearchEntry */
+
+
+const TYPE_TO_KIND = {
+  galaxy: 'galaxy',
+  star: 'star',
+  planet: 'planet',
+  moon: 'moon',
+}
+
+
+/**
+ * Provides SearchEntries for every body tracked by the Loader (galaxy,
+ * sun, planets, moons).  The SceneProvider reads the original JSON
+ * descriptors from `loader.loaded`; each descriptor's optional `aliases`
+ * array contributes extra search tokens ("luna" → Moon, etc).
+ */
+export default class SceneProvider {
+  /**
+   * @param {object} loader
+   */
+  constructor(loader) {
+    this.id = 'scene'
+    this.lazy = false
+    this.loader = loader
+  }
+
+
+  /**
+   * Ensure the full tree below 'milkyway' is loaded.  In typical usage
+   * Celestiary has already expanded the tree at init; this is idempotent
+   * coverage for edge cases (e.g. deep-linked entry to a leaf body).
+   *
+   * @returns {Promise<void>}
+   */
+  async preload() {
+    // loadObj with expand=true recurses through every `system` child.
+    // Already-loaded children are no-ops.  FileLoader has no promise API,
+    // so we yield a microtask for any kickoffs to settle.  In the already-
+    // loaded case this resolves immediately after the tick.
+    this.loader.loadObj('', 'milkyway', null, true, null)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+
+  /** @returns {SearchEntry[]} */
+  collectAll() {
+    const out = []
+    const loaded = this.loader.loaded
+    for (const name of Object.keys(loaded)) {
+      const obj = loaded[name]
+      if (!obj || obj === 'pending' || typeof obj !== 'object') {
+        continue
+      }
+      const kind = TYPE_TO_KIND[obj.type]
+      if (!kind) {
+        continue
+      }
+      const path = buildPath(name, loaded)
+      if (!path) {
+        continue
+      }
+      out.push({
+        id: name,
+        displayName: capitalize(obj.name || name),
+        aliases: Array.isArray(obj.aliases) ? obj.aliases.slice() : [],
+        kind,
+        path,
+        parent: obj.parent || null,
+        payload: {name},
+      })
+    }
+    return out
+  }
+}
+
+
+/**
+ * Walk parent chain up from `name` using the `parent` field on each descriptor.
+ * Stops when the parent is not loaded (milkyway's parent 'universe' is not).
+ *
+ * @param {string} name
+ * @param {object} loaded
+ * @returns {string} '/'-joined rooted path, or '' if name not loaded.
+ */
+function buildPath(name, loaded) {
+  const parts = []
+  let cur = name
+  const seen = new Set()
+  while (cur && loaded[cur] && typeof loaded[cur] === 'object' && !seen.has(cur)) {
+    parts.unshift(cur)
+    seen.add(cur)
+    cur = loaded[cur].parent
+  }
+  return parts.join('/')
+}

--- a/js/search/providers/StarsProvider.js
+++ b/js/search/providers/StarsProvider.js
@@ -1,0 +1,82 @@
+/** @typedef {import('../SearchProvider.js').SearchEntry} SearchEntry */
+
+
+/**
+ * Provides SearchEntries for every named star in the StarsCatalog.  The
+ * ~120k unnamed HIP stars are NOT fuzzy-indexed (would make as-you-type
+ * unusable); they are reachable only via exact numeric/`HIP N` input,
+ * served by `resolveHip()`.
+ *
+ * Skips hipId=0 (Sun) because the Sun is already contributed by the
+ * SceneProvider as a first-class planet-level body.
+ */
+export default class StarsProvider {
+  /**
+   * @param {object} catalog StarsCatalog
+   */
+  constructor(catalog) {
+    this.id = 'stars'
+    this.lazy = false
+    this.catalog = catalog
+  }
+
+
+  /** @returns {SearchEntry[]} */
+  collectAll() {
+    const out = []
+    const namesByHip = this.catalog.namesByHip
+    namesByHip.forEach((names, hipId) => {
+      if (hipId === 0 || !names || names.length === 0) {
+        return
+      }
+      const star = this.catalog.starByHip.get(hipId)
+      if (!star) {
+        return
+      }
+      const displayName = names[0]
+      const aliases = names.slice(1)
+      aliases.push(`HIP ${hipId}`, String(hipId))
+      out.push({
+        id: `hip:${hipId}`,
+        displayName,
+        aliases,
+        kind: 'star',
+        path: `milkyway/hip:${hipId}`,
+        parent: 'milkyway',
+        payload: {hipId, star},
+      })
+    })
+    return out
+  }
+
+
+  /**
+   * Exact-match resolver for numeric/`HIP N` input.  Named and unnamed
+   * stars alike are reachable this way.
+   *
+   * @param {number} hipId
+   * @returns {SearchEntry|null}
+   */
+  resolveHip(hipId) {
+    if (hipId === 0) {
+      return null
+    }
+    const star = this.catalog.starByHip.get(hipId)
+    if (!star) {
+      return null
+    }
+    const names = this.catalog.namesByHip.get(hipId) || []
+    const displayName = names.length > 0 ? names[0] : `HIP ${hipId}`
+    const aliases = names.slice(1)
+    aliases.push(`HIP ${hipId}`, String(hipId))
+    return {
+      id: `hip:${hipId}`,
+      displayName,
+      aliases,
+      kind: 'star',
+      path: `milkyway/hip:${hipId}`,
+      parent: 'milkyway',
+      payload: {hipId, star},
+    }
+  }
+}

--- a/js/store/SearchSlice.js
+++ b/js/store/SearchSlice.js
@@ -1,0 +1,84 @@
+/**
+ * Search feature state.
+ *
+ * @param {Function} set
+ * @param {Function} get
+ * @returns {object} Zustand slice
+ */
+export default function createSearchSlice(set, get) {
+  return {
+    // Breadcrumb path of the currently navigated body.  Source of truth for the
+    // SearchBar's inline breadcrumb.  Empty array before first load.  Stars
+    // (no hash/loader path) use committedStar instead; the two are mutually
+    // exclusive — setting one clears the other.
+    committedPath: [],
+    setCommittedPath: (path) => set(() => ({committedPath: path, committedStar: null})),
+    committedStar: null,
+    setCommittedStar: (s) => set(() => ({committedStar: s, committedPath: []})),
+
+    // Search bar expanded/collapsed state.  Crosshair picking mode is scoped
+    // to the bar's lifecycle: every open starts with picker OFF, every close
+    // deactivates it (per design — picking lives inside the bar now, not as a
+    // top-right standalone toggle).
+    isSearchOpen: false,
+    openSearch: () => set((state) => ({
+      isSearchOpen: true,
+      anchorIndex: state.hoveredAnchorIndex !== null ? state.hoveredAnchorIndex : 0,
+      hoveredAnchorIndex: null,
+      isStarsSelectActive: false,
+    })),
+    closeSearch: () => set(() => ({
+      isSearchOpen: false,
+      searchQuery: '',
+      searchSelection: null,
+      previewPath: null,
+      previewStar: null,
+      hoveredAnchorIndex: null,
+      isStarsSelectActive: false,
+    })),
+
+    // Subtree scoping by breadcrumb position.  anchorIndex = index in
+    // committedPath that the search icon sits BEFORE.  0 = root (everything).
+    // hoveredAnchorIndex mirrors hover in collapsed state; null = none.
+    anchorIndex: 0,
+    setAnchorIndex: (i) => set(() => ({anchorIndex: i})),
+    hoveredAnchorIndex: null,
+    setHoveredAnchorIndex: (i) => set(() => ({hoveredAnchorIndex: i})),
+
+    // Query + selected option.
+    searchQuery: '',
+    setSearchQuery: (q) => set(() => ({searchQuery: q})),
+    searchSelection: null,
+    setSearchSelection: (entry) => set(() => ({searchSelection: entry})),
+
+    // Crosshair hover pipes through this, debounced in PickLabels.
+    searchHoverName: null,
+    setSearchHoverName: (n) => set(() => ({searchHoverName: n})),
+
+    // Preview target — if set, info panel renders this path instead of committedPath.
+    // For stars (no loader entry) previewStar holds the hipId + star props instead.
+    previewPath: null,
+    setPreviewPath: (p) => set(() => ({previewPath: p, previewStar: null})),
+    previewStar: null,
+    setPreviewStar: (s) => set(() => ({previewStar: s, previewPath: null})),
+    clearPreview: () => set(() => ({previewPath: null, previewStar: null})),
+  }
+}
+
+
+/**
+ * Compute a rooted anchor path string for SearchIndex from a breadcrumb
+ * committedPath (no milkyway prefix) and the anchorIndex that the icon is
+ * sitting BEFORE.
+ *
+ * @param {string[]} committedPath
+ * @param {number} anchorIndex
+ * @returns {string}
+ */
+export function anchorPathFor(committedPath, anchorIndex) {
+  if (!committedPath || committedPath.length === 0 || anchorIndex <= 0) {
+    return 'milkyway'
+  }
+  const take = Math.min(anchorIndex, committedPath.length)
+  return `milkyway/${committedPath.slice(0, take).join('/')}`
+}

--- a/js/store/SearchSlice.test.js
+++ b/js/store/SearchSlice.test.js
@@ -1,0 +1,115 @@
+import {describe, expect, it} from 'bun:test'
+import createSearchSlice, {anchorPathFor} from './SearchSlice.js'
+
+
+/** Run a slice against a toy store emulator so transitions can be asserted. */
+function makeSlice(extraInitial = {}) {
+  let state = {...extraInitial}
+  const set = (updater) => {
+    const partial = typeof updater === 'function' ? updater(state) : updater
+    state = {...state, ...partial}
+  }
+  const get = () => state
+  state = {...state, ...createSearchSlice(set, get)}
+  return {
+    get state() {
+      return state
+    },
+    call(name, ...args) {
+      return state[name](...args)
+    },
+  }
+}
+
+
+describe('SearchSlice transitions', () => {
+  it('setCommittedPath clears committedStar (mutually exclusive)', () => {
+    const slice = makeSlice()
+    slice.call('setCommittedStar', {hipId: 1, displayName: 'X', star: {}})
+    expect(slice.state.committedStar).not.toBeNull()
+    slice.call('setCommittedPath', ['sun', 'earth'])
+    expect(slice.state.committedPath).toEqual(['sun', 'earth'])
+    expect(slice.state.committedStar).toBeNull()
+  })
+
+  it('setCommittedStar clears committedPath (mutually exclusive)', () => {
+    const slice = makeSlice()
+    slice.call('setCommittedPath', ['sun'])
+    slice.call('setCommittedStar', {hipId: 99, displayName: 'X', star: {}})
+    expect(slice.state.committedStar.hipId).toBe(99)
+    expect(slice.state.committedPath).toEqual([])
+  })
+
+  it('openSearch forces picking mode off and uses hoveredAnchorIndex', () => {
+    const slice = makeSlice({isStarsSelectActive: true})
+    slice.call('setHoveredAnchorIndex', 2)
+    slice.call('openSearch')
+    expect(slice.state.isSearchOpen).toBe(true)
+    expect(slice.state.anchorIndex).toBe(2)
+    expect(slice.state.hoveredAnchorIndex).toBeNull()
+    expect(slice.state.isStarsSelectActive).toBe(false)
+  })
+
+  it('openSearch defaults anchorIndex to 0 when nothing hovered', () => {
+    const slice = makeSlice()
+    slice.call('openSearch')
+    expect(slice.state.anchorIndex).toBe(0)
+  })
+
+  it('closeSearch clears transient state and picking mode', () => {
+    const slice = makeSlice({isStarsSelectActive: true})
+    slice.call('setSearchQuery', 'rigel')
+    slice.call('setSearchSelection', {id: 'hip:24436'})
+    slice.call('setPreviewPath', ['sun'])
+    slice.call('openSearch')
+    slice.call('closeSearch')
+    expect(slice.state.isSearchOpen).toBe(false)
+    expect(slice.state.searchQuery).toBe('')
+    expect(slice.state.searchSelection).toBeNull()
+    expect(slice.state.previewPath).toBeNull()
+    expect(slice.state.previewStar).toBeNull()
+    expect(slice.state.isStarsSelectActive).toBe(false)
+  })
+
+  it('setPreviewPath and setPreviewStar are mutually exclusive', () => {
+    const slice = makeSlice()
+    slice.call('setPreviewPath', ['sun', 'earth'])
+    expect(slice.state.previewStar).toBeNull()
+    slice.call('setPreviewStar', {hipId: 1, star: {}})
+    expect(slice.state.previewPath).toBeNull()
+  })
+
+  it('clearPreview clears both preview fields', () => {
+    const slice = makeSlice()
+    slice.call('setPreviewStar', {hipId: 1, star: {}})
+    slice.call('clearPreview')
+    expect(slice.state.previewStar).toBeNull()
+    expect(slice.state.previewPath).toBeNull()
+  })
+})
+
+
+describe('anchorPathFor', () => {
+  it('empty path returns milkyway root', () => {
+    expect(anchorPathFor([], 0)).toBe('milkyway')
+    expect(anchorPathFor([], 5)).toBe('milkyway')
+  })
+
+  it('anchorIndex 0 returns milkyway regardless of path', () => {
+    expect(anchorPathFor(['sun', 'earth'], 0)).toBe('milkyway')
+  })
+
+  it('icon before element 1 scopes to first element as subtree root', () => {
+    // Icon in front of Earth → anchorPath = Earth's parent's subtree = 'milkyway/sun'
+    expect(anchorPathFor(['sun', 'earth', 'moon'], 1)).toBe('milkyway/sun')
+  })
+
+  it('icon before element 2 scopes to two-deep subtree', () => {
+    // Icon in front of Moon → anchorPath = Moon's parent's subtree = 'milkyway/sun/earth'
+    expect(anchorPathFor(['sun', 'earth', 'moon'], 2)).toBe('milkyway/sun/earth')
+  })
+
+  it('anchorIndex beyond path length clamps', () => {
+    expect(anchorPathFor(['sun', 'earth'], 99)).toBe('milkyway/sun/earth')
+  })
+})

--- a/js/store/useStore.js
+++ b/js/store/useStore.js
@@ -1,11 +1,13 @@
 import {create} from 'zustand'
 import createAsterismsSlice from './AsterismsSlice'
+import createSearchSlice from './SearchSlice'
 import createStarsSlice from './StarsSlice'
 import createTimeSlice from './TimeSlice'
 
 
 const useStore = create((set, get) => ({
   ...createAsterismsSlice(set, get),
+  ...createSearchSlice(set, get),
   ...createStarsSlice(set, get),
   ...createTimeSlice(set, get),
 }))

--- a/js/ui/SearchBar.jsx
+++ b/js/ui/SearchBar.jsx
@@ -1,0 +1,470 @@
+import React, {ReactElement, useEffect, useMemo, useRef, useState} from 'react'
+import Autocomplete from '@mui/material/Autocomplete'
+import IconButton from '@mui/material/IconButton'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import {searchIndex} from '../search/SearchIndex'
+import {anchorPathFor} from '../store/SearchSlice'
+import useStore from '../store/useStore'
+import {capitalize} from '../utils'
+import CloseIcon from '@mui/icons-material/Close'
+import MyLocationIcon from '@mui/icons-material/MyLocation'
+import SearchIcon from '@mui/icons-material/Search'
+
+
+const HOVER_RESET_MS = 600
+const BLUR_COLLAPSE_MS = 3000
+
+
+/**
+ * Inline search bar anchored to the breadcrumb.
+ *
+ * Collapsed: search icon + breadcrumb.  The icon sits before the first element
+ * by default; hovering a later breadcrumb element moves the icon in front of
+ * it (visually scoping the search to that element's level — peers + below).
+ *
+ * Expanded: the clicked anchor position is frozen; elements right of the
+ * anchor are hidden; an Autocomplete + Go / Picker / Clear buttons follow.
+ *
+ * @returns {ReactElement}
+ */
+export default function SearchBar({celestiary}) {
+  const committedPath = useStore((s) => s.committedPath)
+  const committedStar = useStore((s) => s.committedStar)
+  const isSearchOpen = useStore((s) => s.isSearchOpen)
+  const openSearch = useStore((s) => s.openSearch)
+  const closeSearch = useStore((s) => s.closeSearch)
+  const searchQuery = useStore((s) => s.searchQuery)
+  const setSearchQuery = useStore((s) => s.setSearchQuery)
+  const searchSelection = useStore((s) => s.searchSelection)
+  const setSearchSelection = useStore((s) => s.setSearchSelection)
+  const setPreviewPath = useStore((s) => s.setPreviewPath)
+  const setPreviewStar = useStore((s) => s.setPreviewStar)
+  const clearPreview = useStore((s) => s.clearPreview)
+  const anchorIndex = useStore((s) => s.anchorIndex)
+  const hoveredAnchorIndex = useStore((s) => s.hoveredAnchorIndex)
+  const setHoveredAnchorIndex = useStore((s) => s.setHoveredAnchorIndex)
+  const isStarsSelectActive = useStore((s) => s.isStarsSelectActive)
+  const toggleIsStarsSelectActive = useStore((s) => s.toggleIsStarsSelectActive)
+  const searchHoverName = useStore((s) => s.searchHoverName)
+
+  const [options, setOptions] = useState([])
+  const [ready, setReady] = useState(false)
+  const [inputFocused, setInputFocused] = useState(false)
+
+  const hoverResetTimer = useRef(null)
+  const blurCollapseTimer = useRef(null)
+  const containerRef = useRef(null)
+
+  // When open, the anchorIndex is fixed; when closed, hover rules the visual.
+  const effectiveIconIndex = isSearchOpen ?
+    anchorIndex :
+    (hoveredAnchorIndex !== null ? hoveredAnchorIndex : 0)
+
+  // Breadcrumb source: a star commit collapses the path to a single element
+  // (the star name).  Planet paths render as before.  The hover/anchor logic
+  // doesn't branch on which one is active.
+  const breadcrumbItems = useMemo(() => {
+    if (committedStar) {
+      return [{label: committedStar.displayName || `HIP ${committedStar.hipId}`, hash: null}]
+    }
+    return committedPath.map((name, i) => ({
+      label: capitalize(name),
+      hash: committedPath.slice(0, i + 1).join('/'),
+    }))
+  }, [committedStar, committedPath])
+
+  const anchorPath = useMemo(
+      () => (committedStar ? 'milkyway' :
+        anchorPathFor(committedPath, isSearchOpen ? anchorIndex : 0)),
+      [committedStar, committedPath, anchorIndex, isSearchOpen],
+  )
+
+  useEffect(() => {
+    if (!isSearchOpen || ready) {
+      return
+    }
+    let cancelled = false
+    searchIndex.ensureReady().then(() => {
+      if (!cancelled) {
+        setReady(true)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isSearchOpen, ready])
+
+  useEffect(() => {
+    if (!ready) {
+      setOptions([])
+      return
+    }
+    const results = searchIndex.query(searchQuery, anchorPath, 20)
+    setOptions(results.map((r) => r.entry))
+  }, [searchQuery, anchorPath, ready])
+
+  // Pipe crosshair hover into the input + preview while picking mode is active
+  // AND the user is not actively typing (no mutex: typed input wins over hover).
+  useEffect(() => {
+    if (!isSearchOpen || !isStarsSelectActive || inputFocused) {
+      return
+    }
+    if (!searchHoverName) {
+      return
+    }
+    setSearchQuery(searchHoverName)
+    if (ready) {
+      const entry = searchIndex.resolveByName(searchHoverName, anchorPath)
+      setSearchSelection(entry)
+      setPreviewForEntry(entry, {setPreviewPath, setPreviewStar, clearPreview})
+    }
+  }, [searchHoverName, isStarsSelectActive, isSearchOpen, inputFocused, ready, anchorPath])
+
+  // Close-on-outside-click: while the bar is open, a mousedown outside the
+  // bar AND outside the Autocomplete's portaled popup is treated as an
+  // explicit cancel (snappier than the 3s blur debounce).  The popper is
+  // portaled out of our DOM tree, so check for its class explicitly.
+  useEffect(() => {
+    if (!isSearchOpen) {
+      return
+    }
+    const onDocMouseDown = (e) => {
+      const container = containerRef.current
+      if (!container) {
+        return
+      }
+      if (container.contains(e.target)) {
+        return
+      }
+      if (!e.target.closest) {
+        return
+      }
+      // Autocomplete's popup is portaled outside our DOM tree — don't close.
+      if (e.target.closest('.MuiAutocomplete-popper')) {
+        return
+      }
+      // Scene canvas is part of the search's interaction surface (crosshair
+      // picking clicks + dblclicks land here) — don't close.
+      if (e.target.closest('#scene-id')) {
+        return
+      }
+      closeSearch()
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    return () => document.removeEventListener('mousedown', onDocMouseDown)
+  }, [isSearchOpen, closeSearch])
+
+  // Any navigation (committedPath change) while the bar is open = cancel.
+  // Catches breadcrumb-link clicks inside the bar, 'h' key home, hash edits,
+  // etc.  The search's own commit also triggers this path but closeSearch is
+  // idempotent — handleCommit has already flipped isSearchOpen=false by then.
+  useEffect(() => {
+    if (useStore.getState().isSearchOpen) {
+      closeSearch()
+    }
+  }, [committedPath, closeSearch])
+
+  // Blur-collapse: if bar is open and focus leaves, start a 3s timer.  Re-
+  // focusing cancels it.  Escape / Clear collapse immediately.
+  useEffect(() => {
+    if (!isSearchOpen) {
+      return
+    }
+    const onFocusIn = () => {
+      if (blurCollapseTimer.current) {
+        clearTimeout(blurCollapseTimer.current)
+        blurCollapseTimer.current = null
+      }
+    }
+    const onFocusOut = (e) => {
+      if (containerRef.current && containerRef.current.contains(e.relatedTarget)) {
+        return
+      }
+      if (blurCollapseTimer.current) {
+        clearTimeout(blurCollapseTimer.current)
+      }
+      blurCollapseTimer.current = setTimeout(() => {
+        blurCollapseTimer.current = null
+        closeSearch()
+      }, BLUR_COLLAPSE_MS)
+    }
+    const el = containerRef.current
+    if (!el) {
+      return
+    }
+    el.addEventListener('focusin', onFocusIn)
+    el.addEventListener('focusout', onFocusOut)
+    return () => {
+      el.removeEventListener('focusin', onFocusIn)
+      el.removeEventListener('focusout', onFocusOut)
+      if (blurCollapseTimer.current) {
+        clearTimeout(blurCollapseTimer.current)
+        blurCollapseTimer.current = null
+      }
+    }
+  }, [isSearchOpen, closeSearch])
+
+  const handleCommit = () => {
+    if (!searchSelection) {
+      return
+    }
+    commitEntry(searchSelection, celestiary)
+    closeSearch()
+  }
+
+  const handleClear = () => {
+    if (searchQuery) {
+      setSearchQuery('')
+      setSearchSelection(null)
+    } else {
+      closeSearch()
+    }
+  }
+
+  const clearHoverTimer = () => {
+    if (hoverResetTimer.current) {
+      clearTimeout(hoverResetTimer.current)
+      hoverResetTimer.current = null
+    }
+  }
+
+  const onSegmentEnter = (i) => {
+    if (isSearchOpen) {
+      return
+    }
+    clearHoverTimer()
+    setHoveredAnchorIndex(i)
+  }
+
+  // Reset the anchor only when the mouse leaves the ENTIRE breadcrumb
+  // container (not just a single segment) — otherwise moving diagonally from
+  // a segment to the icon in front of it (which sits in a sibling slot) would
+  // briefly leave the segment's bbox and yank the icon back to the root.
+  const onBreadcrumbEnter = () => clearHoverTimer()
+  const onBreadcrumbLeave = () => {
+    if (isSearchOpen) {
+      return
+    }
+    clearHoverTimer()
+    hoverResetTimer.current = setTimeout(() => {
+      hoverResetTimer.current = null
+      setHoveredAnchorIndex(null)
+    }, HOVER_RESET_MS)
+  }
+
+  // Breadcrumb slice rendered in expanded state: everything up to and
+  // including the anchor element.  Right-of-anchor is cleared per design.
+  const visibleItems = isSearchOpen ?
+    breadcrumbItems.slice(0, Math.min(anchorIndex + 1, breadcrumbItems.length)) :
+    breadcrumbItems
+
+  const iconButton = (
+    <Tooltip title='Search' describeChild>
+      <IconButton
+        size='small'
+        aria-label='Search'
+        data-testid='search-bar-icon'
+        className='search-bar-icon'
+        onClick={openSearch}
+      >
+        <SearchIcon fontSize='small'/>
+      </IconButton>
+    </Tooltip>
+  )
+
+  return (
+    <div
+      ref={containerRef}
+      id='search-bar'
+      className={isSearchOpen ? 'open' : ''}
+      data-testid={isSearchOpen ? 'search-bar-open' : 'search-bar'}
+    >
+      <span
+        className='breadcrumb'
+        onMouseEnter={onBreadcrumbEnter}
+        onMouseLeave={onBreadcrumbLeave}
+      >
+        {/* Each element is a chip.  The chip contains an always-reserved
+            icon slot (visibility toggled so metrics are identical across
+            chips) plus the label.  Wrapping them together lets the whole
+            chip be a hover target and a styled background. */}
+        {visibleItems.map((item, i) => {
+          const key = item.hash || `star-${i}`
+          const isLast = !isSearchOpen && i === visibleItems.length - 1
+          const active = effectiveIconIndex === i
+          const labelNode = isLast || !item.hash ?
+            <span className='chip-label'>{item.label}</span> :
+            <a className='chip-label' href={`#${item.hash}`}>{item.label}</a>
+          return (
+            <React.Fragment key={key}>
+              {i > 0 && <span className='chip-sep' aria-hidden='true'>›</span>}
+              <span
+                className={`chip${active ? ' chip-active' : ''}`}
+                onMouseEnter={() => onSegmentEnter(i)}
+                aria-current={active ? 'true' : undefined}
+              >
+                <span className='chip-icon' aria-hidden={!active}>
+                  {iconButton}
+                </span>
+                {labelNode}
+              </span>
+            </React.Fragment>
+          )
+        })}
+      </span>
+      {isSearchOpen &&
+        <>
+          <Autocomplete
+            size='small'
+            sx={{minWidth: 260, ml: 1}}
+            options={options}
+            getOptionLabel={(o) => (o && o.displayName) || ''}
+            isOptionEqualToValue={(a, b) => a && b && a.id === b.id}
+            filterOptions={(x) => x}
+            freeSolo={false}
+            openOnFocus
+            autoHighlight
+            slotProps={{
+              paper: {
+                sx: {
+                  backgroundColor: 'rgba(30, 30, 30, 0.5)',
+                  backdropFilter: 'blur(4px)',
+                  color: '#fff',
+                },
+              },
+            }}
+            value={searchSelection}
+            inputValue={searchQuery}
+            onInputChange={(e, v) => setSearchQuery(v)}
+            onChange={(e, v) => {
+              setSearchSelection(v)
+              setPreviewForEntry(v, {setPreviewPath, setPreviewStar, clearPreview})
+            }}
+            onHighlightChange={(e, option) => {
+              setPreviewForEntry(option, {setPreviewPath, setPreviewStar, clearPreview})
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                autoFocus
+                placeholder='Search…'
+                variant='standard'
+                data-testid='search-bar-input'
+                onFocus={() => setInputFocused(true)}
+                onBlur={() => setInputFocused(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && searchSelection) {
+                    e.preventDefault()
+                    handleCommit()
+                  } else if (e.key === 'Escape') {
+                    closeSearch()
+                  }
+                }}
+              />
+            )}
+            renderOption={(props, option) => (
+              <li {...props} key={option.id}>
+                {option.displayName}
+              </li>
+            )}
+          />
+          <Tooltip title='Go (Enter)' describeChild>
+            <span>
+              <IconButton
+                size='small'
+                disabled={!searchSelection}
+                onClick={handleCommit}
+                aria-label='Go to selection'
+                data-testid='search-bar-go'
+              >
+                <SearchIcon fontSize='small'/>
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title='Crosshairs picker' describeChild>
+            <IconButton
+              size='small'
+              onClick={toggleIsStarsSelectActive}
+              aria-label='Toggle scene picker'
+              data-testid='search-bar-picker'
+              className={isStarsSelectActive ? 'picker active' : 'picker'}
+            >
+              <MyLocationIcon fontSize='small'/>
+            </IconButton>
+          </Tooltip>
+          <Tooltip title='Clear / Close (Esc)' describeChild>
+            <IconButton
+              size='small'
+              onClick={handleClear}
+              aria-label='Clear or close search'
+              data-testid='search-bar-clear'
+            >
+              <CloseIcon fontSize='small'/>
+            </IconButton>
+          </Tooltip>
+        </>
+      }
+    </div>
+  )
+}
+
+
+/**
+ * Push a SearchEntry into the preview store fields.  Stars use previewStar
+ * (rendered via ControlPanel.showStarPreview); bodies use previewPath.
+ *
+ * @param {SearchEntry|null} entry
+ * @param {object} setters {setPreviewPath, setPreviewStar, clearPreview}
+ */
+function setPreviewForEntry(entry, {setPreviewPath, setPreviewStar, clearPreview}) {
+  if (!entry) {
+    clearPreview()
+    return
+  }
+  if (entry.kind === 'star') {
+    setPreviewStar({
+      hipId: entry.payload && entry.payload.hipId,
+      displayName: entry.displayName,
+      star: entry.payload && entry.payload.star,
+    })
+    return
+  }
+  // 'milkyway/sun/earth/moon' → ['sun', 'earth', 'moon']
+  const parts = entry.path.split('/')
+  if (parts[0] === 'milkyway') {
+    parts.shift()
+  }
+  if (parts.length === 0) {
+    parts.push(entry.id)
+  }
+  setPreviewPath(parts)
+}
+
+
+/**
+ * @param {SearchEntry} entry
+ * @param {object} celestiary
+ */
+function commitEntry(entry, celestiary) {
+  if (!entry || !celestiary) {
+    return
+  }
+  if (entry.kind === 'star' && entry.payload && entry.payload.star) {
+    celestiary.scene.goTo(entry.payload.star)
+    celestiary.useStore.getState().setCommittedStar({
+      hipId: entry.payload.hipId,
+      displayName: entry.displayName,
+      star: entry.payload.star,
+    })
+    return
+  }
+  const name = entry.payload && entry.payload.name
+  if (!name) {
+    return
+  }
+  const path = celestiary.loader.pathByName[name]
+  if (path) {
+    window.location.hash = path
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@react-three/fiber": "8.17.10",
     "@tweenjs/tween.js": "^25.0.0",
     "@types/three": "0.171.0",
+    "fuse.js": "^7.3.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "three": "0.171.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,11 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fuse.js@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-7.3.0.tgz#68e1ea1c6c0ff262f1801a949a78edbe05b0bc13"
+  integrity sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==
+
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"


### PR DESCRIPTION
## Summary

- **Breadcrumb-anchored SearchBar** (`js/ui/SearchBar.jsx`): chips with a movable search icon that hover-scopes queries to the current subtree; clicking expands an inline MUI `Autocomplete`.  Anchor chip stays highlighted while open; right-of-anchor elements hide; Escape / Clear / outside-click / 3s blur-debounce all collapse cleanly.
- **Modular `js/search/` module**: tiered index — named-star Fuse (~8k) + HIP numeric exact (~120k) + per-anchor cache reserved for future places data — behind a `SearchProvider` interface with scene / stars / stub places providers.  Architecture doc at `js/search/DESIGN.md`.
- **Info-panel preview** on highlight + hover (including crosshair hover); commit on Enter, Go icon, or crosshair double-click.  New `ControlPanel.showStarPreview` for catalog stars that have no loader entry.
- **Store wiring**: new `SearchSlice` with mutually-exclusive `committedPath` / `committedStar`; `Celestiary._subscribePreview` is the single info-panel render hub (precedence `previewStar > previewPath > committedStar > committedPath`).
- **Scene.setTarget** now syncs `committedPath` via a new `_pathFor` helper so every target-changing key (`h`, `u`, `0–9`) clears stale star selection.  `h` retargets Sun without traveling; `g` handles committed stars too.
- **Keys** suppresses shortcuts while an `<input>`/`<textarea>`/`<select>`/contenteditable is focused — typing `g` into the search box no longer fires `Celestiary.goTo`.
- **`document.title`** tracks the committed leaf (body or star).  `StarsCatalog.getNameOrId` always returns a string, prefixed with `HIP ` for unnamed catalog entries (consistent sprite labels, breadcrumb chip, and title).
- 159 tests pass (added 29: `SearchIndex`, `SearchSlice`, `anchorPathFor`, `Scene._pathFor`).

## Test plan

- [x] \`yarn precommit\` passes (lint + 159 tests + bundle-check)
- [x] Search by proper name: \`earth\`, \`Earth\`, \`earrth\` (typo), \`luna\`, \`rigel\`, \`Sirius\` — each matches and Enter navigates
- [x] Search by HIP: \`HIP 24436\`, bare \`24436\` — exact-path short-circuit; unnamed HIPs reachable too
- [x] Hover \`Earth\` in the breadcrumb → icon moves to it with no layout shift; click → anchor = solar-system scope; typing \`rigel\` returns no results (out of scope), \`mars\` matches
- [x] Commit to Rigel → breadcrumb + title become \`Rigel\`; info panel shows HIP / class / abs mag / distance
- [x] Press \`h\` → look tween only, no travel; breadcrumb updates to \`Sun\`; \`g\` travels to Sun
- [x] Toggle crosshair, hover a star → info panel previews live, breadcrumb unchanged; dblclick → commits and closes the bar; crosshair deactivates
- [x] Click About / Time panel / breadcrumb-Sun link while search open → immediate cancel
- [x] Tab away without click → 3s then animated collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)