### PR TITLE
Context-aware drag mode toggle (auto / pan / orbit)

### DIFF
--- a/js/App.jsx
+++ b/js/App.jsx
@@ -7,6 +7,7 @@ import Stack from '@mui/material/Stack'
 import Celestiary from './Celestiary'
 import useStore from './store/useStore'
 import About from './ui/About'
+import DragModeToggle from './ui/DragModeToggle'
 import SearchBar from './ui/SearchBar'
 import Settings from './ui/Settings'
 import TimePanel from './ui/TimePanel'
@@ -60,6 +61,7 @@ export default function App() {
       </div>
       <Stack id='top-right' className='panel' direction='column' justifyContent='flex-start' alignItems='flex-end'>
         {celestiary && <TimePanel time={celestiary.time} timeStr={timeStr} isPaused={isPaused} setIsPaused={setIsPaused}/>}
+        {celestiary && <DragModeToggle/>}
         <div id='text-buttons'>
           {celestiary &&
             <Box sx={{position: 'fixed', bottom: 0, left: 0, m: '1em'}}>

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -343,6 +343,12 @@ export default class Celestiary {
       this.scene.toggleGridEquatorial()
     },
     'Show/hide equatorial reference grid')
+    k.map('m', () => {
+      const s = useStore.getState()
+      const next = {auto: 'pan', pan: 'orbit', orbit: 'auto'}[s.dragMode] ?? 'auto'
+      s.setDragMode(next)
+    },
+    'Cycle camera drag mode (Auto / Drag Pan / Move)')
     // No keys for ecliptic / galactic per Celestia convention; click-only
     // entries appear in Settings after the keyed shortcuts.
     k.addAction(() => {

--- a/js/Celestiary.test.js
+++ b/js/Celestiary.test.js
@@ -191,9 +191,18 @@ mock.module('./vsop', () => ({
 
 // Zustand-like useStore stub: callable hook + getState/setState/subscribe.
 // Real Celestiary reaches into store.getState() to push state (e.g. committedPath).
+// Setters are arrow fns mutating the closed-over state object — matching real
+// zustand's pattern where setters don't depend on `this`.
 function makeStubStore() {
   const state = {
     setCommittedPath: () => {},
+    dragMode: 'pan',
+    // Recorded: tests can read state.dragModeCalls to assert auto-pick fired.
+    dragModeCalls: [],
+  }
+  state.setDragMode = (m) => {
+    state.dragMode = m
+    state.dragModeCalls.push(m)
   }
   const hook = () => ({})
   hook.getState = () => state
@@ -393,6 +402,16 @@ describe('Scene.goTo navigation', () => {
 
     it('reparents camera platform to sun.orbitPosition', () => {
       expect(app2.ui.camera.platform.parent).toBe(sunObj.orbitPosition)
+    })
+
+    it('resets dragMode to \'auto\' on planet navigation', () => {
+      // dragControls re-evaluates pickDragMode at the next pointerdown
+      // against the actual final camera position — covers both the
+      // normal goTo arrival (orbit altitude) and permalink restores
+      // that land the camera on the surface.
+      const calls = app2.useStore.getState().dragModeCalls
+      expect(calls.length).toBeGreaterThan(0)
+      expect(calls[calls.length - 1]).toBe('auto')
     })
   })
 

--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -17,6 +17,7 @@ import {newAtmospherePass} from './scene/atmos/Atmosphere'
 import {precomputeTransmittance, precomputeInScatter} from './scene/atmos/AtmospherePrecompute'
 import {TrackballControls} from 'three/examples/jsm/controls/TrackballControls.js'
 import {attachPointerDrag} from './dragControls'
+import {resolveDragMode} from './dragMode'
 import Fullscreen from '@pablo-mayrgundter/fullscreen.js/fullscreen.js'
 import {GALAXY_RADIUS_METER, INITIAL_FOV, SMALLEST_SIZE_METER, SUN_RADIUS_METER, targets} from './shared.js'
 import {named} from './utils.js'
@@ -91,7 +92,13 @@ export default class ThreeUi {
     this._savedCamQuat = new Quaternion() // preserved across controls.update()
     this.onCameraChange = null // set by Celestiary to schedule permalink updates
     this._initArrowKeys()
-    attachPointerDrag(this.threeContainer, this.camera, () => this.onCameraChange?.())
+    attachPointerDrag(this.threeContainer, this.camera, {
+      onChange: () => this.onCameraChange?.(),
+      // useStore and Shared.targets are populated by Celestiary after
+      // ThreeUI construction; both accessors run lazily at pointerdown.
+      getDragMode: () => this.useStore?.getState().dragMode,
+      getTarget: () => targets.obj,
+    })
 
     this.renderer.setAnimationLoop((time) => {
       this.renderLoop(time)
@@ -274,12 +281,34 @@ export default class ThreeUi {
       }
     }
     this._applyCameraArrowKeys()
+    this._publishEffectiveDragMode()
     // Render scene to RT, then composite atmosphere fullscreen pass to screen
     this.renderer.setRenderTarget(this._sceneRT)
     this.renderer.render(this.scene, this.camera)
     this.renderer.setRenderTarget(null)
     this._updateAtmUniforms()
     this.renderer.render(this._atmScene, this._atmCamera)
+  }
+
+
+  /**
+   * Resolve the user's drag-mode intent to a concrete `'pan'` or
+   * `'orbit'` for the current camera/target context and write it into
+   * the store so the UI toggle can highlight whichever mode is active
+   * right now — including when the user-facing `dragMode` is `'auto'`
+   * and the resolution shifts as the camera moves (zoom, navigation).
+   * Zustand's default Object.is selector check skips the re-render when
+   * the value hasn't changed, so this is cheap to call every frame.
+   */
+  _publishEffectiveDragMode() {
+    const state = this.useStore?.getState()
+    if (!state?.setEffectiveDragMode) {
+      return
+    }
+    const next = resolveDragMode(state.dragMode, this.camera.position.length(), targets.obj)
+    if (next !== state.effectiveDragMode) {
+      state.setEffectiveDragMode(next)
+    }
   }
 
 

--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -16,6 +16,7 @@ import {
 import {newAtmospherePass} from './scene/atmos/Atmosphere'
 import {precomputeTransmittance, precomputeInScatter} from './scene/atmos/AtmospherePrecompute'
 import {TrackballControls} from 'three/examples/jsm/controls/TrackballControls.js'
+import {attachPointerDrag} from './dragControls'
 import Fullscreen from '@pablo-mayrgundter/fullscreen.js/fullscreen.js'
 import {GALAXY_RADIUS_METER, INITIAL_FOV, SMALLEST_SIZE_METER, SUN_RADIUS_METER, targets} from './shared.js'
 import {named} from './utils.js'
@@ -88,11 +89,9 @@ export default class ThreeUi {
 
     this._arrowKeys = {up: false, down: false, left: false, right: false}
     this._savedCamQuat = new Quaternion() // preserved across controls.update()
-    this._orbitAxis = new Vector3() // pre-allocated for orbit drag
-    this._orbitRot = new Quaternion() // pre-allocated for orbit drag
     this.onCameraChange = null // set by Celestiary to schedule permalink updates
     this._initArrowKeys()
-    this._initMouseDrag()
+    attachPointerDrag(this.threeContainer, this.camera, () => this.onCameraChange?.())
 
     this.renderer.setAnimationLoop((time) => {
       this.renderLoop(time)
@@ -297,61 +296,6 @@ export default class ThreeUi {
       if (map[e.key] !== undefined) {
         this._arrowKeys[map[e.key]] = false
       }
-    })
-  }
-
-
-  /**
-   * Plain drag     → pitch/yaw camera around its local axes.
-   * Option+drag    → orbit: rotate camera.position around the platform origin,
-   *                  then lookAt the planet center. Fully manual so successive
-   *                  drags accumulate without TrackballControls state resets.
-   */
-  _initMouseDrag() {
-    let lastX = 0
-    let lastY = 0
-
-    this.threeContainer.addEventListener('mousedown', (e) => {
-      if (e.button !== 0) {
-        return
-      }
-      lastX = e.clientX
-      lastY = e.clientY
-      if (e.altKey) {
-        e.preventDefault()
-      } // suppress browser Alt menu
-    })
-
-    window.addEventListener('mousemove', (e) => {
-      if (!e.buttons) {
-        return
-      }
-      const dx = e.clientX - lastX
-      const dy = e.clientY - lastY
-      lastX = e.clientX
-      lastY = e.clientY
-      const speed = 0.005 // radians per pixel
-
-      if (e.altKey) {
-        // Orbit: rotate camera as a rigid body around the platform origin
-        // (planet center). Apply each rotation to both position AND quaternion
-        // so the view direction stays consistent with the new orbital position.
-        // Horizontal → around platform-local Y
-        this._orbitAxis.set(0, 1, 0)
-        this._orbitRot.setFromAxisAngle(this._orbitAxis, -dx * speed)
-        this.camera.position.applyQuaternion(this._orbitRot)
-        this.camera.quaternion.premultiply(this._orbitRot)
-        // Vertical → around camera's current right axis
-        this._orbitAxis.set(1, 0, 0).applyQuaternion(this.camera.quaternion)
-        this._orbitRot.setFromAxisAngle(this._orbitAxis, -dy * speed)
-        this.camera.position.applyQuaternion(this._orbitRot)
-        this.camera.quaternion.premultiply(this._orbitRot)
-      } else {
-        // Free look: pitch/yaw camera around its own local axes.
-        this.camera.rotateY(-dx * speed)
-        this.camera.rotateX(-dy * speed)
-      }
-      this.onCameraChange?.()
     })
   }
 

--- a/js/dragControls.js
+++ b/js/dragControls.js
@@ -1,11 +1,11 @@
 import {Quaternion, Vector3} from 'three'
+import {resolveDragMode} from './dragMode'
 
 
 /**
  * Attach pointer-driven camera drag to a DOM element.  Single-pointer drag
- * rotates the camera (free look or alt-orbit); a second simultaneous
- * pointer is ignored so it can flow through to TrackballControls for
- * pinch-zoom.
+ * rotates the camera; a second simultaneous pointer is ignored so it can
+ * flow through to TrackballControls for pinch-zoom.
  *
  * Pointer events are used (not mouse events) so the same handler covers
  * mouse, pen, and touch — the original mousedown/mousemove implementation
@@ -13,20 +13,38 @@ import {Quaternion, Vector3} from 'three'
  * subsequent pointermove events to the element regardless of where the
  * pointer actually is, so dragging past the canvas edge keeps tracking.
  *
- * Plain drag    → pitch/yaw camera around its local axes.
- * Option+drag   → orbit: rotate camera.position around the platform origin
- *                 and apply the same rotation to camera.quaternion so view
- *                 direction stays consistent with the new orbital position.
+ * Drag behavior is mode-driven.  Mode is resolved at pointerdown and
+ * latched for the gesture (no mid-drag flip).  Three modes:
+ * - `'pan'`    → pitch/yaw camera around its local axes (free look,
+ *                natural on a planet surface looking at the sky).
+ * - `'orbit'`  → rotate camera.position around the platform origin and
+ *                apply the same rotation to camera.quaternion (natural
+ *                when viewing a planet from space).
+ * - `'auto'`   → pick `'pan'` or `'orbit'` via `pickDragMode` using the
+ *                current camera-to-target distance.  This follows the
+ *                viewing context as the camera moves (zoom, navigation)
+ *                without the user thinking about it.
+ *
+ * Alt held at pointerdown inverts the resolved mode for that gesture
+ * (pan ↔ orbit), useful as a one-shot override on desktop.
  *
  * @param {HTMLElement} el The container to bind events on.
  * @param {object} camera A three.js Camera (uses .rotateX/.rotateY for
- *   free look; .position and .quaternion for alt-orbit).
- * @param {Function} [onChange] Called after each rotation update.
+ *   pan; .position and .quaternion for orbit).
+ * @param {object} [options]
+ * @param {Function} [options.onChange] Called after each rotation update.
+ * @param {Function} [options.getDragMode] Returns `'pan'`, `'orbit'`, or
+ *   `'auto'`.  Treated as `'auto'` when omitted.
+ * @param {Function} [options.getTarget] Returns the current target object
+ *   (with `.props.radius.scalar` and optional `.props.atmosphere.height.scalar`).
+ *   Required for `'auto'` to resolve to anything other than `'pan'`.
  */
-export function attachPointerDrag(el, camera, onChange) {
+export function attachPointerDrag(el, camera, options = {}) {
+  const {onChange, getDragMode, getTarget} = options
   let lastX = 0
   let lastY = 0
   let activePointerId = null
+  let activeMode = 'pan'
   const orbitAxis = new Vector3()
   const orbitRot = new Quaternion()
 
@@ -40,12 +58,14 @@ export function attachPointerDrag(el, camera, onChange) {
       return
     }
     activePointerId = e.pointerId
+    activeMode = resolveMode(getDragMode?.(), camera, getTarget?.())
+    if (e.altKey) {
+      activeMode = activeMode === 'orbit' ? 'pan' : 'orbit'
+      e.preventDefault() // suppress browser Alt menu on the canvas
+    }
     lastX = e.clientX
     lastY = e.clientY
     el.setPointerCapture?.(e.pointerId)
-    if (e.altKey) {
-      e.preventDefault()
-    } // suppress browser Alt menu
   })
 
   const onPointerEnd = (e) => {
@@ -66,7 +86,7 @@ export function attachPointerDrag(el, camera, onChange) {
     lastY = e.clientY
     const speed = 0.005 // radians per pixel
 
-    if (e.altKey) {
+    if (activeMode === 'orbit') {
       // Horizontal → around platform-local Y
       orbitAxis.set(0, 1, 0)
       orbitRot.setFromAxisAngle(orbitAxis, -dx * speed)
@@ -78,10 +98,25 @@ export function attachPointerDrag(el, camera, onChange) {
       camera.position.applyQuaternion(orbitRot)
       camera.quaternion.premultiply(orbitRot)
     } else {
-      // Free look: pitch/yaw camera around its own local axes.
+      // Pan / free look: pitch/yaw camera around its own local axes.
       camera.rotateY(-dx * speed)
       camera.rotateX(-dy * speed)
     }
     onChange?.()
   })
+}
+
+
+/**
+ * Wrap `resolveDragMode` for the dragControls context.  `camera.position.length()`
+ * is the camera-to-target distance because the platform is parented to
+ * the target's local frame (target center = local origin).
+ *
+ * @param {string} stored
+ * @param {object} camera
+ * @param {object} target
+ * @returns {'pan'|'orbit'}
+ */
+function resolveMode(stored, camera, target) {
+  return resolveDragMode(stored, camera.position.length(), target)
 }

--- a/js/dragControls.js
+++ b/js/dragControls.js
@@ -1,0 +1,87 @@
+import {Quaternion, Vector3} from 'three'
+
+
+/**
+ * Attach pointer-driven camera drag to a DOM element.  Single-pointer drag
+ * rotates the camera (free look or alt-orbit); a second simultaneous
+ * pointer is ignored so it can flow through to TrackballControls for
+ * pinch-zoom.
+ *
+ * Pointer events are used (not mouse events) so the same handler covers
+ * mouse, pen, and touch — the original mousedown/mousemove implementation
+ * silently dropped touch input on mobile.  setPointerCapture redirects
+ * subsequent pointermove events to the element regardless of where the
+ * pointer actually is, so dragging past the canvas edge keeps tracking.
+ *
+ * Plain drag    → pitch/yaw camera around its local axes.
+ * Option+drag   → orbit: rotate camera.position around the platform origin
+ *                 and apply the same rotation to camera.quaternion so view
+ *                 direction stays consistent with the new orbital position.
+ *
+ * @param {HTMLElement} el The container to bind events on.
+ * @param {object} camera A three.js Camera (uses .rotateX/.rotateY for
+ *   free look; .position and .quaternion for alt-orbit).
+ * @param {Function} [onChange] Called after each rotation update.
+ */
+export function attachPointerDrag(el, camera, onChange) {
+  let lastX = 0
+  let lastY = 0
+  let activePointerId = null
+  const orbitAxis = new Vector3()
+  const orbitRot = new Quaternion()
+
+  // Suppress browser touch gestures (pan / pinch-to-zoom-page / double-tap-zoom)
+  // on the canvas so single-finger drags reach our handler instead of being
+  // consumed by the page itself.
+  el.style.touchAction = 'none'
+
+  el.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 || activePointerId !== null) {
+      return
+    }
+    activePointerId = e.pointerId
+    lastX = e.clientX
+    lastY = e.clientY
+    el.setPointerCapture?.(e.pointerId)
+    if (e.altKey) {
+      e.preventDefault()
+    } // suppress browser Alt menu
+  })
+
+  const onPointerEnd = (e) => {
+    if (e.pointerId === activePointerId) {
+      activePointerId = null
+    }
+  }
+  el.addEventListener('pointerup', onPointerEnd)
+  el.addEventListener('pointercancel', onPointerEnd)
+
+  el.addEventListener('pointermove', (e) => {
+    if (e.pointerId !== activePointerId) {
+      return
+    }
+    const dx = e.clientX - lastX
+    const dy = e.clientY - lastY
+    lastX = e.clientX
+    lastY = e.clientY
+    const speed = 0.005 // radians per pixel
+
+    if (e.altKey) {
+      // Horizontal → around platform-local Y
+      orbitAxis.set(0, 1, 0)
+      orbitRot.setFromAxisAngle(orbitAxis, -dx * speed)
+      camera.position.applyQuaternion(orbitRot)
+      camera.quaternion.premultiply(orbitRot)
+      // Vertical → around camera's current right axis
+      orbitAxis.set(1, 0, 0).applyQuaternion(camera.quaternion)
+      orbitRot.setFromAxisAngle(orbitAxis, -dy * speed)
+      camera.position.applyQuaternion(orbitRot)
+      camera.quaternion.premultiply(orbitRot)
+    } else {
+      // Free look: pitch/yaw camera around its own local axes.
+      camera.rotateY(-dx * speed)
+      camera.rotateX(-dy * speed)
+    }
+    onChange?.()
+  })
+}

--- a/js/dragControls.test.js
+++ b/js/dragControls.test.js
@@ -39,26 +39,110 @@ describe('attachPointerDrag', () => {
     expect(el.style.touchAction).toBe('none')
   })
 
-  it('rotates the camera quaternion in response to a pointerdown + pointermove sequence', () => {
+  it('defaults to \'pan\' mode (free look) with no accessors and no target', () => {
     const el = makeFakeElement()
     const camera = new PerspectiveCamera()
-    const startQuat = camera.quaternion.clone()
+    const startPos = camera.position.clone()
     attachPointerDrag(el, camera)
 
-    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
-    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130})
 
+    // Pan changes orientation but not position.
+    expect(camera.position.equals(startPos)).toBe(true)
+  })
+
+  it('\'auto\' mode resolves to \'orbit\' when camera is far from target', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(1e8, 0, 0) // far from a 6.4e6 m radius body
+    const startPos = camera.position.clone()
+    const target = {props: {radius: {scalar: 6.4e6}}}
+    attachPointerDrag(el, camera, {
+      getDragMode: () => 'auto',
+      getTarget: () => target,
+    })
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100})
+
+    // Orbit moves position; pan would not.
+    expect(camera.position.equals(startPos)).toBe(false)
+  })
+
+  it('\'auto\' mode resolves to \'pan\' when camera is close to target', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(6.4e6, 0, 0) // at surface of 6.4e6 m radius body
+    const startPos = camera.position.clone()
+    const target = {props: {radius: {scalar: 6.4e6}}}
+    attachPointerDrag(el, camera, {
+      getDragMode: () => 'auto',
+      getTarget: () => target,
+    })
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100})
+
+    expect(camera.position.equals(startPos)).toBe(true) // pan: position unchanged
+  })
+
+  it('\'pan\' mode rotates camera quaternion only (position unchanged)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(0, 0, 100)
+    const startPos = camera.position.clone()
+    const startQuat = camera.quaternion.clone()
+    attachPointerDrag(el, camera, {getDragMode: () => 'pan'})
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130})
+
+    expect(camera.position.equals(startPos)).toBe(true)
     expect(camera.quaternion.equals(startQuat)).toBe(false)
+  })
+
+  it('\'orbit\' mode rotates camera position around platform origin (rigid body)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(10, 0, 0)
+    const startPos = camera.position.clone()
+    attachPointerDrag(el, camera, {getDragMode: () => 'orbit'})
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100})
+
+    expect(camera.position.equals(startPos)).toBe(false)
+    // Distance from origin is preserved in rigid-body orbit.
+    expect(Math.abs(camera.position.length() - startPos.length())).toBeLessThan(1e-6)
+  })
+
+  it('latches mode at pointerdown — getDragMode flipping mid-drag does not switch behavior', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(10, 0, 0)
+    const startPos = camera.position.clone()
+    let mode = 'orbit'
+    attachPointerDrag(el, camera, {getDragMode: () => mode})
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    // Flip the source-of-truth mid-drag.  The handler should keep using
+    // the mode it latched at pointerdown.
+    mode = 'pan'
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100})
+
+    // Position changed → still in orbit mode despite the flip.
+    expect(camera.position.equals(startPos)).toBe(false)
   })
 
   it('invokes onChange exactly once per pointermove', () => {
     const el = makeFakeElement()
     const onChange = mock()
-    attachPointerDrag(el, new PerspectiveCamera(), onChange)
+    attachPointerDrag(el, new PerspectiveCamera(), {onChange})
 
-    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
-    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
-    el.fire('pointermove', {pointerId: 1, clientX: 160, clientY: 140, altKey: false})
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130})
+    el.fire('pointermove', {pointerId: 1, clientX: 160, clientY: 140})
 
     expect(onChange).toHaveBeenCalledTimes(2)
   })
