### PR TITLE
fix: drag-to-rotate broken on mobile (mouse → pointer events)

### DIFF
--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -16,6 +16,7 @@ import {
 import {newAtmospherePass} from './scene/atmos/Atmosphere'
 import {precomputeTransmittance, precomputeInScatter} from './scene/atmos/AtmospherePrecompute'
 import {TrackballControls} from 'three/examples/jsm/controls/TrackballControls.js'
+import {attachPointerDrag} from './dragControls'
 import Fullscreen from '@pablo-mayrgundter/fullscreen.js/fullscreen.js'
 import {GALAXY_RADIUS_METER, INITIAL_FOV, SMALLEST_SIZE_METER, SUN_RADIUS_METER, targets} from './shared.js'
 import {named} from './utils.js'
@@ -88,11 +89,9 @@ export default class ThreeUi {
 
     this._arrowKeys = {up: false, down: false, left: false, right: false}
     this._savedCamQuat = new Quaternion() // preserved across controls.update()
-    this._orbitAxis = new Vector3() // pre-allocated for orbit drag
-    this._orbitRot = new Quaternion() // pre-allocated for orbit drag
     this.onCameraChange = null // set by Celestiary to schedule permalink updates
     this._initArrowKeys()
-    this._initMouseDrag()
+    attachPointerDrag(this.threeContainer, this.camera, () => this.onCameraChange?.())
 
     this.renderer.setAnimationLoop((time) => {
       this.renderLoop(time)
@@ -297,61 +296,6 @@ export default class ThreeUi {
       if (map[e.key] !== undefined) {
         this._arrowKeys[map[e.key]] = false
       }
-    })
-  }
-
-
-  /**
-   * Plain drag     → pitch/yaw camera around its local axes.
-   * Option+drag    → orbit: rotate camera.position around the platform origin,
-   *                  then lookAt the planet center. Fully manual so successive
-   *                  drags accumulate without TrackballControls state resets.
-   */
-  _initMouseDrag() {
-    let lastX = 0
-    let lastY = 0
-
-    this.threeContainer.addEventListener('mousedown', (e) => {
-      if (e.button !== 0) {
-        return
-      }
-      lastX = e.clientX
-      lastY = e.clientY
-      if (e.altKey) {
-        e.preventDefault()
-      } // suppress browser Alt menu
-    })
-
-    window.addEventListener('mousemove', (e) => {
-      if (!e.buttons) {
-        return
-      }
-      const dx = e.clientX - lastX
-      const dy = e.clientY - lastY
-      lastX = e.clientX
-      lastY = e.clientY
-      const speed = 0.005 // radians per pixel
-
-      if (e.altKey) {
-        // Orbit: rotate camera as a rigid body around the platform origin
-        // (planet center). Apply each rotation to both position AND quaternion
-        // so the view direction stays consistent with the new orbital position.
-        // Horizontal → around platform-local Y
-        this._orbitAxis.set(0, 1, 0)
-        this._orbitRot.setFromAxisAngle(this._orbitAxis, -dx * speed)
-        this.camera.position.applyQuaternion(this._orbitRot)
-        this.camera.quaternion.premultiply(this._orbitRot)
-        // Vertical → around camera's current right axis
-        this._orbitAxis.set(1, 0, 0).applyQuaternion(this.camera.quaternion)
-        this._orbitRot.setFromAxisAngle(this._orbitAxis, -dy * speed)
-        this.camera.position.applyQuaternion(this._orbitRot)
-        this.camera.quaternion.premultiply(this._orbitRot)
-      } else {
-        // Free look: pitch/yaw camera around its own local axes.
-        this.camera.rotateY(-dx * speed)
-        this.camera.rotateX(-dy * speed)
-      }
-      this.onCameraChange?.()
     })
   }
 

--- a/js/dragControls.js
+++ b/js/dragControls.js
@@ -1,0 +1,87 @@
+import {Quaternion, Vector3} from 'three'
+
+
+/**
+ * Attach pointer-driven camera drag to a DOM element.  Single-pointer drag
+ * rotates the camera (free look or alt-orbit); a second simultaneous
+ * pointer is ignored so it can flow through to TrackballControls for
+ * pinch-zoom.
+ *
+ * Pointer events are used (not mouse events) so the same handler covers
+ * mouse, pen, and touch — the original mousedown/mousemove implementation
+ * silently dropped touch input on mobile.  setPointerCapture redirects
+ * subsequent pointermove events to the element regardless of where the
+ * pointer actually is, so dragging past the canvas edge keeps tracking.
+ *
+ * Plain drag    → pitch/yaw camera around its local axes.
+ * Option+drag   → orbit: rotate camera.position around the platform origin
+ *                 and apply the same rotation to camera.quaternion so view
+ *                 direction stays consistent with the new orbital position.
+ *
+ * @param {HTMLElement} el The container to bind events on.
+ * @param {object} camera A three.js Camera (uses .rotateX/.rotateY for
+ *   free look; .position and .quaternion for alt-orbit).
+ * @param {Function} [onChange] Called after each rotation update.
+ */
+export function attachPointerDrag(el, camera, onChange) {
+  let lastX = 0
+  let lastY = 0
+  let activePointerId = null
+  const orbitAxis = new Vector3()
+  const orbitRot = new Quaternion()
+
+  // Suppress browser touch gestures (pan / pinch-to-zoom-page / double-tap-zoom)
+  // on the canvas so single-finger drags reach our handler instead of being
+  // consumed by the page itself.
+  el.style.touchAction = 'none'
+
+  el.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 || activePointerId !== null) {
+      return
+    }
+    activePointerId = e.pointerId
+    lastX = e.clientX
+    lastY = e.clientY
+    el.setPointerCapture?.(e.pointerId)
+    if (e.altKey) {
+      e.preventDefault()
+    } // suppress browser Alt menu
+  })
+
+  const onPointerEnd = (e) => {
+    if (e.pointerId === activePointerId) {
+      activePointerId = null
+    }
+  }
+  el.addEventListener('pointerup', onPointerEnd)
+  el.addEventListener('pointercancel', onPointerEnd)
+
+  el.addEventListener('pointermove', (e) => {
+    if (e.pointerId !== activePointerId) {
+      return
+    }
+    const dx = e.clientX - lastX
+    const dy = e.clientY - lastY
+    lastX = e.clientX
+    lastY = e.clientY
+    const speed = 0.005 // radians per pixel
+
+    if (e.altKey) {
+      // Horizontal → around platform-local Y
+      orbitAxis.set(0, 1, 0)
+      orbitRot.setFromAxisAngle(orbitAxis, -dx * speed)
+      camera.position.applyQuaternion(orbitRot)
+      camera.quaternion.premultiply(orbitRot)
+      // Vertical → around camera's current right axis
+      orbitAxis.set(1, 0, 0).applyQuaternion(camera.quaternion)
+      orbitRot.setFromAxisAngle(orbitAxis, -dy * speed)
+      camera.position.applyQuaternion(orbitRot)
+      camera.quaternion.premultiply(orbitRot)
+    } else {
+      // Free look: pitch/yaw camera around its own local axes.
+      camera.rotateY(-dx * speed)
+      camera.rotateX(-dy * speed)
+    }
+    onChange?.()
+  })
+}

