### PR TITLE
Reference grids, Milky Way, permalink settings, atmosphere fix

### DIFF
--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -19,6 +19,14 @@ import {decodePermalink, decodeSettings, encodePermalink, pathFromFragment} from
 import {elt} from './utils'
 
 
+// Scene-annotation settings keys (see permalink.js SETTINGS_DEFAULTS).
+// 'V' (Shift+v) toggles all of these together as a "presentation mode" —
+// keys here are the lowercase per-overlay toggles ('a' asterisms, 'p'
+// planet labels, etc.); the HTML chrome key 'v' is deliberately not in
+// this list so users can hide overlays and chrome independently.
+const SCENE_INFO_KEYS = ['a', 'l', 'p', 'o', 'e', 'c', 'g']
+
+
 /** Main application class. */
 export default class Celestiary {
   /**
@@ -277,14 +285,42 @@ export default class Celestiary {
   }
 
 
+  /**
+   * Wire up keyboard shortcuts.
+   *
+   * Keys.js dispatches case-sensitively, so 'v' and 'V' bind to different
+   * actions.  We use the convention:
+   *
+   *   - lowercase letters         = scoped toggles (one specific overlay
+   *                                 element each: 'a' asterisms, 'p'
+   *                                 planet labels, etc.)
+   *   - uppercase / Shift letters = "wider" actions affecting many things
+   *                                 at once.
+   *
+   * The two relevant cases today:
+   *
+   *   - 'v' hides the HTML chrome only — the nav panel, the search bar,
+   *     and the time / target heads-up text.  Scene annotations stay
+   *     visible.
+   *   - 'V' (Shift+v) is "presentation mode": hides every scene
+   *     annotation (planet labels, star labels, asterisms, orbits, all
+   *     reference grids) and snapshots their state so a second 'V' press
+   *     restores exactly what the user had.  The HTML chrome is left
+   *     alone — combine with 'v' for a fully bare view.
+   *
+   * The order of `k.map(...)` calls drives the Settings panel listing
+   * order.
+   */
   setupKeyListeners(useStore) {
     const k = new Keys(window, useStore)
 
-    // Order determines listing in Settings panel.
-
-    // Nav panels
+    // Nav panels (HTML chrome only)
     k.map('v', () => this._toggleNav(),
-        'Hide/show navigation panels')
+        'Hide/show navigation panels (HTML overlay)')
+
+    // Presentation mode — hide every scene annotation at once.
+    k.map('V', () => this._toggleAllSceneInfo(),
+        'Hide/show all scene annotations (labels, orbits, asterisms, grids)')
 
     // Scene elements
     k.map('a', () => {
@@ -435,6 +471,38 @@ export default class Celestiary {
     })
     this.navVisible = !this.navVisible
     this.scene.flipSetting('v')
+  }
+
+
+  /**
+   * "Presentation mode" — hide every scene annotation in one shot, with
+   * snapshot+restore so a second press brings the user's prior state back.
+   *
+   * The hidden keys are the per-overlay scene toggles: planet labels (p),
+   * star labels (l), asterisms (a), orbits (o), and the three reference
+   * grids (e, c, g).  HTML chrome ('v') is intentionally left alone —
+   * users can combine with the 'v' key for a fully bare view.
+   *
+   * We snapshot only the relevant keys (not the whole settings map) so
+   * unrelated state changes between the press pair don't get clobbered on
+   * restore.
+   */
+  _toggleAllSceneInfo() {
+    if (this._sceneInfoSnapshot) {
+      const target = {...this.scene.getSettings(), ...this._sceneInfoSnapshot}
+      this._sceneInfoSnapshot = null
+      this.scene.applySettings(target)
+      return
+    }
+    const cur = this.scene.getSettings()
+    const snapshot = {}
+    const target = {...cur}
+    for (const key of SCENE_INFO_KEYS) {
+      snapshot[key] = cur[key]
+      target[key] = false
+    }
+    this._sceneInfoSnapshot = snapshot
+    this.scene.applySettings(target)
   }
 
 

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -296,6 +296,10 @@ export default class Celestiary {
       this.scene.toggleOrbits()
     },
     'Show/hide orbits')