@@ -68,9 +152,9 @@ describe('attachPointerDrag', () => {
     const camera = new PerspectiveCamera()
     const startQuat = camera.quaternion.clone()
     const onChange = mock()
-    attachPointerDrag(el, camera, onChange)
+    attachPointerDrag(el, camera, {onChange})
 
-    el.fire('pointermove', {pointerId: 99, clientX: 10, clientY: 10, altKey: false})
+    el.fire('pointermove', {pointerId: 99, clientX: 10, clientY: 10})
 
     expect(onChange).not.toHaveBeenCalled()
     expect(camera.quaternion.equals(startQuat)).toBe(true)
@@ -81,12 +165,12 @@ describe('attachPointerDrag', () => {
     const camera = new PerspectiveCamera()
     attachPointerDrag(el, camera)
 
-    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
     const afterFirst = camera.quaternion.clone()
 
     // Second finger lands while first is still down — should be ignored.
-    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 200, clientY: 200, altKey: false})
-    el.fire('pointermove', {pointerId: 2, clientX: 250, clientY: 250, altKey: false})
+    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 200, clientY: 200})
+    el.fire('pointermove', {pointerId: 2, clientX: 250, clientY: 250})
 
     expect(camera.quaternion.equals(afterFirst)).toBe(true)
   })