--- a/js/dragControls.test.js
+++ b/js/dragControls.test.js
@@ -1,0 +1,134 @@
+import {describe, expect, it, mock} from 'bun:test'
+import {PerspectiveCamera} from 'three'
+import {attachPointerDrag} from './dragControls'
+
+
+/** Minimal stand-in for an HTMLElement: records handlers so tests can fire them. */
+function makeFakeElement() {
+  const handlers = {}
+  return {
+    style: {},
+    handlers,
+    addEventListener: (name, fn) => {
+      handlers[name] = fn
+    },
+    setPointerCapture: () => {},
+    fire: (name, ev) => handlers[name]?.(ev),
+  }
+}
+
+
+describe('attachPointerDrag', () => {
+  it('binds pointer events — not mouse events — so touch input drives camera drag', () => {
+    // Regression guard: mobile-broken drag came from binding mousedown /
+    // mousemove, which don't fire from touch.  Pointer events cover mouse,
+    // pen, and touch with one API.
+    const el = makeFakeElement()
+    attachPointerDrag(el, new PerspectiveCamera())
+    expect(el.handlers.pointerdown).toBeDefined()
+    expect(el.handlers.pointermove).toBeDefined()
+    expect(el.handlers.pointerup).toBeDefined()
+    expect(el.handlers.pointercancel).toBeDefined()
+    expect(el.handlers.mousedown).toBeUndefined()
+    expect(el.handlers.mousemove).toBeUndefined()
+  })
+
+  it('sets touch-action: none so the browser does not eat single-finger drags', () => {
+    const el = makeFakeElement()
+    attachPointerDrag(el, new PerspectiveCamera())
+    expect(el.style.touchAction).toBe('none')
+  })
+
+  it('rotates the camera quaternion in response to a pointerdown + pointermove sequence', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    const startQuat = camera.quaternion.clone()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+
+    expect(camera.quaternion.equals(startQuat)).toBe(false)
+  })
+
+  it('invokes onChange exactly once per pointermove', () => {
+    const el = makeFakeElement()
+    const onChange = mock()
+    attachPointerDrag(el, new PerspectiveCamera(), onChange)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 160, clientY: 140, altKey: false})
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores pointermove with no matching pointerdown (e.g. stray events)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    const startQuat = camera.quaternion.clone()
+    const onChange = mock()
+    attachPointerDrag(el, camera, onChange)
+
+    el.fire('pointermove', {pointerId: 99, clientX: 10, clientY: 10, altKey: false})
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(camera.quaternion.equals(startQuat)).toBe(true)
+  })
+
+  it('ignores a second simultaneous pointer so pinch-zoom flows to TrackballControls', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    const afterFirst = camera.quaternion.clone()
+
+    // Second finger lands while first is still down — should be ignored.
+    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 200, clientY: 200, altKey: false})
+    el.fire('pointermove', {pointerId: 2, clientX: 250, clientY: 250, altKey: false})
+
+    expect(camera.quaternion.equals(afterFirst)).toBe(true)
+  })
+
+  it('releases the active pointer on pointerup so the next press can claim it', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointerup', {pointerId: 1})
+    // After release, a different pointerId can take over.
+    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 50, clientY: 50, altKey: false})
+    const beforeMove = camera.quaternion.clone()
+    el.fire('pointermove', {pointerId: 2, clientX: 100, clientY: 80, altKey: false})
+
+    expect(camera.quaternion.equals(beforeMove)).toBe(false)
+  })
+
+  it('alt+drag orbits camera position (rigid-body rotation around platform origin)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(10, 0, 0)
+    const startPos = camera.position.clone()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown',
+        {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: true, preventDefault: () => {}})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100, altKey: true})
+
+    expect(camera.position.equals(startPos)).toBe(false)
+  })
+
+  it('ignores non-primary mouse buttons (right-click, middle-click)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    const startQuat = camera.quaternion.clone()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 2, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+
+    expect(camera.quaternion.equals(startQuat)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Drag-to-rotate did nothing on mobile — `mousedown` / `mousemove` don't fire from touch input, so single-finger drags were silently dropped.  Pinch-zoom still worked because `TrackballControls` already handles its own touch events.
- Switched the custom drag handler to `pointerdown` / `pointermove`, which cover mouse, pen, and touch with one API.  Added `setPointerCapture` so dragging past the canvas edge keeps tracking (replaces the old window-level `mousemove` fallback).  Set `touch-action: none` on the canvas so the browser doesn't claim single-finger drags as page scrolling.  Track only the first active pointer; a second simultaneous touch is ignored here so it can flow through to `TrackballControls` for pinch-zoom.
- Extracted the handler from `ThreeUI._initMouseDrag` into `js/dragControls.js#attachPointerDrag` so it can be unit-tested in isolation.  `js/dragControls.test.js` covers the regression directly (asserts pointer events are bound, not mouse events) plus drag behavior, secondary-pointer ignoring, alt-orbit, and pointer release.

## Test plan
- [x] On mobile: single-finger drag rotates the camera; pinch zooms
- [x] On desktop: mouse drag still rotates; alt+drag still orbits; mouse wheel still zooms
- [x] `bun test` — all 230 tests pass (9 new in `dragControls.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)