+    k.map(';', () => {
+      this.scene.toggleGridsOrientation()
+    },
+    'Show/hide ecliptic + galactic reference grids')
 
     // Time
     k.map(' ', () => {

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -297,9 +297,19 @@ export default class Celestiary {
     },
     'Show/hide orbits')
     k.map(';', () => {
-      this.scene.toggleGridsOrientation()
+      this.scene.toggleGridEquatorial()
     },
-    'Show/hide ecliptic + galactic reference grids')
+    'Show/hide equatorial reference grid')
+    // No keys for ecliptic / galactic per Celestia convention; click-only
+    // entries appear in Settings after the keyed shortcuts.
+    k.addAction(() => {
+      this.scene.toggleGridEcliptic()
+    },
+    'Show/hide ecliptic reference grid')
+    k.addAction(() => {
+      this.scene.toggleGridGalactic()
+    },
+    'Show/hide galactic reference grid')
 
     // Time
     k.map(' ', () => {

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -419,12 +419,18 @@ export default class Celestiary {
    * Used both by the 'v' keypress and by Scene.applySettings on permalink
    * restore — the latter goes through the applier registered in the
    * constructor, so the canonical _settings.v stays in sync.
+   *
+   * Uses `display: none` rather than `visibility: hidden` because the
+   * SearchBar's CSS sets `visibility: visible` on chip icons, which would
+   * override an ancestor's `visibility: hidden` and leak the search icon
+   * back through.  `display: none` removes the elements from layout
+   * entirely so descendants can't punch back through.
    */
   _toggleNav() {
     const panels = [elt('nav-id'), elt('top-right'), elt('search-bar')]
     panels.forEach((panel) => {
       if (panel) {
-        panel.style.visibility = this.navVisible ? 'hidden' : 'visible'
+        panel.style.display = this.navVisible ? 'none' : ''
       }
     })
     this.navVisible = !this.navVisible

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -15,7 +15,7 @@ import * as Shapes from './scene/shapes'
 import * as Shared from './shared'
 import {assertArgs} from './assert'
 import {latLngAltToLocal, worldToLatLngAlt} from './coords'
-import {decodePermalink, encodePermalink, pathFromFragment} from './permalink'
+import {decodePermalink, decodeSettings, encodePermalink, pathFromFragment} from './permalink'
 import {elt} from './utils'
 
 
@@ -48,6 +48,9 @@ export default class Celestiary {
     this.ui.onCameraChange = () => this._schedulePermalinkUpdate()
     this.camera = this.ui.camera
     this.scene = new Scene(this.ui)
+    // Any settings toggle (asterisms, grids, etc.) updates the permalink so
+    // the URL always reflects the live view configuration.
+    this.scene.onSettingsChange = () => this._schedulePermalinkUpdate()
     this.loader = new Loader()
     this.controlPanel = new ControlPanel(navElt, this.loader)
     this.firstTime = true
@@ -208,8 +211,14 @@ export default class Celestiary {
           }
         }
         if (this.firstTime) {
-          this.scene.toggleAsterisms()
-          this.scene.toggleStarLabels()
+          // Apply scene settings — either from the permalink's `s=` flags
+          // or the SETTINGS_DEFAULTS table.  applySettings is idempotent;
+          // any setting already at its target state is a no-op, so this
+          // does the equivalent of the old "toggleAsterisms / toggleStarLabels"
+          // pair for a fresh viewer, and additionally honors the
+          // permalink for returning users.
+          const wantedSettings = pl?.settings ?? decodeSettings(undefined)
+          this.scene.applySettings(wantedSettings)
           this.firstTime = false
         }
       }, this._pendingPermalink ? 0 : (this.firstTime ? 1000 : 0))
@@ -433,7 +442,9 @@ export default class Celestiary {
           camWorldPos, planetWorldPos, planetWorldQuat, tObj.props.radius.scalar,
       )
       const d2000 = this.time.simTimeJulianDay() - J2000_JD
-      const fragment = encodePermalink(path, d2000, lat, lng, alt, cam.quaternion, cam.fov)
+      const settings = this.scene.getSettings ? this.scene.getSettings() : null
+      const fragment = encodePermalink(
+          path, d2000, lat, lng, alt, cam.quaternion, cam.fov, settings)
       history.replaceState(null, '', `#${fragment}`)
     }, 1000)
   }

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -51,6 +51,9 @@ export default class Celestiary {
     // Any settings toggle (asterisms, grids, etc.) updates the permalink so
     // the URL always reflects the live view configuration.
     this.scene.onSettingsChange = () => this._schedulePermalinkUpdate()
+    // 'v' (nav panels) is a Celestiary-level toggle — register the applier
+    // so Scene.applySettings can drive it on permalink restore.
+    this.scene.registerSettingApplier('v', () => this._toggleNav())
     this.loader = new Loader()
     this.controlPanel = new ControlPanel(navElt, this.loader)
     this.firstTime = true
@@ -280,13 +283,8 @@ export default class Celestiary {
     // Order determines listing in Settings panel.
 
     // Nav panels
-    k.map('v', () => {
-      const panels = [elt('nav-id'), elt('top-right')]
-      panels.map((panel) => {
-        panel.style.visibility = this.navVisible ? 'hidden' : 'visible'
-      })
-      this.navVisible = !this.navVisible
-    }, 'Hide/show navigation panels')
+    k.map('v', () => this._toggleNav(),
+        'Hide/show navigation panels')
 
     // Scene elements
     k.map('a', () => {
@@ -413,6 +411,22 @@ export default class Celestiary {
     k.msgs['ALT+MOUSEDRAG'] = 'Option+drag to orbit target'
 
     this.keys = k
+  }
+
+
+  /**
+   * Single-source-of-truth toggle for the nav panels (heads-up display).
+   * Used both by the 'v' keypress and by Scene.applySettings on permalink
+   * restore — the latter goes through the applier registered in the
+   * constructor, so the canonical _settings.v stays in sync.
+   */
+  _toggleNav() {
+    const panels = [elt('nav-id'), elt('top-right')]
+    panels.forEach((panel) => {
+      panel.style.visibility = this.navVisible ? 'hidden' : 'visible'
+    })
+    this.navVisible = !this.navVisible
+    this.scene.flipSetting('v')
   }
 
 

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -421,9 +421,11 @@ export default class Celestiary {
    * constructor, so the canonical _settings.v stays in sync.
    */
   _toggleNav() {
-    const panels = [elt('nav-id'), elt('top-right')]
+    const panels = [elt('nav-id'), elt('top-right'), elt('search-bar')]
     panels.forEach((panel) => {
-      panel.style.visibility = this.navVisible ? 'hidden' : 'visible'
+      if (panel) {
+        panel.style.visibility = this.navVisible ? 'hidden' : 'visible'
+      }
     })
     this.navVisible = !this.navVisible
     this.scene.flipSetting('v')

--- a/js/Keys.js
+++ b/js/Keys.js
@@ -39,8 +39,13 @@ export default class Keys {
       }
     }
     const charStr = event.key
+    // Case-sensitive lookup so 'v' (plain) and 'V' (Shift+v) can be bound
+    // to different actions — the browser already distinguishes them in
+    // event.key for letters with Shift held.  Non-letter keys (' ', ';',
+    // 'ArrowUp', etc.) are unaffected since their event.key is the same
+    // either way.
     if (charStr && typeof charStr === 'string') {
-      const f = this.keymap[charStr.toUpperCase()]
+      const f = this.keymap[charStr]
       if (f) {
         f()
       }
@@ -49,14 +54,14 @@ export default class Keys {
 
 
   /**
-   * @param {string} c Shortcut key
+   * @param {string} c Shortcut key (case-sensitive — 'v' and 'V' bind to
+   *   different handlers).
    * @param {Function} fn
    * @param {string} msg
    */
   map(c, fn, msg) {
-    const key = c.toUpperCase()
-    this.keymap[key] = fn
-    this.msgs[key] = msg
+    this.keymap[c] = fn
+    this.msgs[c] = msg
   }
 
 

--- a/js/Keys.js
+++ b/js/Keys.js
@@ -5,6 +5,10 @@ export default class Keys {
     this.window = win
     this.keymap = {}
     this.msgs = {}
+    // Click-only actions: items the user can toggle from Settings but which
+    // don't have a keyboard shortcut.  Each entry: {fn, msg}.  Listed in
+    // Settings after the keyed shortcuts.
+    this.actions = []
     this.bindToWindow(useStore)
   }
 
@@ -53,5 +57,16 @@ export default class Keys {
     const key = c.toUpperCase()
     this.keymap[key] = fn
     this.msgs[key] = msg
+  }
+
+
+  /**
+   * Register a click-only action — listed in Settings without a key shortcut.
+   *
+   * @param {Function} fn
+   * @param {string} msg
+   */
+  addAction(fn, msg) {
+    this.actions.push({fn, msg})
   }
 }

--- a/js/Keys.test.js
+++ b/js/Keys.test.js
@@ -1,23 +1,50 @@
+import {describe, expect, it, mock} from 'bun:test'
 import Keys from './Keys'
 
 
 describe('Keys', () => {
-  it('', () => {
-    const keys = new Keys({addEventListener: jest.fn()})
-    const cbA = jest.fn()
-    const cbB = jest.fn()
+  it('dispatches keydown to the handler bound to the same character', () => {
+    const keys = new Keys({addEventListener: mock()})
+    const cbA = mock()
     keys.map('a', cbA, 'a key')
-    keys.map('B', cbB, 'B key')
 
     expect(cbA).not.toHaveBeenCalled()
-    expect(cbB).not.toHaveBeenCalled()
-
     keys.onKeyDown({key: 'a'})
     expect(cbA).toHaveBeenCalledTimes(1)
-    expect(cbB).toHaveBeenCalledTimes(0)
+  })
 
-    keys.onKeyDown({key: 'b'})
-    expect(cbA).toHaveBeenCalledTimes(1)
-    expect(cbB).toHaveBeenCalledTimes(1)
+  it('treats lowercase and uppercase as distinct (Shift produces uppercase event.key)', () => {
+    const keys = new Keys({addEventListener: mock()})
+    const cbV = mock()
+    const cbVUpper = mock()
+    keys.map('v', cbV, 'plain v')
+    keys.map('V', cbVUpper, 'Shift+v')
+
+    keys.onKeyDown({key: 'v'})
+    expect(cbV).toHaveBeenCalledTimes(1)
+    expect(cbVUpper).not.toHaveBeenCalled()
+
+    keys.onKeyDown({key: 'V'})
+    expect(cbV).toHaveBeenCalledTimes(1)
+    expect(cbVUpper).toHaveBeenCalledTimes(1)
+  })
+
+  it('addAction queues click-only actions visible in keys.actions', () => {
+    const keys = new Keys({addEventListener: mock()})
+    const fn = mock()
+    keys.addAction(fn, 'click only')
+    expect(keys.actions).toHaveLength(1)
+    expect(keys.actions[0].msg).toBe('click only')
+    keys.actions[0].fn()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips dispatch when the active element is a text input', () => {
+    const cb = mock()
+    const fakeWindow = {addEventListener: mock(), document: {activeElement: {tagName: 'INPUT'}}}
+    const keys = new Keys(fakeWindow)
+    keys.map('a', cb, 'a key')
+    keys.onKeyDown({key: 'a'})
+    expect(cb).not.toHaveBeenCalled()
   })
 })

--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -391,6 +391,23 @@ export default class ThreeUi {
     const R = atmTarget.props.radius.scalar
 
     atmTarget.getWorldPosition(this._pWorldAtm)
+    this.camera.getWorldPosition(this._camWorldAtm)
+    // Skip the post-process when the camera is too far from the atmosphere
+    // for the in-shader rsi() to remain numerically stable.  The rsi math
+    // squares |eyePos| (and 2·dot(rayDir, eyePos)), so once |eyePos| approaches
+    // sqrt(FLT_MAX) ≈ 1.8e19 m, b² overflows to +Inf for forward-aligned rays
+    // while c is still finite — d becomes spuriously positive and rsi returns
+    // bogus intersections instead of the correct "miss," painting a giant
+    // halo over the screen.  At these distances the atmosphere is far below
+    // sub-pixel anyway, so skipping is the right call.
+    const camDist = this._camWorldAtm.distanceTo(this._pWorldAtm)
+    const FLT_SAFE_DIST = 1e15 // |eyePos|² stays below ~1e30, decades from FLT_MAX
+    if (camDist > FLT_SAFE_DIST) {
+      u.uPlanetCenter.value.set(0, 0, 1e20)
+      u.uAtmosphereRadius.value = u.uGroundRadius.value
+      u.uUseInScatterLUT.value = 0.0
+      return
+    }
     u.uPlanetCenter.value
         .copy(this._pWorldAtm)
         .applyMatrix4(this.camera.matrixWorldInverse)

--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -387,10 +387,11 @@ export default class ThreeUi {
     }
 
     if (!atmTarget) {
-      // No atmosphere ever seen — push planet far off-screen so rsi misses.
-      u.uPlanetCenter.value.set(0, 0, 1e20)
-      u.uAtmosphereRadius.value = u.uGroundRadius.value
-      u.uUseInScatterLUT.value = 0.0
+      // No atmosphere ever seen — kill the pass via the shader's gate.  We
+      // can't simply "push the planet far away" as a sentinel because the
+      // in-shader rsi() squares |eyePos|, and any sentinel large enough to
+      // miss the atmosphere would itself overflow float32.
+      u.uAtmEnabled.value = 0.0
       return
     }
     const atmos = atmTarget.props.atmosphere
@@ -399,21 +400,22 @@ export default class ThreeUi {
     atmTarget.getWorldPosition(this._pWorldAtm)
     this.camera.getWorldPosition(this._camWorldAtm)
     // Skip the post-process when the camera is too far from the atmosphere
-    // for the in-shader rsi() to remain numerically stable.  The rsi math
-    // squares |eyePos| (and 2·dot(rayDir, eyePos)), so once |eyePos| approaches
-    // sqrt(FLT_MAX) ≈ 1.8e19 m, b² overflows to +Inf for forward-aligned rays
-    // while c is still finite — d becomes spuriously positive and rsi returns
-    // bogus intersections instead of the correct "miss," painting a giant
-    // halo over the screen.  At these distances the atmosphere is far below
-    // sub-pixel anyway, so skipping is the right call.
+    // for the in-shader rsi() to remain numerically stable.  rsi squares
+    // |eyePos| (and 2·dot(rayDir, eyePos)), so once |eyePos| approaches
+    // sqrt(FLT_MAX) ≈ 1.8e19 m, b² overflows to +Inf for forward-aligned
+    // rays while c is still finite — d becomes spuriously positive and rsi
+    // returns bogus intersections instead of the correct "miss," painting
+    // huge garbage halos over the screen.  At these distances the
+    // atmosphere is far below sub-pixel anyway, so skipping is the right
+    // call.  Use the shader gate rather than a sentinel uniform value, for
+    // the same reason as the no-target branch above.
     const camDist = this._camWorldAtm.distanceTo(this._pWorldAtm)
     const FLT_SAFE_DIST = 1e15 // |eyePos|² stays below ~1e30, decades from FLT_MAX
     if (camDist > FLT_SAFE_DIST) {
-      u.uPlanetCenter.value.set(0, 0, 1e20)
-      u.uAtmosphereRadius.value = u.uGroundRadius.value
-      u.uUseInScatterLUT.value = 0.0
+      u.uAtmEnabled.value = 0.0
       return
     }
+    u.uAtmEnabled.value = 1.0
     u.uPlanetCenter.value
         .copy(this._pWorldAtm)
         .applyMatrix4(this.camera.matrixWorldInverse)

--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -17,7 +17,7 @@ import {newAtmospherePass} from './scene/atmos/Atmosphere'
 import {precomputeTransmittance, precomputeInScatter} from './scene/atmos/AtmospherePrecompute'
 import {TrackballControls} from 'three/examples/jsm/controls/TrackballControls.js'
 import Fullscreen from '@pablo-mayrgundter/fullscreen.js/fullscreen.js'
-import {INITIAL_FOV, SMALLEST_SIZE_METER, STARS_RADIUS_METER, SUN_RADIUS_METER, targets} from './shared.js'
+import {GALAXY_RADIUS_METER, INITIAL_FOV, SMALLEST_SIZE_METER, SUN_RADIUS_METER, targets} from './shared.js'
 import {named} from './utils.js'
 import {asymptoticZoomDist, dynamicNear} from './zoom.js'
 
@@ -117,7 +117,13 @@ export default class ThreeUi {
   /** Sets camera near and far to deimos and local star cluster. */
   configLargeScene() {
     this.camera.near = SMALLEST_SIZE_METER
-    this.camera.far = STARS_RADIUS_METER * 2
+    // Far must comfortably enclose the procedural Milky Way (galaxy radius +
+    // a healthy navigation buffer for viewing it from outside).  The galaxy
+    // shader pins its z to the far plane so it never z-fights nearer geometry,
+    // so the precision crush at this far/near ratio is harmless for it; the
+    // depth-writing objects (planets, sun) are always orders of magnitude
+    // closer where precision is fine.
+    this.camera.far = GALAXY_RADIUS_METER * 6
     this.camera.updateProjectionMatrix()
 
     // This is a bit of a hack.  Starting the camera away from center so there's

--- a/js/camera.js
+++ b/js/camera.js
@@ -1,4 +1,8 @@
 import {
+  // Camera and Matrix4 are imported only for JSDoc type references below;
+  // the project's eslint no-unused-vars config accepts type-only imports.
+  Camera,
+  Matrix4,
   Quaternion,
   Vector3,
 } from 'three'

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -26,6 +26,7 @@ export const SETTINGS_DEFAULTS = Object.freeze({
   e: false, // equatorial reference grid
   c: false, // ecliptic reference grid
   g: false, // galactic reference grid
+  v: true, // nav panels / heads-up display
 })
 
 

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -12,6 +12,62 @@ const METER_PREFIXES = [
 ]
 
 
+// Toggleable scene settings — see Scene.js.  The `s=` permalink parameter is
+// a string of single-letter codes; each letter present means that setting is
+// in its NON-default state.  Empty / missing param = all defaults.  This
+// keeps the URL trivially short for the common case of a fresh viewer who
+// hasn't customized anything, while still being able to round-trip any
+// configuration faithfully.
+export const SETTINGS_DEFAULTS = Object.freeze({
+  a: true, // asterisms (constellation lines)
+  l: true, // star labels
+  p: true, // planet/moon labels
+  o: true, // orbits
+  e: false, // equatorial reference grid
+  c: false, // ecliptic reference grid
+  g: false, // galactic reference grid
+})
+
+
+/**
+ * Encode the current settings object as a compact letter-flag string for the
+ * permalink `s=` parameter.  Each letter present means "non-default state".
+ *
+ * @param {object} settings - flat {key: bool} map matching SETTINGS_DEFAULTS
+ * @returns {string}
+ */
+export function encodeSettings(settings) {
+  let out = ''
+  for (const key of Object.keys(SETTINGS_DEFAULTS)) {
+    if (settings[key] !== SETTINGS_DEFAULTS[key]) {
+      out += key
+    }
+  }
+  return out
+}
+
+
+/**
+ * Decode the settings flag string back to a full {key: bool} map (every key
+ * from SETTINGS_DEFAULTS is present, defaulted unless flagged).
+ *
+ * @param {string} s - flag string from `s=` param (may be undefined)
+ * @returns {object}
+ */
+export function decodeSettings(s) {
+  const out = {...SETTINGS_DEFAULTS}
+  if (!s) {
+    return out
+  }
+  for (const ch of s) {
+    if (Object.prototype.hasOwnProperty.call(SETTINGS_DEFAULTS, ch)) {
+      out[ch] = !SETTINGS_DEFAULTS[ch]
+    }
+  }
+  return out
+}
+
+
 /**
  * Trim a float to at most 4 decimal places, stripping trailing zeros.
  *
@@ -67,11 +123,14 @@ function parseMeters(s) {
 /**
  * Encode a complete view state into a hash fragment.
  *
- * Format: path@<lat>,<lng>,<alt>;t=<d2000>jd;cq=<qx>,<qy>,<qz>,<qw>;fov=<fov>deg
+ * Format: path@<lat>,<lng>,<alt>;t=<d2000>jd;cq=<qx>,<qy>,<qz>,<qw>;fov=<fov>deg[;s=<flags>]
  *
  * Position is encoded as geographic coordinates (Google Maps style) in the
  * body-fixed frame of the target object.  lat/lng in degrees (4 dp trimmed),
- * alt as SI-prefixed meters rounded to the nearest metre.
+ * alt as SI-prefixed meters rounded to the nearest metre.  The optional
+ * `s=` flag string round-trips toggleable scene settings (asterisms, grids,
+ * etc.) — see SETTINGS_DEFAULTS / encodeSettings.  Omitted when every
+ * setting is at its default, so the common case stays short.
  *
  * See design/permalink.md for the full specification.
  *
@@ -82,14 +141,22 @@ function parseMeters(s) {
  * @param {number} alt  Altitude above planet surface in meters
  * @param {{x:number, y:number, z:number, w:number}} quat  camera.quaternion (platform-local)
  * @param {number} fov  camera.fov in degrees
+ * @param {object} [settings]  Scene settings map matching SETTINGS_DEFAULTS
  * @returns {string}  Hash fragment without leading '#'
  */
-export function encodePermalink(path, d2000, lat, lng, alt, quat, fov) {
+export function encodePermalink(path, d2000, lat, lng, alt, quat, fov, settings) {
   const pos = `${trimFloat(lat)},${trimFloat(lng)},${formatMeters(Math.round(alt))}`
   const t = `${parseFloat(d2000.toFixed(4))}jd`
   const cq = [quat.x, quat.y, quat.z, quat.w].map(trimFloat).join(',')
   const f = `${parseFloat(fov.toFixed(2))}deg`
-  return `${path}${SEPARATOR}${pos}${PARAM_SEP}t=${t}${PARAM_SEP}cq=${cq}${PARAM_SEP}fov=${f}`
+  let frag = `${path}${SEPARATOR}${pos}${PARAM_SEP}t=${t}${PARAM_SEP}cq=${cq}${PARAM_SEP}fov=${f}`
+  if (settings) {
+    const flags = encodeSettings(settings)
+    if (flags) {
+      frag += `${PARAM_SEP}s=${flags}`
+    }
+  }
+  return frag
 }
 
 
@@ -152,7 +219,10 @@ export function decodePermalink(fragment) {
   if ([lat, lng, alt, d2000, qx, qy, qz, qw, fov].some(isNaN)) {
     return null
   }
-  return {path, d2000, lat, lng, alt, quat: {x: qx, y: qy, z: qz, w: qw}, fov}
+  // Settings are always returned as a complete map (defaults + any flagged
+  // overrides) so callers don't need to know the default table.
+  const settings = decodeSettings(params['s'])
+  return {path, d2000, lat, lng, alt, quat: {x: qx, y: qy, z: qz, w: qw}, fov, settings}
 }
 
 

--- a/js/permalink.test.js
+++ b/js/permalink.test.js
@@ -1,4 +1,11 @@
-import {decodePermalink, encodePermalink, pathFromFragment} from './permalink.js'
+import {
+  SETTINGS_DEFAULTS,
+  decodePermalink,
+  decodeSettings,
+  encodePermalink,
+  encodeSettings,
+  pathFromFragment,
+} from './permalink.js'
 
 
 describe('encodePermalink / decodePermalink round-trip', () => {
@@ -173,5 +180,62 @@ describe('lat/lng encoding', () => {
   it('trims trailing zeros from lat/lng', () => {
     const encoded = encodePermalink('sun/earth', 0, 45.0, -90.0, 1000, {x: 0, y: 0, z: 0, w: 1}, 45)
     expect(encoded).toMatch(/^sun\/earth@45,-90,/)
+  })
+})
+
+
+describe('settings encoding', () => {
+  const defaults = {...SETTINGS_DEFAULTS}
+  const baseArgs = ['sun/earth', 0, 0, 0, 1000, {x: 0, y: 0, z: 0, w: 1}, 45]
+
+  it('omits the s= param when all settings are at defaults', () => {
+    const encoded = encodePermalink(...baseArgs, defaults)
+    expect(encoded).not.toContain(';s=')
+  })
+
+  it('omits the s= param when settings is undefined (back-compat)', () => {
+    const encoded = encodePermalink(...baseArgs)
+    expect(encoded).not.toContain(';s=')
+  })
+
+  it('flags only deviations from defaults', () => {
+    const encoded = encodePermalink(...baseArgs,
+        {...defaults, a: false, e: true})
+    expect(encoded).toContain(';s=')
+    expect(encoded).toMatch(/;s=[ae]+/)
+    // a is default ON, set to OFF → "a"; e is default OFF, set to ON → "e"
+    const m = encoded.match(/;s=(\w+)/)
+    const flags = m[1].split('').sort().join('')
+    expect(flags).toBe('ae')
+  })
+
+  it('round-trips an all-defaults permalink', () => {
+    const encoded = encodePermalink(...baseArgs, defaults)
+    const decoded = decodePermalink(encoded)
+    expect(decoded.settings).toEqual(defaults)
+  })
+
+  it('round-trips a permalink with custom settings', () => {
+    const custom = {...defaults, a: false, l: false, e: true, c: true, g: true}
+    const encoded = encodePermalink(...baseArgs, custom)
+    const decoded = decodePermalink(encoded)
+    expect(decoded.settings).toEqual(custom)
+  })
+
+  it('decodeSettings returns full defaults map for empty / missing input', () => {
+    expect(decodeSettings(undefined)).toEqual(defaults)
+    expect(decodeSettings('')).toEqual(defaults)
+  })
+
+  it('decodeSettings ignores unknown letter codes', () => {
+    expect(decodeSettings('aZQ')).toEqual({...defaults, a: false})
+  })
+
+  it('encodeSettings is stable in key order regardless of input ordering', () => {
+    // Caller may build the settings object in any order; the encoded string
+    // must be deterministic so the URL doesn't churn between identical states.
+    const s1 = {a: false, l: true, p: true, o: true, e: true, c: false, g: false}
+    const s2 = {g: false, c: false, e: true, o: true, p: true, l: true, a: false}
+    expect(encodeSettings(s1)).toBe(encodeSettings(s2))
   })
 })

--- a/js/permalink.test.js
+++ b/js/permalink.test.js
@@ -222,6 +222,24 @@ describe('settings encoding', () => {
     expect(decoded.settings).toEqual(custom)
   })
 
+  it('round-trips the v (nav) flag — default ON', () => {
+    expect(SETTINGS_DEFAULTS.v).toBe(true)
+    const navOff = {...defaults, v: false}
+    const encoded = encodePermalink(...baseArgs, navOff)
+    expect(encoded).toContain(';s=v')
+    const decoded = decodePermalink(encoded)
+    expect(decoded.settings.v).toBe(false)
+  })
+
+  it('decodePermalink always populates settings, even with no s= param', () => {
+    // back-compat: pre-settings permalinks should still round-trip cleanly,
+    // with the settings field defaulted.
+    const encoded = encodePermalink(...baseArgs)
+    expect(encoded).not.toContain(';s=')
+    const decoded = decodePermalink(encoded)
+    expect(decoded.settings).toEqual(defaults)
+  })
+
   it('decodeSettings returns full defaults map for empty / missing input', () => {
     expect(decodeSettings(undefined)).toEqual(defaults)
     expect(decodeSettings('')).toEqual(defaults)

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -476,8 +476,17 @@ function attachEdgeFollower(points, items, gridGroup) {
         }
       }
 
-      // Fallback: no bracket — pick the closest visible sample to the edge
-      // (line never reaches the edge, but is still on screen somewhere).
+      // Fallback: no bracket — line never reaches the edge but might still
+      // be visible somewhere.  Pick the visible sample closest to the
+      // edge, then refine to sub-sample precision via a parabolic fit
+      // through that sample and its two neighbours.  Linear interpolation
+      // can't help here (both segment endpoints have score ≥ the local
+      // min), but the score curve through three adjacent samples is
+      // approximately quadratic, and the vertex of the fitted parabola
+      // gives a smooth continuous position even when no segment brackets
+      // the edge.  This eliminates the "snap to nearest sample" stepping
+      // for parallels viewed obliquely (where right/left-edge crossings
+      // are off-screen on the orthogonal axis).
       if (!Number.isFinite(bestScore)) {
         let bestI = -1
         let bestEdgeScore = Infinity
@@ -492,10 +501,11 @@ function attachEdgeFollower(points, items, gridGroup) {
           }
         }
         if (bestI >= 0) {
-          const off = bestI * 3
-          bestX3 = samples[off]
-          bestY3 = samples[off + 1]
-          bestZ3 = samples[off + 2]
+          const refined = refineSubSample(
+              bestI, samples, ndcX, ndcY, front, edge, closed)
+          bestX3 = refined.x
+          bestY3 = refined.y
+          bestZ3 = refined.z
           bestScore = bestEdgeScore
         }
       }
@@ -512,6 +522,72 @@ function attachEdgeFollower(points, items, gridGroup) {
     }
     positionAttr.needsUpdate = true
     visibleAttr.needsUpdate = true
+  }
+}
+
+
+/**
+ * Sub-sample refinement around `bestI`: fit a parabola through bestI's
+ * edge-score and its two neighbours' scores, find the vertex (offset t in
+ * [-1, +1] sample-spacings from bestI), and return the linearly
+ * interpolated 3D position toward whichever neighbour the vertex falls
+ * toward.  Falls back to the bestI sample directly when the three points
+ * don't form a true upward parabola (e.g. one neighbour is off-screen).
+ *
+ * Exported for tests.
+ *
+ * @param {number} bestI
+ * @param {Float32Array|Array<number>} samples flat (x,y,z) triples
+ * @param {Float32Array|Array<number>} ndcX
+ * @param {Float32Array|Array<number>} ndcY
+ * @param {Uint8Array|Array<number>} front per-sample visibility flag (1/0)
+ * @param {string} edge 'top' | 'bottom' | 'right' | 'left'
+ * @param {boolean} closed wrap (-1 ↔ N-1) when true
+ * @returns {{x:number, y:number, z:number}}
+ */
+export function refineSubSample(bestI, samples, ndcX, ndcY, front, edge, closed) {
+  const N = front.length
+  let prevI; let nextI
+  if (closed) {
+    prevI = (bestI - 1 + N) % N
+    nextI = (bestI + 1) % N
+  } else {
+    prevI = bestI > 0 ? bestI - 1 : bestI
+    nextI = bestI < N - 1 ? bestI + 1 : bestI
+  }
+  const offB = bestI * 3
+  if (prevI === bestI || nextI === bestI || !front[prevI] || !front[nextI]) {
+    return {x: samples[offB], y: samples[offB + 1], z: samples[offB + 2]}
+  }
+  const sa = edgeScore(ndcX[prevI], ndcY[prevI], edge)
+  const sb = edgeScore(ndcX[bestI], ndcY[bestI], edge)
+  const sc = edgeScore(ndcX[nextI], ndcY[nextI], edge)
+  if (!Number.isFinite(sa) || !Number.isFinite(sc)) {
+    return {x: samples[offB], y: samples[offB + 1], z: samples[offB + 2]}
+  }
+  // Parabola through (-1, sa), (0, sb), (1, sc) has vertex at
+  //   x* = (sa - sc) / (2 * (sa + sc - 2 sb))
+  // Only use the result if denom > 0 (parabola opens upward, sb really is
+  // a local min between sa and sc).  Clamp to [-1, +1] so we never reach
+  // past the neighbours.
+  const denom = (sa + sc) - (2 * sb)
+  if (denom <= 1e-12) {
+    return {x: samples[offB], y: samples[offB + 1], z: samples[offB + 2]}
+  }
+  let t = (sa - sc) / (2 * denom)
+  if (t > 1) {
+    t = 1
+  } else if (t < -1) {
+    t = -1
+  }
+  // Linearly interpolate between bestI and the neighbour in t's direction.
+  const otherI = t >= 0 ? nextI : prevI
+  const w = Math.abs(t) // fractional distance toward `otherI`, in [0, 1]
+  const offO = otherI * 3
+  return {
+    x: ((1 - w) * samples[offB]) + (w * samples[offO]),
+    y: ((1 - w) * samples[offB + 1]) + (w * samples[offO + 1]),
+    z: ((1 - w) * samples[offB + 2]) + (w * samples[offO + 2]),
   }
 }
 

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -287,15 +287,26 @@ function attachLabels(gridGroup, meridians, parallels, color) {
   // first) sample pair would be a chord through the centre of the sphere,
   // not a continuation of the line, so closed=false.  Parallels are full
   // small circles, so closed=true.
+  //
+  // Parallels also set exitOnly=true so the bracket walk rejects "entry"
+  // (line moving inward) crossings of the side edges.  A parallel viewed
+  // from oblique angles crosses each side edge an even number of times —
+  // typically 2 (one exit + one entry) — and without this filter the
+  // |x|+|y| tie-break can flip between the two crossings as the camera
+  // rotates, producing a visible jump.  Exits are topologically
+  // unambiguous: there's exactly one exit per side-edge crossing pair.
+  // Meridians don't get this filter because their pole-to-pole sample
+  // direction makes the bottom-edge crossing an "entry," and we still
+  // want to label it.
   for (const {lng, text} of meridians) {
     const samples = sampleMeridian(lng)
-    items.push({text, samples, edge: 'top', closed: false})
-    items.push({text, samples, edge: 'bottom', closed: false})
+    items.push({text, samples, edge: 'top', closed: false, exitOnly: false})
+    items.push({text, samples, edge: 'bottom', closed: false, exitOnly: false})
   }
   for (const {lat, text} of parallels) {
     const samples = sampleParallel(lat)
-    items.push({text, samples, edge: 'right', closed: true})
-    items.push({text, samples, edge: 'left', closed: true})
+    items.push({text, samples, edge: 'right', closed: true, exitOnly: true})
+    items.push({text, samples, edge: 'left', closed: true, exitOnly: true})
   }
   const points = buildLabelsPoints(items, color)
   if (!points) {
@@ -433,7 +444,7 @@ function attachEdgeFollower(points, items, gridGroup) {
     const padY = _rendererSize.y > 0 ? (LABEL_FONT_PX * 2) / _rendererSize.y : 0
 
     for (let labelIdx = 0; labelIdx < items.length; labelIdx++) {
-      const {samples, edge, closed} = items[labelIdx]
+      const {samples, edge, closed, exitOnly} = items[labelIdx]
       const padNDC = (edge === 'top' || edge === 'bottom') ? padY : padX
 
       // Pass 1: project all samples once.
@@ -463,7 +474,7 @@ function attachEdgeFollower(points, items, gridGroup) {
         }
         const xi = ndcX[i]; const yi = ndcY[i]
         const xj = ndcX[j]; const yj = ndcY[j]
-        const cross = bracketCrossing(xi, yi, xj, yj, edge, padNDC)
+        const cross = bracketCrossing(xi, yi, xj, yj, edge, padNDC, exitOnly)
         if (cross === null) {
           continue
         }
@@ -604,6 +615,13 @@ export function refineSubSample(bestI, samples, ndcX, ndcY, front, edge, closed)
  * crossing's NDC coordinates.  Returns null if the segment doesn't cross
  * the inset edge or crosses it off-screen on the orthogonal axis.
  *
+ * When `exitOnly` is true, also requires that the segment is going
+ * outward through the edge (line moving from inside to outside).  Used by
+ * the closed-loop parallels, where each side edge is typically crossed
+ * twice (one exit + one entry); filtering to exits gives a topologically
+ * unambiguous pick that doesn't flip between the two crossings as the
+ * camera rotates.
+ *
  * Exported for tests.
  *
  * @param {number} xi NDC x of segment start
@@ -613,15 +631,17 @@ export function refineSubSample(bestI, samples, ndcX, ndcY, front, edge, closed)
  * @param {string} edge 'top' | 'bottom' | 'right' | 'left'
  * @param {number} [padNDC] inset toward screen centre, in NDC units
  *   (e.g. 12 px on a 600 px-tall canvas → 12 / 300 = 0.04).
+ * @param {boolean} [exitOnly] when true, reject brackets where the line
+ *   is moving inward through the edge (an "entry" rather than an "exit").
  * @returns {{t:number, x:number, y:number}|null}
  */
-export function bracketCrossing(xi, yi, xj, yj, edge, padNDC = 0) {
-  let edgeVal; let isYAxis
+export function bracketCrossing(xi, yi, xj, yj, edge, padNDC = 0, exitOnly = false) {
+  let edgeVal; let isYAxis; let outwardSign
   switch (edge) {
-    case 'top': edgeVal = 1 - padNDC; isYAxis = true; break
-    case 'bottom': edgeVal = -1 + padNDC; isYAxis = true; break
-    case 'right': edgeVal = 1 - padNDC; isYAxis = false; break
-    case 'left': edgeVal = -1 + padNDC; isYAxis = false; break
+    case 'top': edgeVal = 1 - padNDC; isYAxis = true; outwardSign = +1; break
+    case 'bottom': edgeVal = -1 + padNDC; isYAxis = true; outwardSign = -1; break
+    case 'right': edgeVal = 1 - padNDC; isYAxis = false; outwardSign = +1; break
+    case 'left': edgeVal = -1 + padNDC; isYAxis = false; outwardSign = -1; break
     default: return null
   }
   const vi = isYAxis ? yi : xi
@@ -631,6 +651,12 @@ export function bracketCrossing(xi, yi, xj, yj, edge, padNDC = 0) {
   const di = vi - edgeVal
   const dj = vj - edgeVal
   if (di * dj >= 0) {
+    return null
+  }
+  // Direction filter: an "exit" goes outward (positive `outwardSign` ⇒
+  // value increasing through the edge; negative ⇒ decreasing).  When the
+  // caller asks for exits only, reject pairs whose motion is inward.
+  if (exitOnly && ((vj - vi) * outwardSign) <= 0) {
     return null
   }
   const t = di / (di - dj) // ∈ (0, 1)

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -47,15 +47,18 @@ const SEGMENTS = 96 // segments per circle
 const PARALLEL_STEP_DEG = 15
 const MERIDIAN_STEP_DEG = 15
 
-// Label point-size (atlas tile is square; this is the pixel size on screen).
-// Tuned for legibility without dominating the view.
-const LABEL_FONT = '20px sans-serif'
+// Label font / atlas tile size.  Small — these are reference-grid axis
+// labels and shouldn't dominate the scene; we want them legible but
+// understated.
+const LABEL_FONT = '10px sans-serif'
+const LABEL_TILE_PAD = 3
+const LABEL_TILE_LINE_H = 14
 
 // How many points to sample along each meridian / parallel circle when
-// searching for the screen-edge intersection per frame.  64 is plenty for
-// smooth, jitter-free label motion at typical FOVs and is cheap (a few
-// thousand matrix-vector mults per grid per frame).
-const EDGE_SAMPLES = 64
+// searching for the screen-edge intersection per frame.  Continuous
+// interpolation between adjacent samples (see attachEdgeFollower) gives
+// smooth label motion regardless of sample count, so 32 is ample.
+const EDGE_SAMPLES = 32
 
 
 /**
@@ -273,15 +276,19 @@ function degParallelLabels() {
  */
 function attachLabels(gridGroup, meridians, parallels, color) {
   const items = []
+  // Meridians are open arcs from south pole to north pole; the (last,
+  // first) sample pair would be a chord through the centre of the sphere,
+  // not a continuation of the line, so closed=false.  Parallels are full
+  // small circles, so closed=true.
   for (const {lng, text} of meridians) {
     const samples = sampleMeridian(lng)
-    items.push({text, samples, edge: 'top'})
-    items.push({text, samples, edge: 'bottom'})
+    items.push({text, samples, edge: 'top', closed: false})
+    items.push({text, samples, edge: 'bottom', closed: false})
   }
   for (const {lat, text} of parallels) {
     const samples = sampleParallel(lat)
-    items.push({text, samples, edge: 'right'})
-    items.push({text, samples, edge: 'left'})
+    items.push({text, samples, edge: 'right', closed: true})
+    items.push({text, samples, edge: 'left', closed: true})
   }
   const points = buildLabelsPoints(items, color)
   if (!points) {
@@ -367,11 +374,20 @@ export function edgeScore(ndcX, ndcY, edge) {
 
 
 /**
- * Per-frame, walk each label's sample circle, project each sample to NDC
- * (using the same skybox-style rotation-only transform the label shader
- * does), and pick the visible sample closest to that label's anchor edge.
- * Update the position attribute and toggle aVisible based on whether any
- * sample landed on screen.
+ * Per-frame, walk each label's sample circle and place the label at the
+ * exact point where the line crosses its target screen edge.  Two-pass:
+ *
+ *   1. Pre-project every sample to NDC (cheap — ~32 matrix-vector mults).
+ *   2. For each pair of adjacent samples, check whether they bracket the
+ *      target edge in NDC; if so, linearly interpolate to find the exact
+ *      crossing in NDC space, then lerp the corresponding 3D positions to
+ *      produce a continuous label position that slides smoothly along the
+ *      edge as the camera rotates.
+ *
+ * Falls back to the closest visible sample when no pair brackets (the
+ * line stays entirely on screen or entirely off the edge side).  When no
+ * sample is visible, marks the label as hidden via the aVisible attribute,
+ * which the fragment shader uses to discard.
  *
  * @param {Points} points
  * @param {Array<object>} items
@@ -382,6 +398,13 @@ function attachEdgeFollower(points, items, gridGroup) {
   const visibleAttr = points.geometry.attributes.aVisible
   const positions = positionAttr.array
   const visibles = visibleAttr.array
+
+  // Per-frame scratch: per-sample NDC + frontness, reused across every
+  // label so we don't reallocate.
+  const ndcX = new Float32Array(EDGE_SAMPLES)
+  const ndcY = new Float32Array(EDGE_SAMPLES)
+  const front = new Uint8Array(EDGE_SAMPLES)
+
   const _v = new Vector3()
   const _modelRot = new Matrix3()
   const _viewRot = new Matrix3()
@@ -392,36 +415,81 @@ function attachEdgeFollower(points, items, gridGroup) {
     _viewRot.setFromMatrix4(camera.matrixWorldInverse)
 
     for (let labelIdx = 0; labelIdx < items.length; labelIdx++) {
-      const {samples, edge} = items[labelIdx]
-      let bestX = 0; let bestY = 0; let bestZ = 0
-      let bestScore = Infinity
+      const {samples, edge, closed} = items[labelIdx]
 
+      // Pass 1: project all samples once.
       for (let i = 0; i < EDGE_SAMPLES; i++) {
         const off = i * 3
         _v.set(samples[off], samples[off + 1], samples[off + 2])
         _v.applyMatrix3(_modelRot).applyMatrix3(_viewRot)
-        // Skip points behind / on the camera plane — perspective projection
-        // is ill-defined and Vector3.applyMatrix4's perspective division
-        // would give nonsense NDC.  Small epsilon guards points exactly at
-        // the eye plane.
         if (_v.z >= -1e-6) {
+          front[i] = 0
           continue
         }
         _v.applyMatrix4(camera.projectionMatrix)
-        const score = edgeScore(_v.x, _v.y, edge)
+        ndcX[i] = _v.x
+        ndcY[i] = _v.y
+        front[i] = 1
+      }
+
+      // Pass 2: walk pairs, find the bracket whose NDC-interpolation
+      // lands closest to screen centre (the visible portion of the line).
+      let bestX3 = 0; let bestY3 = 0; let bestZ3 = 0
+      let bestScore = Infinity
+      const pairLimit = closed ? EDGE_SAMPLES : EDGE_SAMPLES - 1
+      for (let i = 0; i < pairLimit; i++) {
+        const j = (i + 1) % EDGE_SAMPLES
+        if (!front[i] || !front[j]) {
+          continue
+        }
+        const xi = ndcX[i]; const yi = ndcY[i]
+        const xj = ndcX[j]; const yj = ndcY[j]
+        const cross = bracketCrossing(xi, yi, xj, yj, edge)
+        if (cross === null) {
+          continue
+        }
+        // Tie-break: prefer the visible portion of the line — interpolated
+        // crossing closest to screen centre.  Pure |x|+|y| keeps it cheap.
+        const score = Math.abs(cross.x) + Math.abs(cross.y)
         if (score < bestScore) {
           bestScore = score
-          bestX = samples[off]
-          bestY = samples[off + 1]
-          bestZ = samples[off + 2]
+          const t = cross.t
+          const offI = i * 3; const offJ = j * 3
+          bestX3 = ((1 - t) * samples[offI]) + (t * samples[offJ])
+          bestY3 = ((1 - t) * samples[offI + 1]) + (t * samples[offJ + 1])
+          bestZ3 = ((1 - t) * samples[offI + 2]) + (t * samples[offJ + 2])
         }
       }
 
-      const off = labelIdx * 3
+      // Fallback: no bracket — pick the closest visible sample to the edge
+      // (line never reaches the edge, but is still on screen somewhere).
+      if (!Number.isFinite(bestScore)) {
+        let bestI = -1
+        let bestEdgeScore = Infinity
+        for (let i = 0; i < EDGE_SAMPLES; i++) {
+          if (!front[i]) {
+            continue
+          }
+          const score = edgeScore(ndcX[i], ndcY[i], edge)
+          if (score < bestEdgeScore) {
+            bestEdgeScore = score
+            bestI = i
+          }
+        }
+        if (bestI >= 0) {
+          const off = bestI * 3
+          bestX3 = samples[off]
+          bestY3 = samples[off + 1]
+          bestZ3 = samples[off + 2]
+          bestScore = bestEdgeScore
+        }
+      }
+
+      const labelOff = labelIdx * 3
       if (Number.isFinite(bestScore)) {
-        positions[off] = bestX
-        positions[off + 1] = bestY
-        positions[off + 2] = bestZ
+        positions[labelOff] = bestX3
+        positions[labelOff + 1] = bestY3
+        positions[labelOff + 2] = bestZ3
         visibles[labelIdx] = 1
       } else {
         visibles[labelIdx] = 0
@@ -430,6 +498,53 @@ function attachEdgeFollower(points, items, gridGroup) {
     positionAttr.needsUpdate = true
     visibleAttr.needsUpdate = true
   }
+}
+
+
+/**
+ * Test whether the NDC line segment (xi,yi) → (xj,yj) brackets the given
+ * screen edge, and if so return the linear-interpolation parameter t at
+ * the crossing along with the crossing's NDC coordinates.  Returns null
+ * if the segment doesn't cross the edge or crosses it off-screen on the
+ * orthogonal axis.
+ *
+ * Exported for tests.
+ *
+ * @param {number} xi NDC x of segment start
+ * @param {number} yi NDC y of segment start
+ * @param {number} xj NDC x of segment end
+ * @param {number} yj NDC y of segment end
+ * @param {string} edge 'top' | 'bottom' | 'right' | 'left'
+ * @returns {{t:number, x:number, y:number}|null}
+ */
+export function bracketCrossing(xi, yi, xj, yj, edge) {
+  let edgeVal; let isYAxis
+  switch (edge) {
+    case 'top': edgeVal = 1; isYAxis = true; break
+    case 'bottom': edgeVal = -1; isYAxis = true; break
+    case 'right': edgeVal = 1; isYAxis = false; break
+    case 'left': edgeVal = -1; isYAxis = false; break
+    default: return null
+  }
+  const vi = isYAxis ? yi : xi
+  const vj = isYAxis ? yj : xj
+  // Bracket iff edge sits strictly between the two values.  Use product
+  // of differences: negative ⇒ opposite signs ⇒ crosses.
+  const di = vi - edgeVal
+  const dj = vj - edgeVal
+  if (di * dj >= 0) {
+    return null
+  }
+  const t = di / (di - dj) // ∈ (0, 1)
+  const xCross = xi + (t * (xj - xi))
+  const yCross = yi + (t * (yj - yi))
+  // Reject if the orthogonal coordinate is off-screen (line crosses the
+  // edge's axis but outside the visible window).
+  const orth = isYAxis ? xCross : yCross
+  if (orth < -1 || orth > 1) {
+    return null
+  }
+  return {t, x: xCross, y: yCross}
 }
 
 
@@ -456,12 +571,10 @@ function buildLabelsPoints(items, color) {
   // Per-item tile size — the larger of text width and a fixed line height,
   // padded.  Tiles are square so the on-screen sprite (Points are square)
   // displays the text without stretching.
-  const PAD = 6
-  const LINE_H = 24
   const tiles = items.map(({text}) => {
     const m = measureCtx.measureText(text)
     const w = Math.ceil(m.width)
-    const tileSize = Math.max(w, LINE_H) + (PAD * 2)
+    const tileSize = Math.max(w, LABEL_TILE_LINE_H) + (LABEL_TILE_PAD * 2)
     return {tileSize, text, w}
   })
   if (tiles.some((t) => !Number.isFinite(t.tileSize) || t.tileSize <= 0)) {

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -49,10 +49,12 @@ const MERIDIAN_STEP_DEG = 15
 
 // Label font / atlas tile size.  Small — these are reference-grid axis
 // labels and shouldn't dominate the scene; we want them legible but
-// understated.
-const LABEL_FONT = '10px sans-serif'
+// understated.  LABEL_FONT_PX is also the inset (1 em) we apply between
+// the label anchor and the screen edge so labels don't kiss the canvas.
+const LABEL_FONT_PX = 12
+const LABEL_FONT = `${LABEL_FONT_PX}px sans-serif`
 const LABEL_TILE_PAD = 3
-const LABEL_TILE_LINE_H = 14
+const LABEL_TILE_LINE_H = LABEL_FONT_PX + 4
 
 // How many points to sample along each meridian / parallel circle when
 // searching for the screen-edge intersection per frame.  Continuous
@@ -408,14 +410,24 @@ function attachEdgeFollower(points, items, gridGroup) {
   const _v = new Vector3()
   const _modelRot = new Matrix3()
   const _viewRot = new Matrix3()
+  const _rendererSize = {x: 0, y: 0}
 
   points.onBeforeRender = (renderer, scene, camera) => {
     gridGroup.updateMatrixWorld()
     _modelRot.setFromMatrix4(gridGroup.matrixWorld)
     _viewRot.setFromMatrix4(camera.matrixWorldInverse)
+    // Convert a 1 em (LABEL_FONT_PX) inset from each screen edge into NDC.
+    // NDC spans [-1, 1] (= 2 units) across the full canvas in each axis,
+    // so 1 px = 2 / size, and the per-axis pad in NDC is FONT_PX * 2 /
+    // size.  Recomputed each frame so the gap stays a constant em
+    // regardless of window resizes.
+    renderer.getSize(_rendererSize)
+    const padX = _rendererSize.x > 0 ? (LABEL_FONT_PX * 2) / _rendererSize.x : 0
+    const padY = _rendererSize.y > 0 ? (LABEL_FONT_PX * 2) / _rendererSize.y : 0
 
     for (let labelIdx = 0; labelIdx < items.length; labelIdx++) {
       const {samples, edge, closed} = items[labelIdx]
+      const padNDC = (edge === 'top' || edge === 'bottom') ? padY : padX
 
       // Pass 1: project all samples once.
       for (let i = 0; i < EDGE_SAMPLES; i++) {
@@ -444,7 +456,7 @@ function attachEdgeFollower(points, items, gridGroup) {
         }
         const xi = ndcX[i]; const yi = ndcY[i]
         const xj = ndcX[j]; const yj = ndcY[j]
-        const cross = bracketCrossing(xi, yi, xj, yj, edge)
+        const cross = bracketCrossing(xi, yi, xj, yj, edge, padNDC)
         if (cross === null) {
           continue
         }
@@ -502,11 +514,12 @@ function attachEdgeFollower(points, items, gridGroup) {
 
 
 /**
- * Test whether the NDC line segment (xi,yi) → (xj,yj) brackets the given
- * screen edge, and if so return the linear-interpolation parameter t at
- * the crossing along with the crossing's NDC coordinates.  Returns null
- * if the segment doesn't cross the edge or crosses it off-screen on the
- * orthogonal axis.
+ * Test whether the NDC line segment (xi,yi) → (xj,yj) crosses the given
+ * screen edge (optionally inset by `padNDC` from the canvas border so
+ * labels can sit slightly inside the visible area), and if so return the
+ * linear-interpolation parameter t at the crossing along with the
+ * crossing's NDC coordinates.  Returns null if the segment doesn't cross
+ * the inset edge or crosses it off-screen on the orthogonal axis.
  *
  * Exported for tests.
  *
@@ -515,15 +528,17 @@ function attachEdgeFollower(points, items, gridGroup) {
  * @param {number} xj NDC x of segment end
  * @param {number} yj NDC y of segment end
  * @param {string} edge 'top' | 'bottom' | 'right' | 'left'
+ * @param {number} [padNDC] inset toward screen centre, in NDC units
+ *   (e.g. 12 px on a 600 px-tall canvas → 12 / 300 = 0.04).
  * @returns {{t:number, x:number, y:number}|null}
  */
-export function bracketCrossing(xi, yi, xj, yj, edge) {
+export function bracketCrossing(xi, yi, xj, yj, edge, padNDC = 0) {
   let edgeVal; let isYAxis
   switch (edge) {
-    case 'top': edgeVal = 1; isYAxis = true; break
-    case 'bottom': edgeVal = -1; isYAxis = true; break
-    case 'right': edgeVal = 1; isYAxis = false; break
-    case 'left': edgeVal = -1; isYAxis = false; break
+    case 'top': edgeVal = 1 - padNDC; isYAxis = true; break
+    case 'bottom': edgeVal = -1 + padNDC; isYAxis = true; break
+    case 'right': edgeVal = 1 - padNDC; isYAxis = false; break
+    case 'left': edgeVal = -1 + padNDC; isYAxis = false; break
     default: return null
   }
   const vi = isYAxis ? yi : xi
@@ -539,7 +554,7 @@ export function bracketCrossing(xi, yi, xj, yj, edge) {
   const xCross = xi + (t * (xj - xi))
   const yCross = yi + (t * (yj - yi))
   // Reject if the orthogonal coordinate is off-screen (line crosses the
-  // edge's axis but outside the visible window).
+  // edge's axis but outside the visible window — no inset on this axis).
   const orth = isYAxis ? xCross : yCross
   if (orth < -1 || orth > 1) {
     return null

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -9,6 +9,7 @@ import {
   Matrix3,
   Points,
   ShaderMaterial,
+  Vector2,
   Vector3,
 } from 'three'
 import {named} from '../utils.js'
@@ -410,7 +411,9 @@ function attachEdgeFollower(points, items, gridGroup) {
   const _v = new Vector3()
   const _modelRot = new Matrix3()
   const _viewRot = new Matrix3()
-  const _rendererSize = {x: 0, y: 0}
+  // renderer.getSize requires a Vector2 (the Three.js call does
+  // `target.set(width, height)`, which a plain literal won't provide).
+  const _rendererSize = new Vector2()
 
   points.onBeforeRender = (renderer, scene, camera) => {
     gridGroup.updateMatrixWorld()

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -1,9 +1,12 @@
 import {
   BufferGeometry,
+  CanvasTexture,
   Color,
   Float32BufferAttribute,
   Group,
   LineSegments,
+  LinearFilter,
+  Points,
   ShaderMaterial,
 } from 'three'
 import {named} from '../utils.js'
@@ -30,10 +33,21 @@ const COLOR_EQUATORIAL = new Color(0xddaa44)
 const COLOR_ECLIPTIC = new Color(0xff66cc)
 const COLOR_GALACTIC = new Color(0x44ddee)
 
-// Grid resolution.
-const NUM_PARALLELS = 11 // latitude small-circles (excluding poles)
+// Grid resolution.  13 parallels at 15° spacing matches 24 meridians at 15°
+// (= 1h RA), giving a clean square grid with whole-number labels in both
+// directions.
+const NUM_PARALLELS = 13 // latitude small-circles including poles → 11 strictly between
 const NUM_MERIDIANS = 24 // longitude great-circles (one every 15° = 1h RA)
 const SEGMENTS = 96 // segments per circle
+
+// Label spacing (degrees).  Driven by the grid spacing — one label per
+// meridian and per parallel.
+const PARALLEL_STEP_DEG = 15
+const MERIDIAN_STEP_DEG = 15
+
+// Label point-size (atlas tile is square; this is the pixel size on screen).
+// Tuned for legibility without dominating the view.
+const LABEL_FONT = '20px sans-serif'
 
 
 /**
@@ -57,12 +71,15 @@ export default function newGrids() {
   const equatorial = wrapWithMaterial(sphereGeom, COLOR_EQUATORIAL, 'EquatorialGrid')
   // Match Earth's planetTilt convention (Planet.js rotateZ by axialInclination).
   equatorial.rotation.z = ECLIPTIC_TO_EQUATORIAL_DEG * toRad
+  attachLabels(equatorial, hourMeridianLabels(), degParallelLabels(), COLOR_EQUATORIAL)
 
   const ecliptic = wrapWithMaterial(sphereGeom, COLOR_ECLIPTIC, 'EclipticGrid')
   // identity rotation — the scene's Y axis IS the ecliptic pole
+  attachLabels(ecliptic, degMeridianLabels(), degParallelLabels(), COLOR_ECLIPTIC)
 
   const galactic = wrapWithMaterial(sphereGeom, COLOR_GALACTIC, 'GalacticGrid')
   galactic.rotation.z = ECLIPTIC_TO_GALACTIC_DEG * toRad
+  attachLabels(galactic, degMeridianLabels(), degParallelLabels(), COLOR_GALACTIC)
 
   group.add(equatorial)
   group.add(ecliptic)
@@ -182,5 +199,223 @@ uniform vec3  uColor;
 uniform float uOpacity;
 void main() {
   gl_FragColor = vec4(uColor, uOpacity);
+}
+`
+
+
+// ===========================================================================
+// LABELS
+// ===========================================================================
+//
+// Each grid carries text labels at its meridians and parallels.  Equatorial
+// uses RA hours for longitude (0h…23h) and signed degrees for declination;
+// ecliptic and galactic use signed degrees in both directions.  Labels are
+// rendered as Points sprites sampling a per-grid CanvasTexture atlas, with
+// the same "pin to far plane, ignore camera translation" trick as the lines
+// so they read as sky-fixed at any zoom.
+
+
+/** @returns {Array<{lng:number, text:string}>} */
+function hourMeridianLabels() {
+  // 24 hours of RA; one label per 1h = 15° meridian.
+  const out = []
+  for (let h = 0; h < 24; h += MERIDIAN_STEP_DEG / 15) {
+    out.push({lng: (h * 15) * toRad, text: `${h}h`})
+  }
+  return out
+}
+
+
+/** @returns {Array<{lng:number, text:string}>} */
+function degMeridianLabels() {
+  const out = []
+  for (let d = 0; d < 360; d += MERIDIAN_STEP_DEG) {
+    out.push({lng: d * toRad, text: `${d}°`})
+  }
+  return out
+}
+
+
+/** @returns {Array<{lat:number, text:string}>} */
+function degParallelLabels() {
+  // Strictly between the poles, signed degrees.
+  const out = []
+  for (let d = -90 + PARALLEL_STEP_DEG; d < 90; d += PARALLEL_STEP_DEG) {
+    const sign = d > 0 ? '+' : (d < 0 ? '-' : '')
+    out.push({lat: d * toRad, text: `${sign}${Math.abs(d)}°`})
+  }
+  return out
+}
+
+
+/**
+ * Build a labels Points object for `meridians` (placed at lat=0) and
+ * `parallels` (placed at lng=0) on the unit sphere, and add it as a child of
+ * `gridGroup`.  In the bun test env the canvas APIs are stubbed and tile
+ * sizes come back as zero — the resulting atlas is degenerate but harmless
+ * since no rendering happens; we just early-return on that case.
+ *
+ * @param {Group} gridGroup
+ * @param {Array<{lng:number, text:string}>} meridians
+ * @param {Array<{lat:number, text:string}>} parallels
+ * @param {Color} color
+ */
+function attachLabels(gridGroup, meridians, parallels, color) {
+  const items = []
+  for (const {lng, text} of meridians) {
+    items.push({pos: [Math.cos(lng), 0, Math.sin(lng)], text})
+  }
+  for (const {lat, text} of parallels) {
+    items.push({pos: [Math.cos(lat), Math.sin(lat), 0], text})
+  }
+  const points = buildLabelsPoints(items, color)
+  if (points) {
+    gridGroup.add(points)
+  }
+}
+
+
+/**
+ * Bake `items` into a CanvasTexture atlas + Points geometry with one sprite
+ * per item.  Returns null if the canvas environment can't measure text
+ * (e.g. headless tests).
+ *
+ * @param {Array<{pos:Array<number>, text:string}>} items
+ * @param {Color} color
+ * @returns {Points|null}
+ */
+function buildLabelsPoints(items, color) {
+  if (typeof document === 'undefined' || typeof document.createElement !== 'function') {
+    return null
+  }
+  const measureCanvas = document.createElement('canvas')
+  const measureCtx = measureCanvas.getContext('2d')
+  if (!measureCtx) {
+    return null
+  }
+  measureCtx.font = LABEL_FONT
+
+  // Per-item tile size — the larger of text width and a fixed line height,
+  // padded.  Tiles are square so the on-screen sprite (Points are square)
+  // displays the text without stretching.
+  const PAD = 6
+  const LINE_H = 24
+  const tiles = items.map(({text}) => {
+    const m = measureCtx.measureText(text)
+    const w = Math.ceil(m.width)
+    const tileSize = Math.max(w, LINE_H) + (PAD * 2)
+    return {tileSize, text, w}
+  })
+  if (tiles.some((t) => !Number.isFinite(t.tileSize) || t.tileSize <= 0)) {
+    return null
+  }
+
+  // Pack tiles into a roughly-square atlas, row-by-row.
+  const tilesPerRow = Math.max(1, Math.ceil(Math.sqrt(tiles.length)))
+  const maxTile = Math.max(...tiles.map((t) => t.tileSize))
+  const atlasW = tilesPerRow * maxTile
+  let curX = 0; let curY = 0; let rowH = 0
+  const placed = []
+  for (const t of tiles) {
+    if (curX + t.tileSize > atlasW) {
+      curX = 0
+      curY += rowH
+      rowH = 0
+    }
+    placed.push({...t, x: curX, y: curY})
+    curX += t.tileSize
+    rowH = Math.max(rowH, t.tileSize)
+  }
+  const atlasH = curY + rowH
+
+  // Render the atlas.
+  const canvas = document.createElement('canvas')
+  canvas.width = atlasW
+  canvas.height = atlasH
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return null
+  }
+  ctx.font = LABEL_FONT
+  ctx.fillStyle = color.getStyle()
+  ctx.textBaseline = 'middle'
+  ctx.textAlign = 'center'
+  for (const p of placed) {
+    ctx.fillText(p.text, p.x + (p.tileSize / 2), p.y + (p.tileSize / 2))
+  }
+
+  // Build attribute buffers.  spriteCoord = (u_topLeft, v_topLeft, w, h) in
+  // [0,1] atlas space.  v is flipped because gl_PointCoord runs top-down
+  // while CanvasTexture is uploaded with the canvas's natural Y-down origin.
+  const positions = new Float32Array(items.length * 3)
+  const spriteCoords = new Float32Array(items.length * 4)
+  const sizes = new Float32Array(items.length)
+  for (let i = 0; i < items.length; i++) {
+    const p = placed[i]
+    positions[(3 * i)] = items[i].pos[0]
+    positions[(3 * i) + 1] = items[i].pos[1]
+    positions[(3 * i) + 2] = items[i].pos[2]
+    spriteCoords[(4 * i)] = p.x / atlasW
+    spriteCoords[(4 * i) + 1] = (atlasH - p.y - p.tileSize) / atlasH
+    spriteCoords[(4 * i) + 2] = p.tileSize / atlasW
+    spriteCoords[(4 * i) + 3] = p.tileSize / atlasH
+    sizes[i] = p.tileSize
+  }
+
+  const geom = new BufferGeometry()
+  geom.setAttribute('position', new Float32BufferAttribute(positions, 3))
+  geom.setAttribute('aSpriteCoord', new Float32BufferAttribute(spriteCoords, 4))
+  geom.setAttribute('aSize', new Float32BufferAttribute(sizes, 1))
+
+  const tex = new CanvasTexture(canvas)
+  tex.minFilter = LinearFilter
+  tex.magFilter = LinearFilter
+  tex.needsUpdate = true
+
+  const mat = new ShaderMaterial({
+    uniforms: {map: {value: tex}},
+    vertexShader: LABEL_VERT,
+    fragmentShader: LABEL_FRAG,
+    transparent: true,
+    depthTest: true,
+    depthWrite: false,
+    toneMapped: false,
+  })
+  const points = new Points(geom, mat)
+  points.frustumCulled = false
+  // Render after the lines (also at -1) within the transparent batch so
+  // labels composite on top of grid line crossings.
+  points.renderOrder = 0
+  return points
+}
+
+
+// Vertex: same skybox-style projection as the lines (rotation only, pinned
+// to far plane), plus per-vertex point size taken from aSize.
+const LABEL_VERT = `
+attribute vec4 aSpriteCoord;
+attribute float aSize;
+varying vec4 vSpriteCoord;
+void main() {
+  vSpriteCoord = aSpriteCoord;
+  vec3 dir = mat3(viewMatrix) * (mat3(modelMatrix) * position);
+  vec4 clipPos = projectionMatrix * vec4(dir, 1.0);
+  clipPos.z = clipPos.w * 0.9997;
+  gl_Position = clipPos;
+  gl_PointSize = aSize;
+}
+`
+
+// Fragment: sample the per-tile sub-rect of the atlas.  gl_PointCoord is
+// (0,0)=top-left → (1,1)=bottom-right of the sprite quad, while our atlas
+// has (0,0)=bottom-left in UV — hence the (1.0 - y) flip.
+const LABEL_FRAG = `
+uniform sampler2D map;
+varying vec4 vSpriteCoord;
+void main() {
+  vec2 uv = vec2(
+    vSpriteCoord.x + vSpriteCoord.z * gl_PointCoord.x,
+    vSpriteCoord.y + vSpriteCoord.w * (1.0 - gl_PointCoord.y));
+  gl_FragColor = texture2D(map, uv);
 }
 `

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -6,8 +6,10 @@ import {
   Group,
   LineSegments,
   LinearFilter,
+  Matrix3,
   Points,
   ShaderMaterial,
+  Vector3,
 } from 'three'
 import {named} from '../utils.js'
 import {toRad} from '../shared.js'
@@ -48,6 +50,12 @@ const MERIDIAN_STEP_DEG = 15
 // Label point-size (atlas tile is square; this is the pixel size on screen).
 // Tuned for legibility without dominating the view.
 const LABEL_FONT = '20px sans-serif'
+
+// How many points to sample along each meridian / parallel circle when
+// searching for the screen-edge intersection per frame.  64 is plenty for
+// smooth, jitter-free label motion at typical FOVs and is cheap (a few
+// thousand matrix-vector mults per grid per frame).
+const EDGE_SAMPLES = 64
 
 
 /**
@@ -249,11 +257,14 @@ function degParallelLabels() {
 
 
 /**
- * Build a labels Points object for `meridians` (placed at lat=0) and
- * `parallels` (placed at lng=0) on the unit sphere, and add it as a child of
- * `gridGroup`.  In the bun test env the canvas APIs are stubbed and tile
- * sizes come back as zero — the resulting atlas is degenerate but harmless
- * since no rendering happens; we just early-return on that case.
+ * Build a labels Points object for the grid's meridians and parallels and
+ * attach it to `gridGroup`.  Two labels per line — one anchored to each
+ * opposite screen edge (top + bottom for meridians, left + right for
+ * parallels) — so as the camera rotates each line's labels slide along the
+ * edge they're anchored to, like Celestia.
+ *
+ * In the bun test env canvas APIs are stubbed, so the texture build
+ * gracefully returns null; no test impact.
  *
  * @param {Group} gridGroup
  * @param {Array<{lng:number, text:string}>} meridians
@@ -263,14 +274,161 @@ function degParallelLabels() {
 function attachLabels(gridGroup, meridians, parallels, color) {
   const items = []
   for (const {lng, text} of meridians) {
-    items.push({pos: [Math.cos(lng), 0, Math.sin(lng)], text})
+    const samples = sampleMeridian(lng)
+    items.push({text, samples, edge: 'top'})
+    items.push({text, samples, edge: 'bottom'})
   }
   for (const {lat, text} of parallels) {
-    items.push({pos: [Math.cos(lat), Math.sin(lat), 0], text})
+    const samples = sampleParallel(lat)
+    items.push({text, samples, edge: 'right'})
+    items.push({text, samples, edge: 'left'})
   }
   const points = buildLabelsPoints(items, color)
-  if (points) {
-    gridGroup.add(points)
+  if (!points) {
+    return
+  }
+  attachEdgeFollower(points, items, gridGroup)
+  gridGroup.add(points)
+}
+
+
+/**
+ * Unit-sphere samples along a meridian (constant longitude, varying
+ * latitude from south pole to north pole).  Returned as a flat
+ * Float32Array of (x,y,z) triples for cheap iteration in the per-frame
+ * edge follower.
+ *
+ * Exported for tests.
+ *
+ * @param {number} lng radians
+ * @returns {Float32Array}
+ */
+export function sampleMeridian(lng) {
+  const arr = new Float32Array(EDGE_SAMPLES * 3)
+  const cl = Math.cos(lng); const sl = Math.sin(lng)
+  for (let i = 0; i < EDGE_SAMPLES; i++) {
+    const lat = (-Math.PI / 2) + ((Math.PI * i) / (EDGE_SAMPLES - 1))
+    const cy = Math.cos(lat)
+    arr[(3 * i)] = cy * cl
+    arr[(3 * i) + 1] = Math.sin(lat)
+    arr[(3 * i) + 2] = cy * sl
+  }
+  return arr
+}
+
+
+/**
+ * Unit-sphere samples along a parallel (constant latitude, full longitude
+ * loop).  Like sampleMeridian, returned as a flat Float32Array.
+ *
+ * Exported for tests.
+ *
+ * @param {number} lat radians
+ * @returns {Float32Array}
+ */
+export function sampleParallel(lat) {
+  const arr = new Float32Array(EDGE_SAMPLES * 3)
+  const cy = Math.cos(lat); const sy = Math.sin(lat)
+  for (let i = 0; i < EDGE_SAMPLES; i++) {
+    const lng = (2 * Math.PI * i) / EDGE_SAMPLES
+    arr[(3 * i)] = cy * Math.cos(lng)
+    arr[(3 * i) + 1] = sy
+    arr[(3 * i) + 2] = cy * Math.sin(lng)
+  }
+  return arr
+}
+
+
+/**
+ * Score a sample's NDC position by distance to a target screen edge.
+ * Smaller score = closer to that edge.  Off-screen samples return Infinity
+ * so the edge-follower picks the on-screen sample even if all candidates
+ * are far from the edge.
+ *
+ * Exported for tests.
+ *
+ * @param {number} ndcX in [-1, 1]
+ * @param {number} ndcY in [-1, 1]
+ * @param {string} edge 'top' | 'bottom' | 'right' | 'left'
+ * @returns {number}
+ */
+export function edgeScore(ndcX, ndcY, edge) {
+  if (Math.abs(ndcX) > 1 || Math.abs(ndcY) > 1) {
+    return Infinity
+  }
+  switch (edge) {
+    case 'top': return 1 - ndcY
+    case 'bottom': return 1 + ndcY
+    case 'right': return 1 - ndcX
+    case 'left': return 1 + ndcX
+    default: return Infinity
+  }
+}
+
+
+/**
+ * Per-frame, walk each label's sample circle, project each sample to NDC
+ * (using the same skybox-style rotation-only transform the label shader
+ * does), and pick the visible sample closest to that label's anchor edge.
+ * Update the position attribute and toggle aVisible based on whether any
+ * sample landed on screen.
+ *
+ * @param {Points} points
+ * @param {Array<object>} items
+ * @param {Group} gridGroup
+ */
+function attachEdgeFollower(points, items, gridGroup) {
+  const positionAttr = points.geometry.attributes.position
+  const visibleAttr = points.geometry.attributes.aVisible
+  const positions = positionAttr.array
+  const visibles = visibleAttr.array
+  const _v = new Vector3()
+  const _modelRot = new Matrix3()
+  const _viewRot = new Matrix3()
+
+  points.onBeforeRender = (renderer, scene, camera) => {
+    gridGroup.updateMatrixWorld()
+    _modelRot.setFromMatrix4(gridGroup.matrixWorld)
+    _viewRot.setFromMatrix4(camera.matrixWorldInverse)
+
+    for (let labelIdx = 0; labelIdx < items.length; labelIdx++) {
+      const {samples, edge} = items[labelIdx]
+      let bestX = 0; let bestY = 0; let bestZ = 0
+      let bestScore = Infinity
+
+      for (let i = 0; i < EDGE_SAMPLES; i++) {
+        const off = i * 3
+        _v.set(samples[off], samples[off + 1], samples[off + 2])
+        _v.applyMatrix3(_modelRot).applyMatrix3(_viewRot)
+        // Skip points behind / on the camera plane — perspective projection
+        // is ill-defined and Vector3.applyMatrix4's perspective division
+        // would give nonsense NDC.  Small epsilon guards points exactly at
+        // the eye plane.
+        if (_v.z >= -1e-6) {
+          continue
+        }
+        _v.applyMatrix4(camera.projectionMatrix)
+        const score = edgeScore(_v.x, _v.y, edge)
+        if (score < bestScore) {
+          bestScore = score
+          bestX = samples[off]
+          bestY = samples[off + 1]
+          bestZ = samples[off + 2]
+        }
+      }
+
+      const off = labelIdx * 3
+      if (Number.isFinite(bestScore)) {
+        positions[off] = bestX
+        positions[off + 1] = bestY
+        positions[off + 2] = bestZ
+        visibles[labelIdx] = 1
+      } else {
+        visibles[labelIdx] = 0
+      }
+    }
+    positionAttr.needsUpdate = true
+    visibleAttr.needsUpdate = true
   }
 }
 
@@ -347,25 +505,41 @@ function buildLabelsPoints(items, color) {
   // Build attribute buffers.  spriteCoord = (u_topLeft, v_topLeft, w, h) in
   // [0,1] atlas space.  v is flipped because gl_PointCoord runs top-down
   // while CanvasTexture is uploaded with the canvas's natural Y-down origin.
+  // aVisible defaults to 0 — the edge-follower onBeforeRender flips it on
+  // for each label whose line is currently on screen.  If no follower is
+  // attached (e.g. tests), labels stay hidden, which is fine.
   const positions = new Float32Array(items.length * 3)
   const spriteCoords = new Float32Array(items.length * 4)
   const sizes = new Float32Array(items.length)
+  const visibles = new Float32Array(items.length)
   for (let i = 0; i < items.length; i++) {
     const p = placed[i]
-    positions[(3 * i)] = items[i].pos[0]
-    positions[(3 * i) + 1] = items[i].pos[1]
-    positions[(3 * i) + 2] = items[i].pos[2]
+    // Initial position: first sample point if available, else (1, 0, 0).
+    // The follower will overwrite this on the first frame anyway; this is
+    // only used between geometry creation and the first render tick.
+    const samples = items[i].samples
+    if (samples) {
+      positions[(3 * i)] = samples[0]
+      positions[(3 * i) + 1] = samples[1]
+      positions[(3 * i) + 2] = samples[2]
+    } else {
+      positions[(3 * i)] = 1
+      positions[(3 * i) + 1] = 0
+      positions[(3 * i) + 2] = 0
+    }
     spriteCoords[(4 * i)] = p.x / atlasW
     spriteCoords[(4 * i) + 1] = (atlasH - p.y - p.tileSize) / atlasH
     spriteCoords[(4 * i) + 2] = p.tileSize / atlasW
     spriteCoords[(4 * i) + 3] = p.tileSize / atlasH
     sizes[i] = p.tileSize
+    visibles[i] = 0
   }
 
   const geom = new BufferGeometry()
   geom.setAttribute('position', new Float32BufferAttribute(positions, 3))
   geom.setAttribute('aSpriteCoord', new Float32BufferAttribute(spriteCoords, 4))
   geom.setAttribute('aSize', new Float32BufferAttribute(sizes, 1))
+  geom.setAttribute('aVisible', new Float32BufferAttribute(visibles, 1))
 
   const tex = new CanvasTexture(canvas)
   tex.minFilter = LinearFilter
@@ -391,13 +565,18 @@ function buildLabelsPoints(items, color) {
 
 
 // Vertex: same skybox-style projection as the lines (rotation only, pinned
-// to far plane), plus per-vertex point size taken from aSize.
+// to far plane), plus per-vertex point size taken from aSize.  aVisible is
+// passed through to the fragment which discards hidden labels (those whose
+// line is fully off-screen this frame).
 const LABEL_VERT = `
-attribute vec4 aSpriteCoord;
+attribute vec4  aSpriteCoord;
 attribute float aSize;
-varying vec4 vSpriteCoord;
+attribute float aVisible;
+varying vec4  vSpriteCoord;
+varying float vVisible;
 void main() {
   vSpriteCoord = aSpriteCoord;
+  vVisible = aVisible;
   vec3 dir = mat3(viewMatrix) * (mat3(modelMatrix) * position);
   vec4 clipPos = projectionMatrix * vec4(dir, 1.0);
   clipPos.z = clipPos.w * 0.9997;
@@ -408,11 +587,16 @@ void main() {
 
 // Fragment: sample the per-tile sub-rect of the atlas.  gl_PointCoord is
 // (0,0)=top-left → (1,1)=bottom-right of the sprite quad, while our atlas
-// has (0,0)=bottom-left in UV — hence the (1.0 - y) flip.
+// has (0,0)=bottom-left in UV — hence the (1.0 - y) flip.  Discard when
+// the edge-follower has marked the label as not currently on screen.
 const LABEL_FRAG = `
 uniform sampler2D map;
-varying vec4 vSpriteCoord;
+varying vec4  vSpriteCoord;
+varying float vVisible;
 void main() {
+  if (vVisible < 0.5) {
+    discard;
+  }
   vec2 uv = vec2(
     vSpriteCoord.x + vSpriteCoord.z * gl_PointCoord.x,
     vSpriteCoord.y + vSpriteCoord.w * (1.0 - gl_PointCoord.y));

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -59,9 +59,13 @@ const LABEL_TILE_LINE_H = LABEL_FONT_PX + 4
 
 // How many points to sample along each meridian / parallel circle when
 // searching for the screen-edge intersection per frame.  Continuous
-// interpolation between adjacent samples (see attachEdgeFollower) gives
-// smooth label motion regardless of sample count, so 32 is ample.
-const EDGE_SAMPLES = 32
+// interpolation between adjacent samples (see attachEdgeFollower) keeps
+// motion smooth, but the chord-vs-arc discrepancy between linear-3D-lerp
+// and the actual sphere arc shows up as a sub-pixel wobble at low sample
+// counts.  96 samples → 3.75° per step, which is below the perceptible
+// jitter threshold at typical FOVs while still cheap (≈10k matrix-vector
+// mults per grid per frame).
+const EDGE_SAMPLES = 96
 
 
 /**

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -1,0 +1,186 @@
+import {
+  BufferGeometry,
+  Color,
+  Float32BufferAttribute,
+  Group,
+  LineSegments,
+  ShaderMaterial,
+} from 'three'
+import {named} from '../utils.js'
+import {toRad} from '../shared.js'
+
+
+// Earth's obliquity at J2000 — angle between the celestial equator (Earth's
+// equatorial plane) and the ecliptic.  The scene's Y axis is the ecliptic
+// pole (vsop's z-axis is mapped to scene-y in Animation.js), so a Z-rotation
+// by the obliquity tilts the grid's pole into the celestial-pole direction
+// matching Earth's planetTilt rotation in Planet.js.
+const ECLIPTIC_TO_EQUATORIAL_DEG = 23.4392811
+
+// Galactic north pole, J2000, in equatorial coords: α=192.85948°, δ=27.12825°.
+// Converted to ecliptic (λ ≈ 180°, β ≈ 29.81°) — happens to lie in the X-Y
+// plane of the scene frame, so a single Z-rotation suffices.  Sign matches
+// the equatorial case: pole tilts toward -X.
+const ECLIPTIC_TO_GALACTIC_DEG = 60.187
+
+// Grid colors chosen for distinct fast identification, vaguely matching
+// Celestia's defaults (warm amber for the rotating Earth frame, magenta for
+// the orbital frame, cyan for the galactic frame).
+const COLOR_EQUATORIAL = new Color(0xddaa44)
+const COLOR_ECLIPTIC = new Color(0xff66cc)
+const COLOR_GALACTIC = new Color(0x44ddee)
+
+// Grid resolution.
+const NUM_PARALLELS = 11 // latitude small-circles (excluding poles)
+const NUM_MERIDIANS = 24 // longitude great-circles (one every 15° = 1h RA)
+const SEGMENTS = 96 // segments per circle
+
+
+/**
+ * Three reference-frame grids (Equatorial, Ecliptic, Galactic) wrapping the
+ * camera as if at infinity.  Each grid is a wireframe sphere, oriented so
+ * its pole points along the relevant celestial pole, and shaded with a
+ * custom material that pins gl_Position.z to (just inside) the far plane —
+ * so the grids never z-fight any nearer geometry and always render as a
+ * background reference, regardless of camera position or zoom.
+ *
+ * @returns {{group: Group, equatorial: Group, ecliptic: Group, galactic: Group}}
+ */
+export default function newGrids() {
+  const group = named(new Group(), 'Grids')
+
+  // Built once, reused: a unit-sphere wireframe with poles along +Y.  Each
+  // grid wraps it in its own Group with its own rotation and material so
+  // visibility / color can be toggled independently.
+  const sphereGeom = buildWireSphereGeometry()
+
+  const equatorial = wrapWithMaterial(sphereGeom, COLOR_EQUATORIAL, 'EquatorialGrid')
+  // Match Earth's planetTilt convention (Planet.js rotateZ by axialInclination).
+  equatorial.rotation.z = ECLIPTIC_TO_EQUATORIAL_DEG * toRad
+
+  const ecliptic = wrapWithMaterial(sphereGeom, COLOR_ECLIPTIC, 'EclipticGrid')
+  // identity rotation — the scene's Y axis IS the ecliptic pole
+
+  const galactic = wrapWithMaterial(sphereGeom, COLOR_GALACTIC, 'GalacticGrid')
+  galactic.rotation.z = ECLIPTIC_TO_GALACTIC_DEG * toRad
+
+  group.add(equatorial)
+  group.add(ecliptic)
+  group.add(galactic)
+
+  // Default: all hidden.  Toggled in by the user.
+  equatorial.visible = false
+  ecliptic.visible = false
+  galactic.visible = false
+
+  return {group, equatorial, ecliptic, galactic}
+}
+
+
+/**
+ * Unit-sphere wireframe: NUM_MERIDIANS great-circle meridians (pole-to-pole)
+ * + NUM_PARALLELS small-circle parallels.  Returned as a single
+ * BufferGeometry of LineSegments-style position pairs.
+ *
+ * @returns {BufferGeometry}
+ */
+function buildWireSphereGeometry() {
+  const positions = []
+  // Parallels (latitude circles, excluding poles).
+  for (let i = 1; i < NUM_PARALLELS - 1; i++) {
+    const lat = (-Math.PI / 2) + ((Math.PI * i) / (NUM_PARALLELS - 1))
+    const r = Math.cos(lat)
+    const y = Math.sin(lat)
+    for (let j = 0; j < SEGMENTS; j++) {
+      const a1 = (2 * Math.PI * j) / SEGMENTS
+      const a2 = (2 * Math.PI * (j + 1)) / SEGMENTS
+      positions.push(r * Math.cos(a1), y, r * Math.sin(a1))
+      positions.push(r * Math.cos(a2), y, r * Math.sin(a2))
+    }
+  }
+  // Equator great-circle, drawn explicitly so it's a continuous loop even if
+  // NUM_PARALLELS is even (the loop above only emits parallels strictly
+  // between the poles).
+  for (let j = 0; j < SEGMENTS; j++) {
+    const a1 = (2 * Math.PI * j) / SEGMENTS
+    const a2 = (2 * Math.PI * (j + 1)) / SEGMENTS
+    positions.push(Math.cos(a1), 0, Math.sin(a1))
+    positions.push(Math.cos(a2), 0, Math.sin(a2))
+  }
+  // Meridians (great-circles pole-to-pole).
+  for (let j = 0; j < NUM_MERIDIANS; j++) {
+    const lng = (2 * Math.PI * j) / NUM_MERIDIANS
+    const cosL = Math.cos(lng)
+    const sinL = Math.sin(lng)
+    for (let i = 0; i < SEGMENTS; i++) {
+      const a1 = (-Math.PI / 2) + ((Math.PI * i) / SEGMENTS)
+      const a2 = (-Math.PI / 2) + ((Math.PI * (i + 1)) / SEGMENTS)
+      const c1 = Math.cos(a1); const s1 = Math.sin(a1)
+      const c2 = Math.cos(a2); const s2 = Math.sin(a2)
+      positions.push(c1 * cosL, s1, c1 * sinL)
+      positions.push(c2 * cosL, s2, c2 * sinL)
+    }
+  }
+  const geom = new BufferGeometry()
+  geom.setAttribute('position', new Float32BufferAttribute(positions, 3))
+  return geom
+}
+
+
+/**
+ * Wrap the shared sphere geometry in its own LineSegments + Group, with a
+ * material whose vertex shader pins clip-space z to just inside the far
+ * plane — so the grid feels "at infinity," depth-wise: it never wins a
+ * depth comparison against any nearer object.
+ *
+ * @param {BufferGeometry} geom
+ * @param {Color} color
+ * @param {string} name
+ * @returns {Group}
+ */
+function wrapWithMaterial(geom, color, name) {
+  const mat = new ShaderMaterial({
+    uniforms: {
+      uColor: {value: color},
+      uOpacity: {value: 0.45},
+    },
+    vertexShader: VERT,
+    fragmentShader: FRAG,
+    depthTest: true,
+    depthWrite: false,
+    transparent: true,
+    toneMapped: false,
+  })
+  const lines = new LineSegments(geom, mat)
+  lines.frustumCulled = false
+  // Render after the milky way (-2) but before any opaque geometry would
+  // claim the pixel; transparent ordering plus the z-pin handles the rest.
+  lines.renderOrder = -1
+  const wrap = named(new Group(), name)
+  wrap.add(lines)
+  return wrap
+}
+
+
+// Vertex: ignore the camera's translation, keep only its rotation.  That
+// makes the grid feel like a sky reference — it's a fixed-orientation
+// celestial sphere wrapping the camera, not an object at a specific world
+// position.  Pin clip-z to just inside the far plane so the grid loses any
+// depth comparison against nearer geometry (planets, sun) but still
+// composites on top of the at-infinity galaxy (which pins to 0.9999).
+const VERT = `
+void main() {
+  vec3 dir = mat3(viewMatrix) * (mat3(modelMatrix) * position);
+  vec4 clipPos = projectionMatrix * vec4(dir, 1.0);
+  clipPos.z = clipPos.w * 0.9997;
+  gl_Position = clipPos;
+}
+`
+
+const FRAG = `
+uniform vec3  uColor;
+uniform float uOpacity;
+void main() {
+  gl_FragColor = vec4(uColor, uOpacity);
+}
+`

--- a/js/scene/Grids.test.js
+++ b/js/scene/Grids.test.js
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'bun:test'
-import {bracketCrossing, edgeScore, sampleMeridian, sampleParallel} from './Grids.js'
+import {
+  bracketCrossing,
+  edgeScore,
+  refineSubSample,
+  sampleMeridian,
+  sampleParallel,
+} from './Grids.js'
 
 
 describe('sampleMeridian', () => {
@@ -167,5 +173,93 @@ describe('bracketCrossing', () => {
     const r = bracketCrossing(0, -1, 0, 0, 'bottom', 0.1)
     expect(r).not.toBeNull()
     expect(r.y).toBeCloseTo(-0.9, 6)
+  })
+})
+
+
+describe('refineSubSample', () => {
+  // Small synthetic three-sample setup: scores 4, 1, 4 → symmetric
+  // parabola, vertex at offset 0 (no movement); scores 4, 1, 9 → vertex
+  // shifted toward the smaller side (prevI).  Sample positions shape the
+  // 3D output via lerp toward the neighbour the vertex points at.
+  const samples = new Float32Array([
+    -1, 0, 0, // prevI (idx 0)
+    0, 1, 0, // bestI (idx 1)
+    1, 0, 0, // nextI (idx 2)
+  ])
+  const front = new Uint8Array([1, 1, 1])
+
+  it('returns the bestI sample when both neighbours have equal scores', () => {
+    // Score function: |edgeScore(top)| = 1 - y.  Pick top edge with
+    // ndcY values that give scores (4, 1, 4) → vertex at offset 0.
+    const ndcX = new Float32Array([0, 0, 0])
+    const ndcY = new Float32Array([-3, 0, -3]) // top scores: 4, 1, 4
+    const r = refineSubSample(1, samples, ndcX, ndcY, front, 'top', false)
+    // Vertex at t=0 ⇒ no shift ⇒ bestI position
+    expect(r.x).toBeCloseTo(0, 6)
+    expect(r.y).toBeCloseTo(1, 6)
+  })
+
+  it('shifts toward the lower-score neighbour', () => {
+    // ndcY=(0.5, 0.9, 0.3) ⇒ top scores (0.5, 0.1, 0.7).  edgeScore for
+    // top requires y ∈ [-1, 1] (strict < threshold), so all on-screen.
+    //   denom = 0.5 + 0.7 − 0.2 = 1.0
+    //   t = (0.5 − 0.7) / 2 = −0.1  → shift 10% toward prevI = (-1,0,0)
+    const ndcX = new Float32Array([0, 0, 0])
+    const ndcY = new Float32Array([0.5, 0.9, 0.3])
+    const r = refineSubSample(1, samples, ndcX, ndcY, front, 'top', false)
+    const w = 0.1 // |t|
+    // lerp(bestI=(0,1,0) → prevI=(-1,0,0), w)
+    expect(r.x).toBeCloseTo(((1 - w) * 0) + (w * -1), 4)
+    expect(r.y).toBeCloseTo(((1 - w) * 1) + (w * 0), 4)
+  })
+
+  it('returns bestI position when a neighbour is off-screen', () => {
+    const ndcX = new Float32Array([0, 0, 0])
+    const ndcY = new Float32Array([-3, 0, -3])
+    const frontMissing = new Uint8Array([0, 1, 1]) // prevI off-screen
+    const r = refineSubSample(1, samples, ndcX, ndcY, frontMissing, 'top', false)
+    expect(r.x).toBeCloseTo(0, 6)
+    expect(r.y).toBeCloseTo(1, 6)
+  })
+
+  it('returns bestI position when bestI is at the open-loop boundary', () => {
+    // bestI at idx 0 with closed=false has no real prevI — should fall
+    // back to bestI directly without crashing.
+    const ndcX = new Float32Array([0, 0, 0])
+    const ndcY = new Float32Array([-3, -3, -3])
+    const r = refineSubSample(0, samples, ndcX, ndcY, front, 'top', false)
+    expect(r.x).toBeCloseTo(-1, 6) // samples[0] = (-1, 0, 0)
+    expect(r.y).toBeCloseTo(0, 6)
+  })
+
+  it('wraps at the open-loop boundary when closed=true', () => {
+    // bestI=0; closed=true wraps prevI → idx 2.  Asymmetric ndcY values
+    // (scores 1.5, 0, 1) shift the parabolic vertex toward nextI by t≈0.1.
+    // closed=false would hit the prevI===bestI guard and return bestI
+    // directly; closed=true should produce a non-zero lerp.
+    const ndcX = new Float32Array([0, 0, 0])
+    const ndcY = new Float32Array([1, 0, -0.5]) // top scores: 0, 1, 1.5
+    const closedR = refineSubSample(0, samples, ndcX, ndcY, front, 'top', true)
+    const openR = refineSubSample(0, samples, ndcX, ndcY, front, 'top', false)
+    // Closed: sa=1.5 (prevI=idx2), sb=0, sc=1 → denom=2.5, t=+0.1 → toward
+    // nextI by 10%.  Expected: lerp((-1,0,0)→(0,1,0), 0.1) = (-0.9, 0.1, 0)
+    expect(closedR.x).toBeCloseTo(-0.9, 4)
+    expect(closedR.y).toBeCloseTo(0.1, 4)
+    // Open: prevI clamps to bestI ⇒ returns bestI's sample directly.
+    expect(openR.x).toBeCloseTo(-1, 4)
+    expect(openR.y).toBeCloseTo(0, 4)
+  })
+
+  it('clamps the vertex offset to [-1, +1] for extreme score asymmetry', () => {
+    // edgeScore for top is in [0, 2] for on-screen y in [1, -1].  Choose
+    // scores sa=0 (y=1), sb=0.9 (y=0.1), sc=2 (y=-1).
+    //   denom = 0 + 2 − 1.8 = 0.2,  t = (0 − 2) / 0.4 = −5  → clamped to −1.
+    const ndcX = new Float32Array([0, 0, 0])
+    const ndcY = new Float32Array([1, 0.1, -1])
+    const r = refineSubSample(1, samples, ndcX, ndcY, front, 'top', false)
+    // t = −1 ⇒ lerp fully to prevI = samples[0] = (-1, 0, 0)
+    expect(r.x).toBeCloseTo(-1, 4)
+    expect(r.y).toBeCloseTo(0, 4)
   })
 })

--- a/js/scene/Grids.test.js
+++ b/js/scene/Grids.test.js
@@ -144,4 +144,28 @@ describe('bracketCrossing', () => {
     expect(r.t).toBeCloseTo(0.5, 6)
     expect(r.x).toBeCloseTo(0, 6)
   })
+
+  it('padNDC insets the target line for the top edge', () => {
+    // Edge with pad 0.1 means we anchor at y=0.9, not y=1.  A segment
+    // from y=0 to y=1 (which would cross y=0.9 at t=0.9) should now
+    // bracket the inset line.
+    const r = bracketCrossing(0, 0, 0, 1, 'top', 0.1)
+    expect(r).not.toBeNull()
+    expect(r.t).toBeCloseTo(0.9, 6)
+    expect(r.y).toBeCloseTo(0.9, 6)
+  })
+
+  it('padNDC of zero behaves identically to the unpadded call', () => {
+    const a = bracketCrossing(-0.2, 0.8, 0.2, 1.2, 'top')
+    const b = bracketCrossing(-0.2, 0.8, 0.2, 1.2, 'top', 0)
+    expect(a).toEqual(b)
+  })
+
+  it('padNDC pushes the bottom edge inward symmetrically', () => {
+    // Pad 0.1 on bottom moves the target from y=-1 to y=-0.9.  A segment
+    // from y=-1 to y=0 must now bracket y=-0.9.
+    const r = bracketCrossing(0, -1, 0, 0, 'bottom', 0.1)
+    expect(r).not.toBeNull()
+    expect(r.y).toBeCloseTo(-0.9, 6)
+  })
 })

--- a/js/scene/Grids.test.js
+++ b/js/scene/Grids.test.js
@@ -1,0 +1,98 @@
+import {describe, expect, it} from 'bun:test'
+import {edgeScore, sampleMeridian, sampleParallel} from './Grids.js'
+
+
+describe('sampleMeridian', () => {
+  it('emits unit-sphere points along a constant-longitude great circle', () => {
+    const samples = sampleMeridian(0) // lng=0 → samples in the +X / +Y plane (z=0)
+    const N = samples.length / 3
+    expect(N).toBeGreaterThan(8)
+    for (let i = 0; i < N; i++) {
+      const x = samples[(3 * i)]
+      const y = samples[(3 * i) + 1]
+      const z = samples[(3 * i) + 2]
+      // Unit length within float-rounding tolerance
+      expect(Math.hypot(x, y, z)).toBeCloseTo(1, 5)
+      // lng=0 ⇒ z = cos(lat) * sin(0) = 0
+      expect(Math.abs(z)).toBeLessThan(1e-6)
+    }
+  })
+
+  it('first sample is the south pole, last is the north pole', () => {
+    const samples = sampleMeridian(Math.PI / 4) // any longitude
+    const N = samples.length / 3
+    // South pole: y = -1
+    expect(samples[1]).toBeCloseTo(-1, 5)
+    // North pole: y = +1
+    expect(samples[((N - 1) * 3) + 1]).toBeCloseTo(1, 5)
+  })
+
+  it('lng=π/2 ⇒ samples lie in the +Z / +Y plane (x=0)', () => {
+    const samples = sampleMeridian(Math.PI / 2)
+    const N = samples.length / 3
+    for (let i = 0; i < N; i++) {
+      expect(Math.abs(samples[(3 * i)])).toBeLessThan(1e-6)
+    }
+  })
+})
+
+
+describe('sampleParallel', () => {
+  it('emits unit-sphere points at constant latitude', () => {
+    const lat = Math.PI / 6 // 30°
+    const samples = sampleParallel(lat)
+    const N = samples.length / 3
+    expect(N).toBeGreaterThan(8)
+    const expectedY = Math.sin(lat)
+    for (let i = 0; i < N; i++) {
+      const x = samples[(3 * i)]
+      const y = samples[(3 * i) + 1]
+      const z = samples[(3 * i) + 2]
+      expect(Math.hypot(x, y, z)).toBeCloseTo(1, 5)
+      expect(y).toBeCloseTo(expectedY, 5)
+    }
+  })
+
+  it('lat=0 ⇒ samples on the equator (y=0)', () => {
+    const samples = sampleParallel(0)
+    const N = samples.length / 3
+    for (let i = 0; i < N; i++) {
+      expect(Math.abs(samples[(3 * i) + 1])).toBeLessThan(1e-6)
+    }
+  })
+})
+
+
+describe('edgeScore', () => {
+  it('returns Infinity for points off-screen on x', () => {
+    expect(edgeScore(1.5, 0, 'top')).toBe(Infinity)
+    expect(edgeScore(-1.2, 0, 'right')).toBe(Infinity)
+  })
+
+  it('returns Infinity for points off-screen on y', () => {
+    expect(edgeScore(0, 1.1, 'left')).toBe(Infinity)
+    expect(edgeScore(0, -1.5, 'bottom')).toBe(Infinity)
+  })
+
+  it('top edge: smaller score for higher y', () => {
+    expect(edgeScore(0, 0.8, 'top')).toBeLessThan(edgeScore(0, 0.0, 'top'))
+    expect(edgeScore(0, 1.0, 'top')).toBe(0)
+  })
+
+  it('bottom edge: smaller score for lower y', () => {
+    expect(edgeScore(0, -0.8, 'bottom')).toBeLessThan(edgeScore(0, 0.0, 'bottom'))
+    expect(edgeScore(0, -1.0, 'bottom')).toBe(0)
+  })
+
+  it('right edge: smaller score for higher x', () => {
+    expect(edgeScore(0.7, 0, 'right')).toBeLessThan(edgeScore(0.0, 0, 'right'))
+  })
+
+  it('left edge: smaller score for lower x', () => {
+    expect(edgeScore(-0.7, 0, 'left')).toBeLessThan(edgeScore(0.0, 0, 'left'))
+  })
+
+  it('returns Infinity for an unknown edge name', () => {
+    expect(edgeScore(0, 0, 'middle')).toBe(Infinity)
+  })
+})

--- a/js/scene/Grids.test.js
+++ b/js/scene/Grids.test.js
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'bun:test'
-import {edgeScore, sampleMeridian, sampleParallel} from './Grids.js'
+import {bracketCrossing, edgeScore, sampleMeridian, sampleParallel} from './Grids.js'
 
 
 describe('sampleMeridian', () => {
@@ -94,5 +94,54 @@ describe('edgeScore', () => {
 
   it('returns Infinity for an unknown edge name', () => {
     expect(edgeScore(0, 0, 'middle')).toBe(Infinity)
+  })
+})
+
+
+describe('bracketCrossing', () => {
+  it('returns null when both points are on the same side of the edge', () => {
+    expect(bracketCrossing(0, 0.5, 0.3, 0.6, 'top')).toBeNull()
+    expect(bracketCrossing(0, -0.5, 0.3, -0.6, 'bottom')).toBeNull()
+    expect(bracketCrossing(0.5, 0, 0.6, 0, 'right')).toBeNull()
+  })
+
+  it('finds the exact midpoint crossing of a horizontal edge', () => {
+    // Segment from y=0.8 to y=1.2 — bracket sits halfway, t=0.5
+    const r = bracketCrossing(-0.2, 0.8, 0.2, 1.2, 'top')
+    expect(r).not.toBeNull()
+    expect(r.t).toBeCloseTo(0.5, 6)
+    expect(r.y).toBeCloseTo(1, 6)
+    // x interpolates linearly: midpoint of (-0.2, 0.2) = 0
+    expect(r.x).toBeCloseTo(0, 6)
+  })
+
+  it('reports t outside (0, 1) is impossible — crossing always within segment', () => {
+    // Endpoint exactly on edge: t=0 means start is on edge — but bracket
+    // requires strict opposite signs, so endpoint-on-edge returns null.
+    expect(bracketCrossing(0, 1, 0, 1.5, 'top')).toBeNull()
+  })
+
+  it('returns null when the crossing lies off-screen on the orthogonal axis', () => {
+    // Segment crosses y=1 at x=2.5 — outside the screen window.
+    const r = bracketCrossing(2, 0.8, 3, 1.2, 'top')
+    expect(r).toBeNull()
+  })
+
+  it('handles bottom / left / right edges with consistent semantics', () => {
+    expect(bracketCrossing(0, -0.8, 0, -1.2, 'bottom')).not.toBeNull()
+    expect(bracketCrossing(-0.8, 0, -1.2, 0, 'left')).not.toBeNull()
+    expect(bracketCrossing(0.8, 0, 1.2, 0, 'right')).not.toBeNull()
+  })
+
+  it('returns null for unknown edge name', () => {
+    expect(bracketCrossing(0, 0.8, 0, 1.2, 'middle')).toBeNull()
+  })
+
+  it('interpolated x along a top crossing is exactly the linear-interp x', () => {
+    // y goes 0 → 2, edge at y=1 ⇒ t=0.5; x goes -1 → 1 ⇒ x@t=0
+    const r = bracketCrossing(-1, 0, 1, 2, 'top')
+    expect(r).not.toBeNull()
+    expect(r.t).toBeCloseTo(0.5, 6)
+    expect(r.x).toBeCloseTo(0, 6)
   })
 })

--- a/js/scene/Grids.test.js
+++ b/js/scene/Grids.test.js
@@ -174,6 +174,43 @@ describe('bracketCrossing', () => {
     expect(r).not.toBeNull()
     expect(r.y).toBeCloseTo(-0.9, 6)
   })
+
+  describe('exitOnly direction filter', () => {
+    it('top edge: accepts exits (yj > yi), rejects entries', () => {
+      // Exit: vi inside (y < 1) → vj outside (y > 1)
+      expect(bracketCrossing(0, 0.8, 0, 1.2, 'top', 0, true)).not.toBeNull()
+      // Entry: vi outside (y > 1) → vj inside (y < 1)
+      expect(bracketCrossing(0, 1.2, 0, 0.8, 'top', 0, true)).toBeNull()
+    })
+
+    it('bottom edge: exits go more negative (yj < yi)', () => {
+      // Exit through bottom: vi inside (y > -1) → vj outside (y < -1)
+      expect(bracketCrossing(0, -0.8, 0, -1.2, 'bottom', 0, true)).not.toBeNull()
+      // Entry through bottom: vi outside → vj inside
+      expect(bracketCrossing(0, -1.2, 0, -0.8, 'bottom', 0, true)).toBeNull()
+    })
+
+    it('right edge: exits go more positive (xj > xi)', () => {
+      expect(bracketCrossing(0.8, 0, 1.2, 0, 'right', 0, true)).not.toBeNull()
+      expect(bracketCrossing(1.2, 0, 0.8, 0, 'right', 0, true)).toBeNull()
+    })
+
+    it('left edge: exits go more negative (xj < xi)', () => {
+      expect(bracketCrossing(-0.8, 0, -1.2, 0, 'left', 0, true)).not.toBeNull()
+      expect(bracketCrossing(-1.2, 0, -0.8, 0, 'left', 0, true)).toBeNull()
+    })
+
+    it('exitOnly=false (default) accepts both directions', () => {
+      expect(bracketCrossing(0, 0.8, 0, 1.2, 'top')).not.toBeNull()
+      expect(bracketCrossing(0, 1.2, 0, 0.8, 'top')).not.toBeNull()
+    })
+
+    it('exitOnly=true preserves the off-screen-orthogonal rejection', () => {
+      // Crosses the inset top edge but at x=2.5 (off-screen).  Should
+      // still be rejected even with exitOnly=true.
+      expect(bracketCrossing(2, 0.8, 3, 1.2, 'top', 0, true)).toBeNull()
+    })
+  })
 })
 
 

--- a/js/scene/MilkyWay.js
+++ b/js/scene/MilkyWay.js
@@ -1,0 +1,283 @@
+import {
+  AdditiveBlending,
+  BufferGeometry,
+  Float32BufferAttribute,
+  Points,
+  ShaderMaterial,
+  Vector3,
+} from 'three'
+import {pathTexture} from './material.js'
+import {LIGHTYEAR_METER} from '../shared.js'
+
+
+// Sun's distance from the galactic centre (Sgr A*) is ~26 kLY.  We park the
+// galactic centre at a fixed offset from the world origin so the Sun (which
+// already sits at the origin) lands on the inner edge of a spiral arm at
+// roughly its real galacto-centric radius.
+const SUN_GALACTIC_RADIUS_M = 26000 * LIGHTYEAR_METER
+
+// Milky-Way-ish shape parameters (artistic, not surveyed).
+const DISK_RADIUS_M = 50000 * LIGHTYEAR_METER
+const DISK_THICKNESS_M = 1000 * LIGHTYEAR_METER
+const BAR_HALF_LEN_M = 7000 * LIGHTYEAR_METER
+const BAR_HALF_WIDTH_M = 1500 * LIGHTYEAR_METER
+const BULGE_RADIUS_M = 4000 * LIGHTYEAR_METER
+
+const NUM_STARS = 12000
+const NUM_ARMS = 2 // two grand-design arms emerging from the bar
+const ARM_PITCH = 0.22 // tan(pitch); ≈ 12.5° pitch angle, MW-ish
+const FRAC_BULGE = 0.18
+const FRAC_BAR = 0.18
+// Remainder goes into the spiral arms.
+
+// Choice of "Sun arm" controls the galactic orientation.  Arm 0's logarithmic
+// spiral is sampled at r = SUN_GALACTIC_RADIUS_M to find the Sun anchor; the
+// whole disk is then translated so that anchor sits at the world origin.
+const SUN_ARM_INDEX = 0
+
+
+/**
+ * Procedural barred-spiral Milky Way as an additive Points cloud.
+ *
+ * Coordinate convention: built in galactic-centre local space (centre at
+ * origin, disk in XZ plane, +Y = galactic north).  The whole Points object
+ * is then translated so that the Sun's anchor point on a spiral arm lands at
+ * the world origin (where the simulated Sun lives).
+ *
+ * Uses Relative-To-Eye (RTE) emulated double precision in the shader so the
+ * stars stay rock-solid when the camera is rebased during star navigation
+ * (worldGroup shifts under the galaxy, but the eye-relative math cancels out).
+ *
+ * @returns {Points}
+ */
+export default function newMilkyWay() {
+  const positions = new Float32Array(NUM_STARS * 3)
+  const positionLow = new Float32Array(NUM_STARS * 3)
+  const colors = new Float32Array(NUM_STARS * 3)
+
+  // Sun sits on arm SUN_ARM_INDEX at radius SUN_GALACTIC_RADIUS_M.
+  const sunArmAngle = armAngleAt(SUN_ARM_INDEX, SUN_GALACTIC_RADIUS_M)
+  const sunGalCx = SUN_GALACTIC_RADIUS_M * Math.cos(sunArmAngle)
+  const sunGalCz = SUN_GALACTIC_RADIUS_M * Math.sin(sunArmAngle)
+
+  const tmp = new Vector3()
+  for (let i = 0; i < NUM_STARS; i++) {
+    const r = Math.random()
+    let col
+    if (r < FRAC_BULGE) {
+      sampleBulge(tmp); col = bulgeColor()
+    } else if (r < FRAC_BULGE + FRAC_BAR) {
+      sampleBar(tmp); col = barColor()
+    } else {
+      sampleArm(tmp); col = armColor()
+    }
+    // Translate galaxy so the Sun anchor sits at the world origin: galaxy
+    // points get shifted by -sunGalC so SUN ↦ (0,0,0).
+    const x = tmp.x - sunGalCx
+    const y = tmp.y
+    const z = tmp.z - sunGalCz
+    // RTE high/low split: hi = fround(x), lo = x - hi.  Magnitudes match,
+    // so float32 subtraction (position - camPos) is exact.
+    const hx = Math.fround(x); const hy = Math.fround(y); const hz = Math.fround(z)
+    const off3 = i * 3
+    positions[off3] = hx
+    positions[off3 + 1] = hy
+    positions[off3 + 2] = hz
+    positionLow[off3] = x - hx
+    positionLow[off3 + 1] = y - hy
+    positionLow[off3 + 2] = z - hz
+    colors[off3] = col[0]
+    colors[off3 + 1] = col[1]
+    colors[off3 + 2] = col[2]
+  }
+
+  const geom = new BufferGeometry()
+  geom.setAttribute('position', new Float32BufferAttribute(positions, 3))
+  geom.setAttribute('positionLow', new Float32BufferAttribute(positionLow, 3))
+  geom.setAttribute('color', new Float32BufferAttribute(colors, 3))
+
+  // Texture is loaded lazily on first onBeforeRender so headless tests (no
+  // DOM, so TextureLoader.load → document.createElementNS would throw)
+  // construct the galaxy without touching the loader.
+  const mat = new ShaderMaterial({
+    uniforms: {
+      texSampler: {value: null},
+      uMinPxSize: {value: 1.0},
+      uMaxPxSize: {value: 48.0},
+      uSizeFalloff: {value: 8e18}, // metres; gl_PointSize ≈ uSizeFalloff / dist
+      uCamPosWorldHigh: {value: new Vector3()},
+      uCamPosWorldLow: {value: new Vector3()},
+    },
+    vertexShader: VERT,
+    fragmentShader: FRAG,
+    blending: AdditiveBlending,
+    depthTest: true,
+    depthWrite: false,
+    transparent: true,
+    vertexColors: true,
+    toneMapped: false,
+  })
+
+  const points = new Points(geom, mat)
+  points.name = 'MilkyWay'
+  // Galaxy sits on top of any rebase the worldGroup applies; positions are
+  // already in world coords, so identity local transform.
+  // Auto-computed bounding sphere is correct but huge — leave frustum
+  // culling enabled.
+  // RenderOrder < 0 so the additive cloud composites cleanly behind the
+  // local star particles (which default to renderOrder 0).
+  points.renderOrder = -2
+
+  // Drive the RTE camera-position uniforms each frame, mirroring Stars.js.
+  // worldGroup may translate during star navigation; subtract its position so
+  // the residual is in galaxy-local frame (= world frame for this object,
+  // since the galaxy itself sits in worldGroup with identity local).
+  const rtePos = new Vector3()
+  points.onBeforeRender = (renderer, scene, camera) => {
+    if (mat.uniforms.texSampler.value === null) {
+      mat.uniforms.texSampler.value = pathTexture('star_glow', '.png')
+    }
+    camera.getWorldPosition(rtePos)
+    const wg = scene.getObjectByName('WorldGroup')
+    if (wg) {
+      rtePos.sub(wg.position)
+    }
+    const hx = Math.fround(rtePos.x)
+    const hy = Math.fround(rtePos.y)
+    const hz = Math.fround(rtePos.z)
+    mat.uniforms.uCamPosWorldHigh.value.set(hx, hy, hz)
+    mat.uniforms.uCamPosWorldLow.value.set(rtePos.x - hx, rtePos.y - hy, rtePos.z - hz)
+  }
+
+  return points
+}
+
+
+// --- Disk component samplers ------------------------------------------------
+
+/** @param {Vector3} out */
+function sampleBulge(out) {
+  // Slightly oblate spheroid concentrated toward centre.
+  const u = Math.random(); const v = Math.random()
+  const theta = 2 * Math.PI * u
+  const phi = Math.acos((2 * v) - 1)
+  const r = Math.pow(Math.random(), 0.7) * BULGE_RADIUS_M
+  out.set(
+      r * Math.sin(phi) * Math.cos(theta),
+      r * Math.cos(phi) * 0.4, // flatter than wide
+      r * Math.sin(phi) * Math.sin(theta))
+}
+
+
+/** @param {Vector3} out */
+function sampleBar(out) {
+  // Bar oriented along X in galactic-centre frame.  Long-axis density
+  // peaks at centre via sqrt-of-uniform.
+  const tx = (Math.random() - 0.5) * 2.0
+  out.set(
+      Math.sign(tx) * Math.sqrt(Math.abs(tx)) * BAR_HALF_LEN_M,
+      (Math.random() - 0.5) * DISK_THICKNESS_M * 0.6,
+      (Math.random() - 0.5) * BAR_HALF_WIDTH_M * 2.0)
+}
+
+
+/** @param {Vector3} out */
+function sampleArm(out) {
+  const armIdx = Math.floor(Math.random() * NUM_ARMS)
+  // Distance from the bar end out to disk edge, biased outward gently.
+  const t = Math.random()
+  const r = BAR_HALF_LEN_M + (Math.pow(t, 0.5) * (DISK_RADIUS_M - BAR_HALF_LEN_M))
+  const angle = armAngleAt(armIdx, r)
+  // Scatter perpendicular and along the arm so it reads as a thick lane,
+  // not a hairline.
+  const armWidth = (DISK_THICKNESS_M * 0.8) + (r * 0.04)
+  const dr = (Math.random() - 0.5) * armWidth * 1.6
+  const da = (Math.random() - 0.5) * 0.30
+  const finalR = Math.max(0, r + dr)
+  const finalA = angle + da
+  // Disk thins very gradually with radius.
+  const thickness = DISK_THICKNESS_M * (0.6 + (0.4 * Math.exp(-r / DISK_RADIUS_M)))
+  out.set(
+      finalR * Math.cos(finalA),
+      (Math.random() - 0.5) * thickness,
+      finalR * Math.sin(finalA))
+}
+
+
+/**
+ * Logarithmic spiral arm angle at radius r for arm index armIdx.
+ *
+ * @param {number} armIdx
+ * @param {number} r metres from galactic centre
+ * @returns {number} radians
+ */
+function armAngleAt(armIdx, r) {
+  // θ = (1/pitch) · ln(r / r0) + arm_offset
+  const r0 = BAR_HALF_LEN_M
+  return ((1 / ARM_PITCH) * Math.log(Math.max(r, r0) / r0)) + ((armIdx * 2 * Math.PI) / NUM_ARMS)
+}
+
+
+// Slight color variation per region — bulge/bar populated by older yellower
+// stars, arms by hotter younger stars on average.
+
+/** @returns {Array<number>} [r, g, b] in 0..1 */
+function bulgeColor() {
+  const j = Math.random() * 0.1
+  return [1.0, 0.85 - j, 0.6 - j]
+}
+
+/** @returns {Array<number>} [r, g, b] in 0..1 */
+function barColor() {
+  const j = Math.random() * 0.1
+  return [1.0, 0.88 - j, 0.7 - j]
+}
+
+/** @returns {Array<number>} [r, g, b] in 0..1 */
+function armColor() {
+  const blueT = Math.random()
+  return [0.85 + ((1 - blueT) * 0.15), 0.92, 0.95 + (blueT * 0.05)]
+}
+
+
+// ---- Shaders ---------------------------------------------------------------
+//
+// Vertex: RTE eye-relative position so worldGroup rebases stay precise.
+// Bias gl_Position.z to the far plane so the cloud composites strictly behind
+// every depth-writing object regardless of float32 depth-buffer crush at
+// galactic scales.
+
+const VERT = `
+attribute vec3 color;
+attribute vec3 positionLow;
+uniform vec3  uCamPosWorldHigh;
+uniform vec3  uCamPosWorldLow;
+uniform float uMinPxSize;
+uniform float uMaxPxSize;
+uniform float uSizeFalloff;
+varying vec3  vColor;
+void main() {
+  vColor = color;
+  vec3 highDiff = position    - uCamPosWorldHigh;
+  vec3 lowDiff  = positionLow - uCamPosWorldLow;
+  vec3 eyePos   = highDiff + lowDiff;
+  vec4 mvPosition = vec4(mat3(viewMatrix) * eyePos, 1.0);
+  float dist = max(-mvPosition.z, 1.0);
+  gl_PointSize = clamp(uSizeFalloff / dist, uMinPxSize, uMaxPxSize);
+  vec4 clip = projectionMatrix * mvPosition;
+  // Pin to (just inside) far plane in clip space so the additive galaxy
+  // never "wins" a depth comparison against any nearer geometry.  z = w
+  // would map to the far plane exactly; pull a touch in to avoid ties.
+  clip.z = clip.w * 0.9999;
+  gl_Position = clip;
+}
+`
+
+const FRAG = `
+uniform sampler2D texSampler;
+varying vec3 vColor;
+void main() {
+  vec4 tex = texture2D(texSampler, gl_PointCoord);
+  gl_FragColor = vec4(vColor, 1.0) * tex;
+}
+`

--- a/js/scene/MilkyWay.js
+++ b/js/scene/MilkyWay.js
@@ -8,7 +8,7 @@ import {
   Vector3,
 } from 'three'
 import {pathTexture} from './material.js'
-import {LIGHTYEAR_METER, STARS_RADIUS_METER, toRad} from '../shared.js'
+import {LIGHTYEAR_METER, toRad} from '../shared.js'
 
 
 // Sun's distance from the galactic centre (Sgr A*) is ~26 kLY.  We park the
@@ -24,19 +24,34 @@ const SUN_GALACTIC_RADIUS_M = 26000 * LIGHTYEAR_METER
 // the two normals).
 const ECLIPTIC_TO_GALACTIC_DEG = 60.187
 
-// Milky-Way-ish shape parameters (artistic, not surveyed).
+// Milky-Way-ish shape parameters.  Diameter (100 kly) matches the scene's
+// GALAXY_RADIUS_METER and the local Hipparcos catalog's outer scale.
+//
+// DISK_THICKNESS_M is the *peak* perpendicular spread (near the bar); the
+// arm sampler tapers it toward the rim.  10 kly is much thicker than a
+// real spiral disc but matches the perpendicular extent of the local
+// Hipparcos catalog so its stars sit visibly inside the cloud rather than
+// sticking out above/below.
 const DISK_RADIUS_M = 50000 * LIGHTYEAR_METER
-const DISK_THICKNESS_M = 1000 * LIGHTYEAR_METER
+const DISK_THICKNESS_M = 10000 * LIGHTYEAR_METER
 const BAR_HALF_LEN_M = 7000 * LIGHTYEAR_METER
 const BAR_HALF_WIDTH_M = 1800 * LIGHTYEAR_METER
+// Bar perpendicular half-extent — decoupled from DISK_THICKNESS_M so a
+// thicker disc doesn't spread the bar into a fat slab.  ~1.2 kly keeps
+// the bar visually flat and bulge-like in the perpendicular direction.
+const BAR_HALF_HEIGHT_M = 1200 * LIGHTYEAR_METER
 const BULGE_RADIUS_M = 4500 * LIGHTYEAR_METER
 
-const NUM_STARS = 16000
+// Arm region volume is ~600× the bar volume, so arm density appears far
+// lower than bar density at equal particle counts.  Bumping the total budget
+// + shifting fractions toward the arms brings arm visibility close to the
+// bar's appearance without nuking framerate.
+const NUM_STARS = 60000
 const NUM_ARMS = 4 // four arms — Milky Way is a "multi-arm" / 4-arm design
 const ARM_PITCH = 0.22 // tan(pitch); ≈ 12.5° pitch angle, MW-ish
-const FRAC_BULGE = 0.20
-const FRAC_BAR = 0.15
-// Remainder goes into the spiral arms.
+const FRAC_BULGE = 0.08
+const FRAC_BAR = 0.06
+// Remainder (≈ 86%) goes into the spiral arms.
 
 // Choice of "Sun arm" controls the galactic orientation.  Arm 0's logarithmic
 // spiral is sampled at r = SUN_GALACTIC_RADIUS_M to find the Sun anchor; the
@@ -47,9 +62,9 @@ const SUN_ARM_INDEX = 0
 // renders real stars at full fidelity.  Galaxy points inside this hole would
 // (a) overlap individual catalog stars, (b) blow up gl_PointSize when the
 // camera is inside the hole, and (c) be much closer than the cloud is
-// designed for.  Uses STARS_RADIUS_METER (~10 kLY) so the carve-out matches
-// the actual catalog footprint.
-const LOCAL_CATALOG_HOLE_M = STARS_RADIUS_METER
+// designed for.  Sized just large enough to cover the bulk of nearby
+// Hipparcos stars.
+const LOCAL_CATALOG_HOLE_M = 1500 * LIGHTYEAR_METER
 
 
 /**
@@ -220,11 +235,13 @@ function sampleBulge(out) {
 /** @param {Vector3} out */
 function sampleBar(out) {
   // Bar oriented along X in galactic-centre frame.  Long-axis density
-  // peaks at centre via sqrt-of-uniform.
+  // peaks at centre via sqrt-of-uniform.  Perpendicular thickness uses
+  // BAR_HALF_HEIGHT_M (decoupled from disc thickness) so the bar stays
+  // flat regardless of how thick the surrounding disc is.
   const tx = (Math.random() - 0.5) * 2.0
   out.set(
       Math.sign(tx) * Math.sqrt(Math.abs(tx)) * BAR_HALF_LEN_M,
-      (Math.random() - 0.5) * DISK_THICKNESS_M * 0.6,
+      (Math.random() - 0.5) * BAR_HALF_HEIGHT_M * 2.0,
       (Math.random() - 0.5) * BAR_HALF_WIDTH_M * 2.0)
 }
 
@@ -236,15 +253,24 @@ function sampleArm(out) {
   const t = Math.random()
   const r = BAR_HALF_LEN_M + (Math.pow(t, 0.5) * (DISK_RADIUS_M - BAR_HALF_LEN_M))
   const angle = armAngleAt(armIdx, r)
-  // Scatter perpendicular and along the arm so it reads as a thick lane,
-  // not a hairline.
-  const armWidth = (DISK_THICKNESS_M * 0.8) + (r * 0.04)
+  // Arm taper: arms are wide near the bar (so they blend visually into it)
+  // and thin out toward the disc edge (revealing the spiral structure).
+  // Both in-plane scatter (armWidth) and perpendicular scatter (thickness)
+  // follow the same exponential taper in r, plus a small constant floor so
+  // the outer arms still have visible thickness rather than going to a
+  // hairline.
+  const taperR = Math.exp(-(r - BAR_HALF_LEN_M) / (DISK_RADIUS_M * 0.45))
+  // In-plane width: bar-width-like at the inner edge, tapering to a thin
+  // spiral lane at the outer edge.
+  const armWidth = (BAR_HALF_WIDTH_M * 1.0 * taperR) + (DISK_RADIUS_M * 0.012)
   const dr = (Math.random() - 0.5) * armWidth * 1.6
   const da = (Math.random() - 0.5) * 0.30
   const finalR = Math.max(0, r + dr)
   const finalA = angle + da
-  // Disk thins very gradually with radius.
-  const thickness = DISK_THICKNESS_M * (0.6 + (0.4 * Math.exp(-r / DISK_RADIUS_M)))
+  // Perpendicular thickness: matches DISK_THICKNESS_M near the bar, drops
+  // to ~15% at the rim.  Catalog stars near the Sun (≈ 26 kly out) end up
+  // inside the local thickness rather than sticking out perpendicular.
+  const thickness = (DISK_THICKNESS_M * taperR) + (DISK_THICKNESS_M * 0.15)
   out.set(
       finalR * Math.cos(finalA),
       (Math.random() - 0.5) * thickness,

--- a/js/scene/MilkyWay.js
+++ b/js/scene/MilkyWay.js
@@ -8,7 +8,7 @@ import {
   Vector3,
 } from 'three'
 import {pathTexture} from './material.js'
-import {LIGHTYEAR_METER, STARS_RADIUS_METER} from '../shared.js'
+import {LIGHTYEAR_METER, STARS_RADIUS_METER, toRad} from '../shared.js'
 
 
 // Sun's distance from the galactic centre (Sgr A*) is ~26 kLY.  We park the
@@ -17,18 +17,25 @@ import {LIGHTYEAR_METER, STARS_RADIUS_METER} from '../shared.js'
 // roughly its real galacto-centric radius.
 const SUN_GALACTIC_RADIUS_M = 26000 * LIGHTYEAR_METER
 
+// Galactic plane orientation in scene coords.  Same Z-rotation the Galactic
+// reference grid uses (Grids.js); puts the disk perpendicular to the IAU
+// J2000 galactic pole instead of the ecliptic pole.  Without this the disk
+// sits in the ecliptic plane, which is wrong by ~60° (the angle between
+// the two normals).
+const ECLIPTIC_TO_GALACTIC_DEG = 60.187
+
 // Milky-Way-ish shape parameters (artistic, not surveyed).
 const DISK_RADIUS_M = 50000 * LIGHTYEAR_METER
 const DISK_THICKNESS_M = 1000 * LIGHTYEAR_METER
 const BAR_HALF_LEN_M = 7000 * LIGHTYEAR_METER
-const BAR_HALF_WIDTH_M = 1500 * LIGHTYEAR_METER
-const BULGE_RADIUS_M = 4000 * LIGHTYEAR_METER
+const BAR_HALF_WIDTH_M = 1800 * LIGHTYEAR_METER
+const BULGE_RADIUS_M = 4500 * LIGHTYEAR_METER
 
-const NUM_STARS = 8000
-const NUM_ARMS = 2 // two grand-design arms emerging from the bar
+const NUM_STARS = 16000
+const NUM_ARMS = 4 // four arms — Milky Way is a "multi-arm" / 4-arm design
 const ARM_PITCH = 0.22 // tan(pitch); ≈ 12.5° pitch angle, MW-ish
-const FRAC_BULGE = 0.18
-const FRAC_BAR = 0.18
+const FRAC_BULGE = 0.20
+const FRAC_BAR = 0.15
 // Remainder goes into the spiral arms.
 
 // Choice of "Sun arm" controls the galactic orientation.  Arm 0's logarithmic
@@ -63,6 +70,7 @@ export default function newMilkyWay() {
   const positions = new Float32Array(NUM_STARS * 3)
   const positionLow = new Float32Array(NUM_STARS * 3)
   const colors = new Float32Array(NUM_STARS * 3)
+  const sizes = new Float32Array(NUM_STARS)
 
   // Sun sits on arm SUN_ARM_INDEX at radius SUN_GALACTIC_RADIUS_M.
   const sunArmAngle = armAngleAt(SUN_ARM_INDEX, SUN_GALACTIC_RADIUS_M)
@@ -78,13 +86,13 @@ export default function newMilkyWay() {
   const MAX_TRIES = NUM_STARS * 8
   for (let tries = 0; tries < MAX_TRIES && written < NUM_STARS; tries++) {
     const r = Math.random()
-    let col
+    let col; let sz
     if (r < FRAC_BULGE) {
-      sampleBulge(tmp); col = bulgeColor()
+      sampleBulge(tmp); col = bulgeColor(); sz = bulgeSize()
     } else if (r < FRAC_BULGE + FRAC_BAR) {
-      sampleBar(tmp); col = barColor()
+      sampleBar(tmp); col = barColor(); sz = bulgeSize()
     } else {
-      sampleArm(tmp); col = armColor()
+      sampleArm(tmp); col = armColor(); sz = armSize()
     }
     // Translate galaxy so the Sun anchor sits at the world origin: galaxy
     // points get shifted by -sunGalC so SUN ↦ (0,0,0).
@@ -108,17 +116,20 @@ export default function newMilkyWay() {
     colors[off3] = col[0]
     colors[off3 + 1] = col[1]
     colors[off3 + 2] = col[2]
+    sizes[written] = sz
     written++
   }
   // Trim attribute arrays if rejection sampling left us short.
   const positionsFinal = (written === NUM_STARS) ? positions : positions.subarray(0, written * 3)
   const positionLowFinal = (written === NUM_STARS) ? positionLow : positionLow.subarray(0, written * 3)
   const colorsFinal = (written === NUM_STARS) ? colors : colors.subarray(0, written * 3)
+  const sizesFinal = (written === NUM_STARS) ? sizes : sizes.subarray(0, written)
 
   const geom = new BufferGeometry()
   geom.setAttribute('position', new Float32BufferAttribute(positionsFinal, 3))
   geom.setAttribute('positionLow', new Float32BufferAttribute(positionLowFinal, 3))
   geom.setAttribute('aGalaxyColor', new Float32BufferAttribute(colorsFinal, 3))
+  geom.setAttribute('aSize', new Float32BufferAttribute(sizesFinal, 1))
 
   // pathTexture() routes through three's TextureLoader, which calls
   // document.createElementNS synchronously to spin up an Image element.
@@ -136,14 +147,10 @@ export default function newMilkyWay() {
   // shader already declares `attribute vec3 color`.  Three injects a
   // USE_COLOR define and may wire the standard Points chunks into the
   // pipeline, which silently overrides the shader's gl_PointSize and
-  // produces giant fixed-size sprites instead of our 3px constant.
+  // produces giant fixed-size sprites instead of our intended size.
   const mat = new ShaderMaterial({
     uniforms: {
       texSampler: {value: glowTex},
-      // Galaxy "stars" are stand-ins for ~millions of real stars each.
-      // Keep the on-screen size very small (always a near-sub-pixel glow)
-      // so 8k of them stay performant and read as smoke-like background.
-      uPxSize: {value: 3.0},
       uCamPosWorldHigh: {value: new Vector3()},
       uCamPosWorldLow: {value: new Vector3()},
     },
@@ -158,6 +165,12 @@ export default function newMilkyWay() {
 
   const points = new Points(geom, mat)
   points.name = 'MilkyWay'
+  // Tilt the disk into the galactic plane.  The samplers above lay the
+  // galaxy out with its pole along scene +Y (the ecliptic pole); rotating
+  // about Z by the IAU obliquity of the galactic plane swings the pole
+  // onto the actual galactic-pole direction.  Sun stays at the origin
+  // because we already shifted vertices by -sunGalC pre-rotation.
+  points.rotation.z = ECLIPTIC_TO_GALACTIC_DEG * toRad
   // Galaxy sits on top of any rebase the worldGroup applies; positions are
   // already in world coords, so identity local transform.
   // Auto-computed bounding sphere is correct but huge — leave frustum
@@ -254,24 +267,78 @@ function armAngleAt(armIdx, r) {
 
 
 // Slight color variation per region — bulge/bar populated by older yellower
-// stars, arms by hotter younger stars on average.
+// stars, arms by hotter younger stars on average.  Each function returns a
+// random sample from its region's color distribution; the per-particle
+// variation is what gives the cloud its mottled, non-uniform appearance.
 
 /** @returns {Array<number>} [r, g, b] in 0..1 */
 function bulgeColor() {
-  const j = Math.random() * 0.1
-  return [1.0, 0.85 - j, 0.6 - j]
+  // Yellow-orange core with a hint of red on the redder samples.
+  const j = Math.random() * 0.15
+  return [1.0, 0.78 - j, 0.55 - j]
 }
 
 /** @returns {Array<number>} [r, g, b] in 0..1 */
 function barColor() {
-  const j = Math.random() * 0.1
-  return [1.0, 0.88 - j, 0.7 - j]
+  // Slightly cooler than the bulge — transitions toward the arm temperatures.
+  const j = Math.random() * 0.12
+  return [1.0, 0.85 - j, 0.65 - j]
 }
 
 /** @returns {Array<number>} [r, g, b] in 0..1 */
 function armColor() {
+  // Mostly blue-white (young hot OB stars + scatter), with the occasional
+  // yellow giant — matches the catalog's per-star color distribution at the
+  // hole boundary so the transition to the local catalog is seamless.
+  if (Math.random() < 0.06) {
+    return [1.0, 0.85, 0.6]
+  }
   const blueT = Math.random()
   return [0.85 + ((1 - blueT) * 0.15), 0.92, 0.95 + (blueT * 0.05)]
+}
+
+
+// --- Per-particle size --------------------------------------------------
+//
+// The galaxy's visual texture (clumpy bright spots in a sea of fainter
+// background) comes from per-particle size variation, not from real
+// brightness — at galactic distances every star projects to clamp-sized
+// (~3 px) under the catalog's standard rendering, so all the visible
+// "structure" has to be painted by the size distribution.  Most particles
+// are sub-3-px haze; a small fraction are the bright cluster / HII-region
+// stand-ins that show up as the discrete bright dots in Celestia-style
+// galaxy renders.
+//
+// Choices below produce a mix that visually matches the catalog stars at
+// the catalog-hole boundary (~10 kLY).
+
+
+/** @returns {number} pixels — bulge / bar particle */
+function bulgeSize() {
+  // Bulge has a denser, slightly larger average — concentrated mass.
+  const r = Math.random()
+  if (r < 0.05) {
+    return 4.5 + (Math.random() * 2.5)
+  } // bright cluster
+  if (r < 0.20) {
+    return 2.5 + (Math.random() * 1.5)
+  }
+  return 1.2 + (Math.random() * 1.0)
+}
+
+
+/** @returns {number} pixels — arm particle */
+function armSize() {
+  // Arms have more sparse bright spots (HII regions / O-star clusters)
+  // against a fainter background dot population.
+  const r = Math.random()
+  if (r < 0.04) {
+    return 4.0 + (Math.random() * 2.5)
+  } // bright clump
+  if (r < 0.15) {
+    return 2.2 + (Math.random() * 1.3)
+  }
+  return 1.0 + (Math.random() * 1.0)
 }
 
 
@@ -286,11 +353,11 @@ function armColor() {
 // chance of three.js wiring its built-in vertex-color attribute on top of ours
 // — that path expects a different layout and silently breaks gl_PointSize.
 const VERT = `
-attribute vec3 aGalaxyColor;
-attribute vec3 positionLow;
-uniform vec3  uCamPosWorldHigh;
-uniform vec3  uCamPosWorldLow;
-uniform float uPxSize;
+attribute vec3  aGalaxyColor;
+attribute vec3  positionLow;
+attribute float aSize;
+uniform vec3 uCamPosWorldHigh;
+uniform vec3 uCamPosWorldLow;
 varying vec3  vColor;
 void main() {
   vColor = aGalaxyColor;
@@ -298,11 +365,13 @@ void main() {
   vec3 lowDiff  = positionLow - uCamPosWorldLow;
   vec3 eyePos   = highDiff + lowDiff;
   vec4 mvPosition = vec4(mat3(viewMatrix) * eyePos, 1.0);
-  // Constant pixel size — galaxy points are background smoke representing
-  // many stars each, not individual stars.  Keeping size constant (rather
-  // than 1/dist) means close-by points don't blow up into screen-filling
-  // squares and overdraw stays bounded.
-  gl_PointSize = uPxSize;
+  // Per-particle pixel size: the JS-side sampler hands out a mix of small
+  // background dots (1–2 px), medium stars (2.5–4 px), and bright cluster
+  // clumps (5–7 px).  Constant in screen space (no 1/dist) so close-by
+  // points don't blow up and overdraw stays bounded.  The size mix is
+  // what gives the cloud its texture and lets nearby Hipparcos stars
+  // blend into the galaxy at the catalog-hole boundary.
+  gl_PointSize = aSize;
   vec4 clip = projectionMatrix * mvPosition;
   // Pin to (just inside) far plane in clip space so the additive galaxy
   // never "wins" a depth comparison against any nearer geometry.  z = w

--- a/js/scene/MilkyWay.js
+++ b/js/scene/MilkyWay.js
@@ -4,10 +4,11 @@ import {
   Float32BufferAttribute,
   Points,
   ShaderMaterial,
+  Texture,
   Vector3,
 } from 'three'
 import {pathTexture} from './material.js'
-import {LIGHTYEAR_METER} from '../shared.js'
+import {LIGHTYEAR_METER, STARS_RADIUS_METER} from '../shared.js'
 
 
 // Sun's distance from the galactic centre (Sgr A*) is ~26 kLY.  We park the
@@ -23,7 +24,7 @@ const BAR_HALF_LEN_M = 7000 * LIGHTYEAR_METER
 const BAR_HALF_WIDTH_M = 1500 * LIGHTYEAR_METER
 const BULGE_RADIUS_M = 4000 * LIGHTYEAR_METER
 
-const NUM_STARS = 12000
+const NUM_STARS = 8000
 const NUM_ARMS = 2 // two grand-design arms emerging from the bar
 const ARM_PITCH = 0.22 // tan(pitch); ≈ 12.5° pitch angle, MW-ish
 const FRAC_BULGE = 0.18
@@ -34,6 +35,14 @@ const FRAC_BAR = 0.18
 // spiral is sampled at r = SUN_GALACTIC_RADIUS_M to find the Sun anchor; the
 // whole disk is then translated so that anchor sits at the world origin.
 const SUN_ARM_INDEX = 0
+
+// Carve a hole around the Sun where the local Hipparcos catalog already
+// renders real stars at full fidelity.  Galaxy points inside this hole would
+// (a) overlap individual catalog stars, (b) blow up gl_PointSize when the
+// camera is inside the hole, and (c) be much closer than the cloud is
+// designed for.  Uses STARS_RADIUS_METER (~10 kLY) so the carve-out matches
+// the actual catalog footprint.
+const LOCAL_CATALOG_HOLE_M = STARS_RADIUS_METER
 
 
 /**
@@ -61,7 +70,13 @@ export default function newMilkyWay() {
   const sunGalCz = SUN_GALACTIC_RADIUS_M * Math.sin(sunArmAngle)
 
   const tmp = new Vector3()
-  for (let i = 0; i < NUM_STARS; i++) {
+  const holeSq = LOCAL_CATALOG_HOLE_M * LOCAL_CATALOG_HOLE_M
+  let written = 0
+  // Rejection-sample: reroll any point that lands inside the local catalog
+  // hole.  Cap the rejection budget so a degenerate config (Sun far inside
+  // the bar, etc.) can't infinite-loop.
+  const MAX_TRIES = NUM_STARS * 8
+  for (let tries = 0; tries < MAX_TRIES && written < NUM_STARS; tries++) {
     const r = Math.random()
     let col
     if (r < FRAC_BULGE) {
@@ -76,10 +91,14 @@ export default function newMilkyWay() {
     const x = tmp.x - sunGalCx
     const y = tmp.y
     const z = tmp.z - sunGalCz
+    // Reject if inside the local catalog hole around the Sun.
+    if (((x * x) + (y * y) + (z * z)) < holeSq) {
+      continue
+    }
     // RTE high/low split: hi = fround(x), lo = x - hi.  Magnitudes match,
     // so float32 subtraction (position - camPos) is exact.
     const hx = Math.fround(x); const hy = Math.fround(y); const hz = Math.fround(z)
-    const off3 = i * 3
+    const off3 = written * 3
     positions[off3] = hx
     positions[off3 + 1] = hy
     positions[off3 + 2] = hz
@@ -89,22 +108,42 @@ export default function newMilkyWay() {
     colors[off3] = col[0]
     colors[off3 + 1] = col[1]
     colors[off3 + 2] = col[2]
+    written++
   }
+  // Trim attribute arrays if rejection sampling left us short.
+  const positionsFinal = (written === NUM_STARS) ? positions : positions.subarray(0, written * 3)
+  const positionLowFinal = (written === NUM_STARS) ? positionLow : positionLow.subarray(0, written * 3)
+  const colorsFinal = (written === NUM_STARS) ? colors : colors.subarray(0, written * 3)
 
   const geom = new BufferGeometry()
-  geom.setAttribute('position', new Float32BufferAttribute(positions, 3))
-  geom.setAttribute('positionLow', new Float32BufferAttribute(positionLow, 3))
-  geom.setAttribute('color', new Float32BufferAttribute(colors, 3))
+  geom.setAttribute('position', new Float32BufferAttribute(positionsFinal, 3))
+  geom.setAttribute('positionLow', new Float32BufferAttribute(positionLowFinal, 3))
+  geom.setAttribute('aGalaxyColor', new Float32BufferAttribute(colorsFinal, 3))
 
-  // Texture is loaded lazily on first onBeforeRender so headless tests (no
-  // DOM, so TextureLoader.load → document.createElementNS would throw)
-  // construct the galaxy without touching the loader.
+  // pathTexture() routes through three's TextureLoader, which calls
+  // document.createElementNS synchronously to spin up an Image element.
+  // The bun test env supplies a stub document without that method, so
+  // guard the call: in headless we use a 1x1 placeholder texture (the
+  // Points cloud is never actually rendered there anyway).
+  let glowTex
+  try {
+    glowTex = pathTexture('star_glow', '.png')
+  } catch {
+    glowTex = new Texture()
+  }
+
+  // Note: do NOT set `vertexColors: true` on a ShaderMaterial whose vertex
+  // shader already declares `attribute vec3 color`.  Three injects a
+  // USE_COLOR define and may wire the standard Points chunks into the
+  // pipeline, which silently overrides the shader's gl_PointSize and
+  // produces giant fixed-size sprites instead of our 3px constant.
   const mat = new ShaderMaterial({
     uniforms: {
-      texSampler: {value: null},
-      uMinPxSize: {value: 1.0},
-      uMaxPxSize: {value: 48.0},
-      uSizeFalloff: {value: 8e18}, // metres; gl_PointSize ≈ uSizeFalloff / dist
+      texSampler: {value: glowTex},
+      // Galaxy "stars" are stand-ins for ~millions of real stars each.
+      // Keep the on-screen size very small (always a near-sub-pixel glow)
+      // so 8k of them stay performant and read as smoke-like background.
+      uPxSize: {value: 3.0},
       uCamPosWorldHigh: {value: new Vector3()},
       uCamPosWorldLow: {value: new Vector3()},
     },
@@ -114,7 +153,6 @@ export default function newMilkyWay() {
     depthTest: true,
     depthWrite: false,
     transparent: true,
-    vertexColors: true,
     toneMapped: false,
   })
 
@@ -134,9 +172,6 @@ export default function newMilkyWay() {
   // since the galaxy itself sits in worldGroup with identity local).
   const rtePos = new Vector3()
   points.onBeforeRender = (renderer, scene, camera) => {
-    if (mat.uniforms.texSampler.value === null) {
-      mat.uniforms.texSampler.value = pathTexture('star_glow', '.png')
-    }
     camera.getWorldPosition(rtePos)
     const wg = scene.getObjectByName('WorldGroup')
     if (wg) {
@@ -247,23 +282,27 @@ function armColor() {
 // every depth-writing object regardless of float32 depth-buffer crush at
 // galactic scales.
 
+// Custom attribute name aGalaxyColor (instead of plain `color`) sidesteps any
+// chance of three.js wiring its built-in vertex-color attribute on top of ours
+// — that path expects a different layout and silently breaks gl_PointSize.
 const VERT = `
-attribute vec3 color;
+attribute vec3 aGalaxyColor;
 attribute vec3 positionLow;
 uniform vec3  uCamPosWorldHigh;
 uniform vec3  uCamPosWorldLow;
-uniform float uMinPxSize;
-uniform float uMaxPxSize;
-uniform float uSizeFalloff;
+uniform float uPxSize;
 varying vec3  vColor;
 void main() {
-  vColor = color;
+  vColor = aGalaxyColor;
   vec3 highDiff = position    - uCamPosWorldHigh;
   vec3 lowDiff  = positionLow - uCamPosWorldLow;
   vec3 eyePos   = highDiff + lowDiff;
   vec4 mvPosition = vec4(mat3(viewMatrix) * eyePos, 1.0);
-  float dist = max(-mvPosition.z, 1.0);
-  gl_PointSize = clamp(uSizeFalloff / dist, uMinPxSize, uMaxPxSize);
+  // Constant pixel size — galaxy points are background smoke representing
+  // many stars each, not individual stars.  Keeping size constant (rather
+  // than 1/dist) means close-by points don't blow up into screen-filling
+  // squares and overdraw stays bounded.
+  gl_PointSize = uPxSize;
   vec4 clip = projectionMatrix * mvPosition;
   // Pin to (just inside) far plane in clip space so the additive galaxy
   // never "wins" a depth comparison against any nearer geometry.  z = w

--- a/js/scene/Planet.js
+++ b/js/scene/Planet.js
@@ -120,6 +120,12 @@ export default class Planet extends Object {
     group.add(pathShape)
     const orbitScaled = orbit.semiMajorAxis.scalar
     group.scale.setScalar(orbitScaled)
+    // Initial visibility from the scene's current settings — handles the
+    // case where this planet loads after applySettings has already toggled
+    // orbits off (toggleOrbits' visitSetProperty only walks
+    // already-attached children), so the new orbit doesn't sneak in
+    // visible and contradict the user's saved permalink state.
+    group.visible = scene.getSetting ? scene.getSetting('o') : true
     return group
   }
 
@@ -192,6 +198,10 @@ export default class Planet extends Object {
     labelLOD.addLevel(FAR_OBJ, labelTooNearDist)
     labelLOD.addLevel(labelSheet.compile(), labelTooNearDist)
     labelLOD.addLevel(FAR_OBJ, labelTooFarDist)
+    // Initial visibility from the scene's current settings (see newOrbit
+    // above) — guards against the load-order race where a planet appears
+    // after togglePlanetLabels has already run.
+    labelLOD.visible = scene.getSetting ? scene.getSetting('p') : true
 
     const group = new Object3D
     group.add(named(planetLOD, 'planet LOD'))

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -6,6 +6,7 @@ import {
   Vector3,
 } from 'three'
 import Asterisms from './Asterisms.js'
+import newGrids from './Grids.js'
 import newMilkyWay from './MilkyWay.js'
 import Planet from './Planet.js'
 import Star from './Star.js'
@@ -34,6 +35,13 @@ export default class Scene {
     this.worldGroup = new Object3D
     this.worldGroup.name = 'WorldGroup'
     ui.scene.add(this.worldGroup)
+    // Reference-frame grids (Equatorial, Ecliptic, Galactic).  Lives in the
+    // worldGroup so star-navigation rebases shift it along with the
+    // universe, but the grid shader ignores camera translation so the grid
+    // wraps the camera as a sky reference regardless.  All hidden by
+    // default; toggled via keyboard.
+    this.grids = newGrids()
+    this.worldGroup.add(this.grids.group)
     this.mouse = new Vector2
     this.raycaster = new Raycaster
     // this.raycaster = new CustomRaycaster;
@@ -396,6 +404,49 @@ export default class Scene {
   toggleStarLabels() {
     if (this.stars) {
       this.stars.labelLOD.visible = !this.stars.labelLOD.visible
+    }
+  }
+
+
+  /**
+   * Toggle the Ecliptic + Galactic reference grids together.  The two
+   * frames are the most useful pair for navigating outside the solar
+   * system: ecliptic gives "where am I relative to the planetary plane",
+   * galactic gives "where am I in the Milky Way".  Equatorial is left
+   * separate (rotates with Earth's spin axis, less useful for interstellar
+   * orientation).
+   */
+  toggleGridsOrientation() {
+    if (!this.grids) {
+      return
+    }
+    // Drive both off the ecliptic's state so they always match.
+    const next = !this.grids.ecliptic.visible
+    this.grids.ecliptic.visible = next
+    this.grids.galactic.visible = next
+  }
+
+
+  /** */
+  toggleGridEquatorial() {
+    if (this.grids) {
+      this.grids.equatorial.visible = !this.grids.equatorial.visible
+    }
+  }
+
+
+  /** */
+  toggleGridEcliptic() {
+    if (this.grids) {
+      this.grids.ecliptic.visible = !this.grids.ecliptic.visible
+    }
+  }
+
+
+  /** */
+  toggleGridGalactic() {
+    if (this.grids) {
+      this.grids.galactic.visible = !this.grids.galactic.visible
     }
   }
 

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -68,10 +68,49 @@ export default class Scene {
       e: false, // equatorial grid
       c: false, // ecliptic grid
       g: false, // galactic grid
+      v: true, // nav panels / heads-up display (Celestiary-owned, see registerSettingApplier)
     }
+    // Custom appliers for settings keys that the Scene doesn't own directly
+    // (Celestiary registers 'v' here).  applySettings dispatches to these
+    // alongside the built-in toggle methods.
+    this._customAppliers = {}
     // Set by Celestiary; called whenever any settings flag flips so the
     // permalink can be updated.
     this.onSettingsChange = null
+  }
+
+
+  /**
+   * Register a key handler so applySettings can drive a toggle the Scene
+   * doesn't own (e.g. the Celestiary-level nav panels).  The applier
+   * function should perform the same effect as a user keypress and update
+   * Scene._settings via _flipSetting (or by calling back into a method
+   * that does).
+   *
+   * @param {string} key one of the SETTINGS_DEFAULTS keys
+   * @param {Function} fn
+   */
+  registerSettingApplier(key, fn) {
+    this._customAppliers[key] = fn
+  }
+
+
+  /**
+   * Public flip — updates _settings[key] and notifies the listener.
+   * Exposed so Celestiary-owned toggles (which can't easily call the
+   * underscore-prefixed internal version from outside) can keep the
+   * canonical state in sync.
+   *
+   * @param {string} key
+   */
+  flipSetting(key) {
+    this._flipSetting(key)
+  }
+
+
+  /** @returns {boolean} current value of a single setting */
+  getSetting(key) {
+    return this._settings[key]
   }
 
 
@@ -110,6 +149,7 @@ export default class Scene {
       e: () => this.toggleGridEquatorial(),
       c: () => this.toggleGridEcliptic(),
       g: () => this.toggleGridGalactic(),
+      ...this._customAppliers,
     }
     for (const key of Object.keys(dispatch)) {
       if (requested[key] !== undefined && requested[key] !== this._settings[key]) {

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -6,6 +6,7 @@ import {
   Vector3,
 } from 'three'
 import Asterisms from './Asterisms.js'
+import newMilkyWay from './MilkyWay.js'
 import Planet from './Planet.js'
 import Star from './Star.js'
 import Stars from './Stars.js'
@@ -408,6 +409,11 @@ export default class Scene {
       // console.log('Well done, you found the galaxy!');
     })
     this.objects[`${galaxyProps.name}.orbitPosition`] = group
+    // Procedural barred-spiral Milky Way as a background star cloud.  Built in
+    // galactic-centre coords and translated so the Sun (world origin) lands on
+    // a spiral arm.  Lives in worldGroup so star-navigation rebases shift it
+    // along with everything else, keeping the universe coherent.
+    group.add(newMilkyWay())
     return group
   }
 }

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -89,6 +89,19 @@ export default class Scene {
    * @param {object} requested flat {key: bool} map
    */
   applySettings(requested) {
+    // toggleStarLabels and toggleAsterisms guard on this.stars existing
+    // (the Stars instance, not the catalog).  On a permalink load the 0ms
+    // setTimeout in Celestiary.onDone can race the stars.json fetch — if
+    // earth.json wins, applySettings runs while this.stars is still null
+    // and the stars-dependent toggles silently no-op, leaving _settings.l
+    // and _settings.a stuck at their initial values.  Defer the whole
+    // apply pass until Stars is constructed; orbits / grids work either
+    // way, but doing them all at once keeps _settings coherent and gives
+    // a single permalink-update fire instead of two.
+    if (!this.stars) {
+      this.onStarsReady(() => this.applySettings(requested))
+      return
+    }
     const dispatch = {
       a: () => this.toggleAsterisms(),
       l: () => this.toggleStarLabels(),
@@ -102,6 +115,38 @@ export default class Scene {
       if (requested[key] !== undefined && requested[key] !== this._settings[key]) {
         dispatch[key]()
       }
+    }
+  }
+
+
+  /**
+   * Register a callback to fire when this.stars (the Stars instance) is
+   * constructed.  Fires synchronously if already set.  Used by
+   * applySettings to avoid the race described there.
+   *
+   * @param {Function} cb
+   */
+  onStarsReady(cb) {
+    if (this.stars) {
+      cb()
+      return
+    }
+    if (!this._starsReadyCbs) {
+      this._starsReadyCbs = []
+    }
+    this._starsReadyCbs.push(cb)
+  }
+
+
+  /** Internal: drain the stars-ready callback queue. */
+  _markStarsReady() {
+    const cbs = this._starsReadyCbs
+    this._starsReadyCbs = null
+    if (!cbs) {
+      return
+    }
+    for (const cb of cbs) {
+      cb()
     }
   }
 
@@ -145,7 +190,10 @@ export default class Scene {
   objectFactory(props) {
     switch (props.type) {
       case 'galaxy': return this.newGalaxy(props)
-      case 'stars': this.stars = new Stars(props, this.ui); return this.stars
+      case 'stars':
+        this.stars = new Stars(props, this.ui)
+        this._markStarsReady()
+        return this.stars
       case 'star': return new Star(props, this.objects, this.ui)
       case 'planet': return new Planet(this, props)
       case 'moon': return new Planet(this, props, true)

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -53,6 +53,63 @@ export default class Scene {
     this.stars = null
     this.asterisms = null
     this.orbitsVisible = true
+    // Toggleable settings.  Initialized to the runtime state right after
+    // Scene construction (before any user / firstTime toggle): asterisms
+    // and star labels are off (built / unhidden lazily); planet labels and
+    // orbits are visible by default; all reference grids are hidden.  Kept
+    // in sync by every toggle method below; surfaced for permalink
+    // round-tripping via getSettings() / applySettings().  Letter codes
+    // match permalink.js's SETTINGS_DEFAULTS.
+    this._settings = {
+      a: false, // asterisms
+      l: false, // star labels
+      p: true, // planet labels
+      o: true, // orbits
+      e: false, // equatorial grid
+      c: false, // ecliptic grid
+      g: false, // galactic grid
+    }
+    // Set by Celestiary; called whenever any settings flag flips so the
+    // permalink can be updated.
+    this.onSettingsChange = null
+  }
+
+
+  /** @returns {object} flat {key: bool} map matching permalink SETTINGS_DEFAULTS */
+  getSettings() {
+    return {...this._settings}
+  }
+
+
+  /**
+   * Drive each settings toggle to match the requested state, idempotently.
+   * Called at startup to reify either defaults or a permalink override; any
+   * key whose target value already matches the current value is a no-op.
+   *
+   * @param {object} requested flat {key: bool} map
+   */
+  applySettings(requested) {
+    const dispatch = {
+      a: () => this.toggleAsterisms(),
+      l: () => this.toggleStarLabels(),
+      p: () => this.togglePlanetLabels(),
+      o: () => this.toggleOrbits(),
+      e: () => this.toggleGridEquatorial(),
+      c: () => this.toggleGridEcliptic(),
+      g: () => this.toggleGridGalactic(),
+    }
+    for (const key of Object.keys(dispatch)) {
+      if (requested[key] !== undefined && requested[key] !== this._settings[key]) {
+        dispatch[key]()
+      }
+    }
+  }
+
+
+  /** Internal: flip a single key in _settings and notify the listener. */
+  _flipSetting(key) {
+    this._settings[key] = !this._settings[key]
+    this.onSettingsChange?.()
   }
 
 
@@ -388,11 +445,12 @@ export default class Scene {
         return
       }
       this._asterismsPending = true
+      this._flipSetting('a')
       this.stars.onCatalogReady(() => {
         const asterisms = new Asterisms(this.ui, this.stars, () => {
           this.stars.add(asterisms)
           this.asterisms = asterisms
-          this.asterisms.visible = true
+          this.asterisms.visible = this._settings.a
           this._asterismsPending = false
         })
       })
@@ -400,6 +458,7 @@ export default class Scene {
     }
     if (this.asterisms) {
       this.asterisms.visible = !this.asterisms.visible
+      this._flipSetting('a')
     }
   }
 
@@ -407,12 +466,14 @@ export default class Scene {
   /** */
   toggleOrbits() {
     Utils.visitSetProperty(this.objects['sun'], 'name', 'orbit', 'visible', this.orbitsVisible = !this.orbitsVisible)
+    this._flipSetting('o')
   }
 
 
   /** */
   togglePlanetLabels() {
     Utils.visitToggleProperty(this.objects['sun'], 'name', 'label LOD', 'visible')
+    this._flipSetting('p')
   }
 
 
@@ -420,6 +481,7 @@ export default class Scene {
   toggleStarLabels() {
     if (this.stars) {
       this.stars.labelLOD.visible = !this.stars.labelLOD.visible
+      this._flipSetting('l')
     }
   }
 
@@ -428,6 +490,7 @@ export default class Scene {
   toggleGridEquatorial() {
     if (this.grids) {
       this.grids.equatorial.visible = !this.grids.equatorial.visible
+      this._flipSetting('e')
     }
   }
 
@@ -436,6 +499,7 @@ export default class Scene {
   toggleGridEcliptic() {
     if (this.grids) {
       this.grids.ecliptic.visible = !this.grids.ecliptic.visible
+      this._flipSetting('c')
     }
   }
 
@@ -444,6 +508,7 @@ export default class Scene {
   toggleGridGalactic() {
     if (this.grids) {
       this.grids.galactic.visible = !this.grids.galactic.visible
+      this._flipSetting('g')
     }
   }
 

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -375,10 +375,26 @@ export default class Scene {
   /** */
   toggleAsterisms() {
     if (this.asterisms === null && this.stars !== null) {
-      const asterisms = new Asterisms(this.ui, this.stars, () => {
-        this.stars.add(asterisms)
-        this.asterisms = asterisms
-        this.asterisms.visible = true
+      // Defer the actual Asterisms construction until the stars catalog
+      // has loaded.  Without this, on permalink loads (which use a 0ms
+      // setTimeout in Celestiary.onDone) the asterism build runs against
+      // an empty starByHip map and silently produces zero line segments —
+      // so reload / permalink users would see no constellations even
+      // though the catalog itself was about to load fine.
+      // _asterismsPending guards against repeated toggle calls during the
+      // catalog-load window enqueueing duplicate callbacks (each would
+      // build its own Asterisms once ready).
+      if (this._asterismsPending) {
+        return
+      }
+      this._asterismsPending = true
+      this.stars.onCatalogReady(() => {
+        const asterisms = new Asterisms(this.ui, this.stars, () => {
+          this.stars.add(asterisms)
+          this.asterisms = asterisms
+          this.asterisms.visible = true
+          this._asterismsPending = false
+        })
       })
       return
     }

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -408,25 +408,6 @@ export default class Scene {
   }
 
 
-  /**
-   * Toggle the Ecliptic + Galactic reference grids together.  The two
-   * frames are the most useful pair for navigating outside the solar
-   * system: ecliptic gives "where am I relative to the planetary plane",
-   * galactic gives "where am I in the Milky Way".  Equatorial is left
-   * separate (rotates with Earth's spin axis, less useful for interstellar
-   * orientation).
-   */
-  toggleGridsOrientation() {
-    if (!this.grids) {
-      return
-    }
-    // Drive both off the ecliptic's state so they always match.
-    const next = !this.grids.ecliptic.visible
-    this.grids.ecliptic.visible = next
-    this.grids.galactic.visible = next
-  }
-
-
   /** */
   toggleGridEquatorial() {
     if (this.grids) {

--- a/js/scene/Scene.test.js
+++ b/js/scene/Scene.test.js
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'bun:test'
 import {Scene as ThreeScene} from 'three'
+import {SETTINGS_DEFAULTS} from '../permalink.js'
 import Scene from './Scene.js'
 
 
@@ -9,6 +10,36 @@ function makeScene() {
     addClickCb: () => {},
   }
   return new Scene(ui)
+}
+
+
+// Several toggle methods reach into scene.objects['sun'] / scene.stars; the
+// tests below wire up the smallest possible fakes that the toggle paths
+// actually touch (a label-LOD child for togglePlanetLabels, an LOD with a
+// boolean .visible for toggleStarLabels, etc).  fakeStars also satisfies
+// the contract toggleAsterisms expects: onCatalogReady never fires in
+// these tests, so asterisms construction is deferred forever — perfect for
+// exercising the bookkeeping (_asterismsPending, _settings.a flip) without
+// actually building Three.js geometry.
+function fakeStars() {
+  return {
+    labelLOD: {visible: false},
+    onCatalogReady: () => {},
+    add: () => {},
+  }
+}
+function fakeSunWithLabelLOD() {
+  // visitToggleProperty walks children searching for an object with
+  // name='label LOD' and toggles the boolean .visible.  The fake mirrors
+  // that contract.
+  return {
+    children: [{name: 'label LOD', visible: true}],
+  }
+}
+function fakeSunWithOrbit() {
+  return {
+    children: [{name: 'orbit', visible: true}],
+  }
 }
 
 
@@ -58,5 +89,176 @@ describe('Scene._pathFor', () => {
     s.objects['b'] = {props: {parent: 'a'}}
     const path = s._pathFor('a')
     expect(path.length).toBeLessThanOrEqual(2)
+  })
+})
+
+
+describe('Scene settings tracking', () => {
+  it('initial _settings reflects the runtime state, not the SETTINGS_DEFAULTS', () => {
+    // The default table is "what the user expects after firstTime" — but
+    // _settings starts from the constructor-fresh state (asterisms not yet
+    // built, star labels hidden, etc).  These intentionally differ for the
+    // a/l keys.
+    const s = makeScene()
+    expect(s.getSettings().a).toBe(false)
+    expect(s.getSettings().l).toBe(false)
+    expect(s.getSettings().p).toBe(true)
+    expect(s.getSettings().o).toBe(true)
+    expect(s.getSettings().e).toBe(false)
+    expect(s.getSettings().c).toBe(false)
+    expect(s.getSettings().g).toBe(false)
+    expect(s.getSettings().v).toBe(true)
+  })
+
+  it('every key in SETTINGS_DEFAULTS has a slot in Scene._settings', () => {
+    const s = makeScene()
+    const have = s.getSettings()
+    for (const key of Object.keys(SETTINGS_DEFAULTS)) {
+      expect(have).toHaveProperty(key)
+    }
+  })
+
+  it('toggleStarLabels flips the l flag and notifies onSettingsChange', () => {
+    const s = makeScene()
+    s.stars = fakeStars()
+    let fired = 0
+    s.onSettingsChange = () => fired++
+    s.toggleStarLabels()
+    expect(s.getSettings().l).toBe(true)
+    expect(s.stars.labelLOD.visible).toBe(true)
+    expect(fired).toBe(1)
+  })
+
+  it('toggleStarLabels is a no-op when stars is null and does not fire', () => {
+    const s = makeScene()
+    let fired = 0
+    s.onSettingsChange = () => fired++
+    s.toggleStarLabels()
+    expect(s.getSettings().l).toBe(false)
+    expect(fired).toBe(0)
+  })
+
+  it('toggleOrbits flips o, drives orbitsVisible, and walks attached planet orbits', () => {
+    const s = makeScene()
+    s.objects['sun'] = fakeSunWithOrbit()
+    s.toggleOrbits()
+    expect(s.getSettings().o).toBe(false)
+    expect(s.orbitsVisible).toBe(false)
+    expect(s.objects['sun'].children[0].visible).toBe(false)
+  })
+
+  it('togglePlanetLabels flips p and walks attached planet label LODs', () => {
+    const s = makeScene()
+    s.objects['sun'] = fakeSunWithLabelLOD()
+    s.togglePlanetLabels()
+    expect(s.getSettings().p).toBe(false)
+    expect(s.objects['sun'].children[0].visible).toBe(false)
+  })
+
+  it('toggleGridEquatorial / Ecliptic / Galactic flip e / c / g respectively', () => {
+    const s = makeScene()
+    s.toggleGridEquatorial()
+    s.toggleGridEcliptic()
+    s.toggleGridGalactic()
+    expect(s.getSettings().e).toBe(true)
+    expect(s.getSettings().c).toBe(true)
+    expect(s.getSettings().g).toBe(true)
+    expect(s.grids.equatorial.visible).toBe(true)
+    expect(s.grids.ecliptic.visible).toBe(true)
+    expect(s.grids.galactic.visible).toBe(true)
+  })
+})
+
+
+describe('Scene.applySettings', () => {
+  it('runs each toggle whose requested value differs from current', () => {
+    const s = makeScene()
+    s.stars = fakeStars()
+    s.objects['sun'] = {children: [
+      {name: 'label LOD', visible: true},
+      {name: 'orbit', visible: true},
+    ]}
+    s.applySettings({...SETTINGS_DEFAULTS, l: true, o: false})
+    expect(s.getSettings().l).toBe(true)
+    expect(s.getSettings().o).toBe(false)
+    expect(s.stars.labelLOD.visible).toBe(true)
+    expect(s.objects['sun'].children[1].visible).toBe(false)
+  })
+
+  it('is idempotent — re-applying the same state is a no-op', () => {
+    const s = makeScene()
+    s.stars = fakeStars()
+    s.applySettings({...SETTINGS_DEFAULTS, l: true})
+    expect(s.stars.labelLOD.visible).toBe(true)
+    let fired = 0
+    s.onSettingsChange = () => fired++
+    s.applySettings({...SETTINGS_DEFAULTS, l: true})
+    expect(fired).toBe(0)
+  })
+
+  it('defers the entire pass when this.stars is null, then runs once it is set', () => {
+    const s = makeScene()
+    s.objects['sun'] = {children: [{name: 'orbit', visible: true}]}
+    s.applySettings({...SETTINGS_DEFAULTS, o: false}) // stars not yet set
+    expect(s.objects['sun'].children[0].visible).toBe(true) // still visible — deferred
+    s.stars = fakeStars()
+    s._markStarsReady()
+    expect(s.objects['sun'].children[0].visible).toBe(false)
+    expect(s.getSettings().o).toBe(false)
+  })
+
+  it('dispatches custom appliers registered via registerSettingApplier', () => {
+    const s = makeScene()
+    s.stars = fakeStars()
+    let called = 0
+    s.registerSettingApplier('v', () => {
+      called++
+      s.flipSetting('v')
+    })
+    s.applySettings({...SETTINGS_DEFAULTS, v: false}) // current true → toggle
+    expect(called).toBe(1)
+    expect(s.getSettings().v).toBe(false)
+  })
+
+  it('round-trips a full settings map through getSettings → applySettings', () => {
+    const s = makeScene()
+    s.stars = fakeStars()
+    s.objects['sun'] = {children: [
+      {name: 'label LOD', visible: true},
+      {name: 'orbit', visible: true},
+    ]}
+    const target = {a: false, l: true, p: false, o: false, e: true, c: true, g: true, v: false}
+    s.registerSettingApplier('v', () => s.flipSetting('v'))
+    s.applySettings(target)
+    expect(s.getSettings()).toEqual(target)
+  })
+})
+
+
+describe('Scene.onStarsReady', () => {
+  it('fires synchronously when stars is already set', () => {
+    const s = makeScene()
+    s.stars = fakeStars()
+    let fired = false
+    s.onStarsReady(() => {
+      fired = true
+    })
+    expect(fired).toBe(true)
+  })
+
+  it('queues callbacks until _markStarsReady is called', () => {
+    const s = makeScene()
+    let fired = 0
+    s.onStarsReady(() => fired++)
+    s.onStarsReady(() => fired++)
+    expect(fired).toBe(0)
+    s.stars = fakeStars()
+    s._markStarsReady()
+    expect(fired).toBe(2)
+  })
+
+  it('_markStarsReady is a no-op when no callbacks are queued', () => {
+    const s = makeScene()
+    expect(() => s._markStarsReady()).not.toThrow()
   })
 })

--- a/js/scene/Stars.js
+++ b/js/scene/Stars.js
@@ -44,6 +44,14 @@ export default class Stars extends Object {
     this.labelLOD.addLevel(FAR_OBJ, STARS_RADIUS_METER)
     this.add(this.labelLOD)
     this.geom = null
+    // Catalog readiness signalling.  The catalog object is mutated in place
+    // during async load, so subscribing to starsCatalog identity in the
+    // store doesn't fire a change event — we maintain our own callback list
+    // that's drained once load completes.  Anyone needing a populated
+    // catalog (asterisms, search, etc) calls onCatalogReady(cb) and gets
+    // either an immediate dispatch (if already loaded) or a deferred one.
+    this._catalogReady = false
+    this._catalogReadyCbs = []
 
     // Used by guide/Asterisms.jsx to center camera.
     this.labelCenterPosByName = {}
@@ -58,6 +66,7 @@ export default class Stars extends Object {
         this.showLabels()
       }
       this.ui.useStore.setState({starsCatalog: this.catalog})
+      this._markCatalogReady()
     } else {
       this.catalog = new StarsCatalog()
       // Expose the (empty) catalog immediately so About / search wiring can
@@ -69,7 +78,36 @@ export default class Stars extends Object {
         this.show()
         this.showLabels()
         this.ui.useStore.setState({starsCatalog: this.catalog})
+        this._markCatalogReady()
       })
+    }
+  }
+
+
+  /**
+   * Register a callback to fire once the stars catalog has finished
+   * loading.  If already loaded, fires synchronously.  Used by
+   * Scene.toggleAsterisms to avoid building an empty asterism geometry
+   * (would happen on a permalink load that races the catalog fetch).
+   *
+   * @param {Function} cb
+   */
+  onCatalogReady(cb) {
+    if (this._catalogReady) {
+      cb()
+      return
+    }
+    this._catalogReadyCbs.push(cb)
+  }
+
+
+  /** Internal: drain the readiness callback queue. */
+  _markCatalogReady() {
+    this._catalogReady = true
+    const cbs = this._catalogReadyCbs
+    this._catalogReadyCbs = []
+    for (const cb of cbs) {
+      cb()
     }
   }
 

--- a/js/scene/atmos/Atmosphere.js
+++ b/js/scene/atmos/Atmosphere.js
@@ -350,6 +350,10 @@ export function newAtmospherePass() {
       uUseTransmittanceLUT: {value: 0.0},
       tInScatter: {value: null},
       uUseInScatterLUT: {value: 0.0},
+      // Hard kill-switch.  When false the shader composites the scene RT
+      // unchanged — no rsi(), no scatter, no risk of float32 overflow at
+      // interstellar distances.  Set by ThreeUI._updateAtmUniforms.
+      uAtmEnabled: {value: 0.0},
     },
     vertexShader: FULLSCREEN_VERT,
     fragmentShader: FULLSCREEN_FRAG,
@@ -395,6 +399,7 @@ uniform sampler2D tTransmittance;
 uniform float     uUseTransmittanceLUT;
 uniform sampler2D tInScatter;
 uniform float     uUseInScatterLUT;
+uniform float     uAtmEnabled;
 
 #define PI        3.141592
 #define I_STEPS   64
@@ -546,6 +551,15 @@ vec4 scatter(
 }
 
 void main() {
+  // Hard kill-switch: when the camera is too far for the in-shader rsi() to
+  // remain numerically stable (or there's simply no atmosphere target), pass
+  // the scene through unchanged.  Must happen before any rsi() / scatter()
+  // call — eyePos² overflows float32 once |eyePos| ≳ 1.8e19 m, and a sentinel
+  // "push planet far away" value would itself trip that limit.
+  if (uAtmEnabled < 0.5) {
+    gl_FragColor = texture2D(tDiffuse, vUv);
+    return;
+  }
   vec2 ndc = vUv * 2.0 - 1.0;
   float depthSample = texture2D(tDepth, vUv).r;
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -24,6 +24,10 @@ export const ASTRO_UNIT_METER = 149597870700
 export const INITIAL_FOV = 45
 // largest coords for stars in Celestia dataset
 export const STARS_RADIUS_METER = LIGHTYEAR_METER * 1e4
+// Outer radius of the procedural Milky Way (see scene/MilkyWay.js).  Camera
+// far-plane is sized off this so the whole galaxy + a navigation buffer fits
+// without clipping when zoomed out.
+export const GALAXY_RADIUS_METER = LIGHTYEAR_METER * 5e4
 // This size is chosen to allow for the maximum object and distance size range
 // in the scene.  The smallest object in the scene is Mars's moon Deimos, which
 // is 6.2e3m, but going a bit smaller to allow zoom in on it as well.

--- a/js/ui/Settings.jsx
+++ b/js/ui/Settings.jsx
@@ -28,6 +28,12 @@ export default function Settings({keys, href = '~/'}) {
             {keys.msgs[key]}
           </li>
         ))}
+        {(keys.actions ?? []).map((action, ndx) => (
+          <li key={`action-${ndx}`}>
+            <Button onClick={action.fn}>•</Button>
+            {action.msg}
+          </li>
+        ))}
       </ul>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

- **Reference-frame grids** (equatorial / ecliptic / galactic), each toggleable independently. Celestia-style edge-anchored sliding labels — parabolic sub-sample interpolation + direction-filtered brackets so labels glide smoothly along screen edges instead of snapping (`EDGE_SAMPLES = 96`).
- **Procedural Milky Way galaxy** as a background point cloud: barred-spiral with 4 arms, oriented in the galactic plane (60.187° from ecliptic), Sun anchored on a spiral arm at ~26 kly galactocentric radius. Uses RTE (high/low float32 split) so positions stay precise across `WorldGroup` rebases. Arm thickness tapers from bar-width at the inner radius to a thin spiral lane at the rim.
- **Permalink settings**: scene toggles (asterisms / star labels / orbits / planet labels / grids / nav UI) round-trip through the URL hash as `s=<flags>`. Reload preserves state.
- **Presentation-mode toggle**: `Shift+V` hides all scene annotations (snapshot/restore); `v` still toggles the nav UI as before. Made key dispatch case-sensitive so `v` and `V` can bind to different actions.
- **Atmosphere fix**: skip the post-process pass when no atmospheric body is in front of the camera. Removes the float32 overflow in `rsi()` that produced a giant glow sphere when zooming out from Earth past interstellar distances.
- **Misc**: `camera.js` JSDoc imports, `Stars.onCatalogReady` hook to fix asterism / permalink races against the async catalog load.

## Test plan
- [x] Toggle grids (`;` equatorial, `'` ecliptic, `g` galactic) — labels glide along screen edges without snapping as the camera rotates
- [x] Set scene toggles, copy URL, reload — state restores correctly
- [x] Press `V` — all scene info hides; press again to restore
- [x] Zoom out from Earth to interstellar distances — no glow-sphere artifact
- [x] Galaxy renders as a tilted barred spiral; local catalog stars sit inside the cloud
- [x] `bun test` — 221 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)