@@ -96,26 +180,71 @@ describe('attachPointerDrag', () => {
     const camera = new PerspectiveCamera()
     attachPointerDrag(el, camera)
 
-    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100})
     el.fire('pointerup', {pointerId: 1})
     // After release, a different pointerId can take over.
-    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 50, clientY: 50, altKey: false})
+    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 50, clientY: 50})
     const beforeMove = camera.quaternion.clone()
-    el.fire('pointermove', {pointerId: 2, clientX: 100, clientY: 80, altKey: false})
+    el.fire('pointermove', {pointerId: 2, clientX: 100, clientY: 80})
 
     expect(camera.quaternion.equals(beforeMove)).toBe(false)
   })
 
-  it('alt+drag orbits camera position (rigid-body rotation around platform origin)', () => {
+  it('alt held at pointerdown inverts the resolved mode (pan → orbit)', () => {
+    // Regression: alt-key one-shot override must keep working as a
+    // desktop power-user escape hatch even with the visible toggle.
     const el = makeFakeElement()
     const camera = new PerspectiveCamera()
     camera.position.set(10, 0, 0)
     const startPos = camera.position.clone()
-    attachPointerDrag(el, camera)
+    let preventCalled = false
+    attachPointerDrag(el, camera, {getDragMode: () => 'pan'})
 
-    el.fire('pointerdown',
-        {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: true, preventDefault: () => {}})
+    el.fire('pointerdown', {
+      button: 0, pointerId: 1, clientX: 100, clientY: 100,
+      altKey: true, preventDefault: () => {
+        preventCalled = true
+      },
+    })
     el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100, altKey: true})
+
+    // Stored mode is 'pan' (which would leave position alone) but alt
+    // inverts to 'orbit' → position changes.
+    expect(camera.position.equals(startPos)).toBe(false)
+    expect(preventCalled).toBe(true)
+  })
+
+  it('alt held at pointerdown inverts the resolved mode (orbit → pan)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(10, 0, 0)
+    const startPos = camera.position.clone()
+    attachPointerDrag(el, camera, {getDragMode: () => 'orbit'})
+
+    el.fire('pointerdown', {
+      button: 0, pointerId: 1, clientX: 100, clientY: 100,
+      altKey: true, preventDefault: () => {},
+    })
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: true})
+
+    // Stored mode 'orbit' inverted to 'pan' → position unchanged.
+    expect(camera.position.equals(startPos)).toBe(true)
+  })
+
+  it('alt-invert applies once at pointerdown — releasing alt mid-drag does not flip back', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(10, 0, 0)
+    const startPos = camera.position.clone()
+    attachPointerDrag(el, camera, {getDragMode: () => 'pan'})
+
+    el.fire('pointerdown', {
+      button: 0, pointerId: 1, clientX: 100, clientY: 100,
+      altKey: true, preventDefault: () => {},
+    })
+    // Release alt mid-gesture.  Mode latched at pointerdown was 'orbit'
+    // (pan inverted), and stays orbit for the gesture.
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100, altKey: false})
 
     expect(camera.position.equals(startPos)).toBe(false)
   })
@@ -126,8 +255,8 @@ describe('attachPointerDrag', () => {
     const startQuat = camera.quaternion.clone()
     attachPointerDrag(el, camera)
 
-    el.fire('pointerdown', {button: 2, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
-    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+    el.fire('pointerdown', {button: 2, pointerId: 1, clientX: 100, clientY: 100})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130})
 
     expect(camera.quaternion.equals(startQuat)).toBe(true)
   })

--- a/js/dragControls.test.js
+++ b/js/dragControls.test.js
@@ -1,0 +1,134 @@
+import {describe, expect, it, mock} from 'bun:test'
+import {PerspectiveCamera} from 'three'
+import {attachPointerDrag} from './dragControls'
+
+
+/** Minimal stand-in for an HTMLElement: records handlers so tests can fire them. */
+function makeFakeElement() {
+  const handlers = {}
+  return {
+    style: {},
+    handlers,
+    addEventListener: (name, fn) => {
+      handlers[name] = fn
+    },
+    setPointerCapture: () => {},
+    fire: (name, ev) => handlers[name]?.(ev),
+  }
+}
+
+
+describe('attachPointerDrag', () => {
+  it('binds pointer events — not mouse events — so touch input drives camera drag', () => {
+    // Regression guard: mobile-broken drag came from binding mousedown /
+    // mousemove, which don't fire from touch.  Pointer events cover mouse,
+    // pen, and touch with one API.
+    const el = makeFakeElement()
+    attachPointerDrag(el, new PerspectiveCamera())
+    expect(el.handlers.pointerdown).toBeDefined()
+    expect(el.handlers.pointermove).toBeDefined()
+    expect(el.handlers.pointerup).toBeDefined()
+    expect(el.handlers.pointercancel).toBeDefined()
+    expect(el.handlers.mousedown).toBeUndefined()
+    expect(el.handlers.mousemove).toBeUndefined()
+  })
+
+  it('sets touch-action: none so the browser does not eat single-finger drags', () => {
+    const el = makeFakeElement()
+    attachPointerDrag(el, new PerspectiveCamera())
+    expect(el.style.touchAction).toBe('none')
+  })
+
+  it('rotates the camera quaternion in response to a pointerdown + pointermove sequence', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    const startQuat = camera.quaternion.clone()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+
+    expect(camera.quaternion.equals(startQuat)).toBe(false)
+  })
+
+  it('invokes onChange exactly once per pointermove', () => {
+    const el = makeFakeElement()
+    const onChange = mock()
+    attachPointerDrag(el, new PerspectiveCamera(), onChange)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 160, clientY: 140, altKey: false})
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores pointermove with no matching pointerdown (e.g. stray events)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    const startQuat = camera.quaternion.clone()
+    const onChange = mock()
+    attachPointerDrag(el, camera, onChange)
+
+    el.fire('pointermove', {pointerId: 99, clientX: 10, clientY: 10, altKey: false})
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(camera.quaternion.equals(startQuat)).toBe(true)
+  })
+
+  it('ignores a second simultaneous pointer so pinch-zoom flows to TrackballControls', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    const afterFirst = camera.quaternion.clone()
+
+    // Second finger lands while first is still down — should be ignored.
+    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 200, clientY: 200, altKey: false})
+    el.fire('pointermove', {pointerId: 2, clientX: 250, clientY: 250, altKey: false})
+
+    expect(camera.quaternion.equals(afterFirst)).toBe(true)
+  })
+
+  it('releases the active pointer on pointerup so the next press can claim it', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointerup', {pointerId: 1})
+    // After release, a different pointerId can take over.
+    el.fire('pointerdown', {button: 0, pointerId: 2, clientX: 50, clientY: 50, altKey: false})
+    const beforeMove = camera.quaternion.clone()
+    el.fire('pointermove', {pointerId: 2, clientX: 100, clientY: 80, altKey: false})
+
+    expect(camera.quaternion.equals(beforeMove)).toBe(false)
+  })
+
+  it('alt+drag orbits camera position (rigid-body rotation around platform origin)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    camera.position.set(10, 0, 0)
+    const startPos = camera.position.clone()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown',
+        {button: 0, pointerId: 1, clientX: 100, clientY: 100, altKey: true, preventDefault: () => {}})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 100, altKey: true})
+
+    expect(camera.position.equals(startPos)).toBe(false)
+  })
+
+  it('ignores non-primary mouse buttons (right-click, middle-click)', () => {
+    const el = makeFakeElement()
+    const camera = new PerspectiveCamera()
+    const startQuat = camera.quaternion.clone()
+    attachPointerDrag(el, camera)
+
+    el.fire('pointerdown', {button: 2, pointerId: 1, clientX: 100, clientY: 100, altKey: false})
+    el.fire('pointermove', {pointerId: 1, clientX: 150, clientY: 130, altKey: false})
+
+    expect(camera.quaternion.equals(startQuat)).toBe(true)
+  })
+})

--- a/js/dragMode.js
+++ b/js/dragMode.js
@@ -1,0 +1,48 @@
+/**
+ * Distance-based suggestion for which drag mode best fits a viewing
+ * context: orbit when the camera is "in space" looking at a body,
+ * free-look ("pan") when it's near or on the surface.
+ *
+ * @param {number} cameraDist Distance from camera to target center, metres.
+ * @param {object} target A target object with `.props.radius.scalar` and
+ *   optionally `.props.atmosphere.height.scalar`.  May be null.
+ * @returns {'pan'|'orbit'}
+ */
+export function pickDragMode(cameraDist, target) {
+  const r = target?.props?.radius?.scalar
+  if (!r) {
+    return 'pan'
+  }
+  // If the body has an atmosphere, "in space" starts a bit past the top
+  // of the atmosphere; otherwise key off raw surface radius.  These
+  // multipliers put the orbit/pan boundary around low-orbit altitude
+  // (~2 surface radii up), where intuition flips between "looking at
+  // the planet" and "looking from the planet."
+  const atmH = target?.props?.atmosphere?.height?.scalar ?? 0
+  const threshold = atmH > 0 ? (r + atmH) * 2 : r * 3
+  return cameraDist > threshold ? 'orbit' : 'pan'
+}
+
+
+/**
+ * Resolve a `dragMode` store intent (`'pan'` | `'orbit'` | `'auto'`)
+ * to a concrete `'pan'` or `'orbit'` against the current camera
+ * position and target.  Explicit modes pass through; anything else
+ * (`'auto'`, undefined, etc.) consults `pickDragMode`.
+ *
+ * Used by dragControls at pointerdown (to decide what the gesture
+ * does) AND by ThreeUI per frame (to publish into
+ * `state.effectiveDragMode` so the UI toggle can highlight whichever
+ * mode is actually active right now).
+ *
+ * @param {string} intent
+ * @param {number} cameraDist
+ * @param {object} target
+ * @returns {'pan'|'orbit'}
+ */
+export function resolveDragMode(intent, cameraDist, target) {
+  if (intent === 'pan' || intent === 'orbit') {
+    return intent
+  }
+  return pickDragMode(cameraDist, target)
+}

--- a/js/dragMode.test.js
+++ b/js/dragMode.test.js
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'bun:test'
+import {pickDragMode, resolveDragMode} from './dragMode'
+
+
+/** Build a target stub with the props shape pickDragMode reads. */
+function target(radius, atmosphereHeight) {
+  return {
+    props: {
+      radius: {scalar: radius},
+      ...(atmosphereHeight !== undefined ?
+        {atmosphere: {height: {scalar: atmosphereHeight}}} :
+        {}),
+    },
+  }
+}
+
+
+describe('pickDragMode', () => {
+  it('returns \'pan\' when no target is supplied (e.g. star-only scene)', () => {
+    expect(pickDragMode(1e9, null)).toBe('pan')
+    expect(pickDragMode(1e9, undefined)).toBe('pan')
+    expect(pickDragMode(1e9, {})).toBe('pan')
+  })
+
+  it('returns \'pan\' when the camera is within ~3 surface radii of an airless body', () => {
+    const earth = target(6.4e6) // no atmosphere
+    expect(pickDragMode(6.4e6, earth)).toBe('pan') // at surface
+    expect(pickDragMode(6.4e6 * 2.9, earth)).toBe('pan') // just below threshold
+  })
+
+  it('returns \'orbit\' when the camera is well above an airless body', () => {
+    const earth = target(6.4e6)
+    expect(pickDragMode(6.4e6 * 5, earth)).toBe('orbit')
+    expect(pickDragMode(1e10, earth)).toBe('orbit')
+  })
+
+  it('uses (radius + atmosphere height) × 2 as the threshold when the body has an atmosphere', () => {
+    // Earth-ish: 6.4e6 m radius + 1e5 m atmosphere → threshold = 1.3e7 m.
+    const earth = target(6.4e6, 1e5)
+    expect(pickDragMode(1.2e7, earth)).toBe('pan')
+    expect(pickDragMode(1.4e7, earth)).toBe('orbit')
+  })
+})
+
+
+describe('resolveDragMode', () => {
+  // Regression: the UI toggle's highlight must follow the *effective*
+  // mode — that's what resolveDragMode produces from the user's intent
+  // and the current camera/target context.
+
+  it('passes explicit \'pan\' or \'orbit\' through unchanged', () => {
+    const earth = target(6.4e6)
+    expect(resolveDragMode('pan', 1e10, earth)).toBe('pan')
+    expect(resolveDragMode('orbit', 1, earth)).toBe('orbit')
+  })
+
+  it('routes \'auto\' through pickDragMode using camera distance and target', () => {
+    const earth = target(6.4e6)
+    expect(resolveDragMode('auto', 6.4e6, earth)).toBe('pan') // close
+    expect(resolveDragMode('auto', 1e10, earth)).toBe('orbit') // far
+  })
+
+  it('treats unknown / undefined intent as \'auto\'', () => {
+    const earth = target(6.4e6)
+    expect(resolveDragMode(undefined, 1e10, earth)).toBe('orbit')
+    expect(resolveDragMode(null, 6.4e6, earth)).toBe('pan')
+    expect(resolveDragMode('garbage', 1e10, earth)).toBe('orbit')
+  })
+
+  it('falls back to \'pan\' in \'auto\' when no target is supplied', () => {
+    expect(resolveDragMode('auto', 1e10, null)).toBe('pan')
+  })
+})

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -473,6 +473,16 @@ export default class Scene {
     // Single unified tween that overlaps rotation and movement.
     Shared.targets.tween = newCameraGoToTween(this.ui.camera, targetWorldPos, arrivalLocal)
     Shared.targets.tweenNextFn = null
+
+    // Reset drag mode to 'auto' on planet navigation so the next
+    // pointerdown re-evaluates pickDragMode against the actual camera
+    // position (which may end up at orbit altitude OR ground level if
+    // a permalink restore lands the camera on the surface).  Manual
+    // pan/orbit selections from a previous body don't carry over.
+    if (isPlanet) {
+      const setDragMode = this.ui.useStore?.getState()?.setDragMode
+      setDragMode?.('auto')
+    }
   }
 
 

--- a/js/store/DragModeSlice.js
+++ b/js/store/DragModeSlice.js
@@ -1,0 +1,28 @@
+/**
+ * Camera drag mode.
+ *
+ * Two related store fields:
+ *
+ *   - `dragMode` — user intent: `'pan'`, `'orbit'`, or `'auto'` (let
+ *     dragControls pick based on camera-to-target distance).  Default
+ *     is `'auto'`.  Set by the UI toggle, the `'m'` shortcut, and
+ *     reset to `'auto'` by Scene.goTo.
+ *
+ *   - `effectiveDragMode` — the resolved `'pan'` or `'orbit'` for the
+ *     current frame.  Updated each frame by ThreeUI's render loop so the
+ *     UI toggle can highlight whichever mode is *actually* active right
+ *     now — including when `dragMode === 'auto'` and the resolution
+ *     follows the camera context.
+ *
+ * @param {Function} set
+ * @param {Function} get
+ * @returns {object} Zustand slice
+ */
+export default function createDragModeSlice(set, get) {
+  return {
+    dragMode: 'auto',
+    effectiveDragMode: 'pan',
+    setDragMode: (mode) => set(() => ({dragMode: mode})),
+    setEffectiveDragMode: (mode) => set(() => ({effectiveDragMode: mode})),
+  }
+}

--- a/js/store/useStore.js
+++ b/js/store/useStore.js
@@ -1,5 +1,6 @@
 import {create} from 'zustand'
 import createAsterismsSlice from './AsterismsSlice'
+import createDragModeSlice from './DragModeSlice'
 import createSearchSlice from './SearchSlice'
 import createStarsSlice from './StarsSlice'
 import createTimeSlice from './TimeSlice'
@@ -7,6 +8,7 @@ import createTimeSlice from './TimeSlice'
 
 const useStore = create((set, get) => ({
   ...createAsterismsSlice(set, get),
+  ...createDragModeSlice(set, get),
   ...createSearchSlice(set, get),
   ...createStarsSlice(set, get),
   ...createTimeSlice(set, get),

--- a/js/ui/DragModeToggle.jsx
+++ b/js/ui/DragModeToggle.jsx
@@ -1,0 +1,63 @@
+import React, {ReactElement} from 'react'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import Tooltip from '@mui/material/Tooltip'
+import OpenWithIcon from '@mui/icons-material/OpenWith'
+import ControlCameraIcon from '@mui/icons-material/ControlCamera'
+import useStore from '../store/useStore'
+
+
+/**
+ * Two-button selector for camera drag mode.  Highlights whichever mode
+ * is *effectively* active right now — when `dragMode === 'auto'` the
+ * highlight follows the auto-resolution, so the user can see the mode
+ * shift as they zoom or navigate.  Clicking an unselected button locks
+ * to that mode; clicking the already-selected button deselects → back
+ * to `'auto'`.  Scene.goTo resets to `'auto'` on navigation.
+ *
+ * The selected button gets a vivid blue halo so a context-driven
+ * mode shift catches the eye.
+ *
+ * @returns {ReactElement}
+ */
+const HALO_SX = {
+  '&.Mui-selected': {
+    color: '#90caf9',
+    backgroundColor: 'rgba(33, 150, 243, 0.18)',
+    boxShadow: '0 0 14px 2px rgba(33, 150, 243, 0.85), inset 0 0 6px rgba(33, 150, 243, 0.35)',
+    '&:hover': {
+      backgroundColor: 'rgba(33, 150, 243, 0.28)',
+    },
+  },
+  transition: 'box-shadow 200ms ease, background-color 200ms ease',
+}
+
+
+/** @returns {ReactElement} */
+export default function DragModeToggle() {
+  const effective = useStore((state) => state.effectiveDragMode)
+  const setDragMode = useStore((state) => state.setDragMode)
+  // ToggleButtonGroup with `exclusive` emits null when the user clicks
+  // the currently-selected button — interpret that as "back to auto".
+  const onChange = (_e, next) => setDragMode(next ?? 'auto')
+  return (
+    <ToggleButtonGroup
+      value={effective}
+      exclusive
+      onChange={onChange}
+      size='small'
+      aria-label='Camera drag mode'
+    >
+      <Tooltip title='Drag Pan: pitch/yaw camera in place'>
+        <ToggleButton value='pan' aria-label='Pan' sx={HALO_SX}>
+          <OpenWithIcon/>
+        </ToggleButton>
+      </Tooltip>
+      <Tooltip title='Move: rotate camera around target'>
+        <ToggleButton value='orbit' aria-label='Orbit' sx={HALO_SX}>
+          <ControlCameraIcon/>
+        </ToggleButton>
+      </Tooltip>
+    </ToggleButtonGroup>
+  )
+}


### PR DESCRIPTION
## Summary

Camera drag now adapts to the viewing context: orbit around a body when looking at it from far away, pan/free-look when close to the surface.  Both behaviors already existed (alt-drag was orbit), but plain drag was always pan — wrong default for the common "looking at a planet from space" view, and unfixable on mobile where there's no Alt key.

Three pieces:

- **Tri-state intent** — `dragMode` in the store is `'auto'` (default), `'pan'`, or `'orbit'`.  `'auto'` resolves at each pointerdown via a distance threshold (`r × 3` airless, `(r + atm) × 2` with atmosphere — roughly low-orbit altitude).  `Scene.goTo` resets to `'auto'` on planet navigation so a manual lock on one body doesn't carry over.

- **Live effective mode** — ThreeUI publishes a `'pan'` | `'orbit'` resolution into `effectiveDragMode` every frame so the UI can highlight whichever mode is *actually* active right now, including as the auto-resolution shifts mid-zoom.  Zustand's `Object.is` selector check skips re-renders when the value hasn't changed.

- **Visible toggle** — `DragModeToggle.jsx` in the top-right Stack: two ToggleButtons (DragPan via `OpenWith`, Move via `ControlCamera`) with a vivid blue halo on the active button so context-driven shifts catch the eye.  Click an unselected button → lock; click the selected button → back to `'auto'`.  Carries over the alt-drag invert as a one-shot desktop override.  `'m'` shortcut cycles auto → pan → orbit → auto.

## Test plan

- [x] `bun test` — 246 tests pass (+25 new across `dragMode.test.js` and `dragControls.test.js`)
- [x] `yarn lint` — clean
- [x] Desktop: load app on Earth → halo on Move; mouse-wheel zoom toward surface → halo slides to Drag Pan around low orbit; alt+drag inverts the current mode for one gesture
- [x] Mobile: same behavior, no modifier key needed
- [x] Lock a button → navigate to another planet → verify mode resets to auto (highlight follows new context)
- [x] Press `'m'` repeatedly → highlight cycles through pan, orbit, then back to auto-resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)