### PR TITLE
Stars visible from atmosphere — physics-driven day/night/dusk composition

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,6 +260,37 @@ scene graph alone.
 
 LOD (`THREE.LOD`) is used throughout to swap between detailed meshes, point sprites, and invisible placeholders based on camera distance.
 
+## Overlays & visibility groups
+
+Every visual feature in the app must opt into one of two top-level
+visibility groups so the user has predictable global hide/show controls:
+
+- **`v`** (lowercase v key) — **HTML chrome**: nav panels, search bar,
+  time/target HUD, settings dialogs.  React/MUI overlays only — anything
+  rendered outside the WebGL canvas.
+- **`V`** (Shift+v key, "presentation mode") — **scene annotations**:
+  everything drawn into the WebGL scene that isn't a celestial body or
+  texture.  Labels, asterism lines, orbit ellipses, reference grids,
+  surface place labels, etc.  A second `V` press restores the prior
+  per-element state (snapshotted on first press) so users can flip
+  between "bare" and "annotated" views without losing their
+  per-element toggles.
+
+Each scene-annotation feature also has its OWN scoped lowercase toggle
+(`a` asterisms, `p` planet+moon+place labels, `s` star labels, `o` orbits,
+`;` equatorial grid, etc.).  `V` is the union of all the lowercase
+scene-annotation toggles.
+
+**When adding a new visual feature, decide which group it belongs in and
+wire it through the corresponding toggle method.**  Surface place labels,
+for example, live under the `p` group: their visibility is controlled
+inside `Scene.togglePlanetLabels` alongside the planet name LODs, so the
+single 'p' shortcut and the global 'V' both pick them up automatically.
+
+Failing to opt in means the user has no way to hide the new element
+short of reloading the page — and `V` (presentation mode) won't be
+truly bare.
+
 ## State Management (Zustand)
 
 `js/store/useStore.js` composes four slices:

--- a/js/scene/Planet.js
+++ b/js/scene/Planet.js
@@ -341,7 +341,14 @@ export default class Planet extends Object {
       }
     }
 
-    const surface = named(sphere({radius: this.props.radius.scalar, matr: surfaceMaterial}), 'planet surface')
+    // Bump surface resolution from sphere()'s default (128 segs ≈ 16k tris,
+    // ~310 km triangle edge at Earth scale) to 512 (~262k tris, ~78 km
+    // edge).  At close range — landing, low-altitude flight — the smaller
+    // triangles plus tighter chord-to-arc fit reduce sub-pixel rasterization
+    // gaps that previously let the sun show through Earth.  Cost per body
+    // is trivial on a modern GPU; one planet's worth of triangles dwarfed
+    // by the star catalog.
+    const surface = named(sphere({radius: this.props.radius.scalar, resolution: 512, matr: surfaceMaterial}), 'planet surface')
 
     // Per-frame: refresh sun direction (view space) for the night-lights
     // shader.  Sun lives at world origin; transform direction-from-planet-

--- a/js/scene/Planet.js
+++ b/js/scene/Planet.js
@@ -151,7 +151,15 @@ export default class Planet extends Object {
     }
 
     if (this.props.has_locations) {
-      planet.add(this.loadLocations(this.props))
+      const places = this.loadLocations(this.props)
+      // Stash a reference on the rotating planet node so Scene.togglePlanetLabels
+      // can toggle places visibility alongside the planet name labels (both
+      // belong to the 'p' overlay group — see DESIGN.md "Overlays & visibility").
+      planet.places = places
+      // Initial visibility tracks the 'p' setting for the same reason — without
+      // this, places would be visible after a permalink restore that had 'p' off.
+      places.visible = scene.getSetting ? scene.getSetting('p') : true
+      planet.add(places)
     }
 
     // An object must have a mesh to have onBeforeRender called, so

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -591,9 +591,14 @@ export default class Scene {
       Shared.targets.tweenNextFn = null
     }
 
-    // Lock to pan mode; mark landed for permalink + UI.
+    // Reset drag mode to 'auto' so pickDragMode picks 'pan' here at the
+    // surface AND naturally flips back to 'orbit' when the user later
+    // zooms out past the auto-switch threshold.  Earlier we forced
+    // 'pan' explicitly, which felt right at touchdown but stayed sticky:
+    // zooming out past orbit altitude kept dragging in pan mode forever.
+    // Mark landed for permalink + UI; this is independent of drag mode.
     const state = this.ui.useStore?.getState?.()
-    state?.setDragMode?.('pan')
+    state?.setDragMode?.('auto')
     state?.setLanded?.(true)
     Shared.targets.landed = true
 

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -712,9 +712,25 @@ export default class Scene {
   }
 
 
-  /** */
+  /**
+   * Toggle planet/moon name labels AND surface place labels.  Both belong
+   * to the 'p' overlay group: planet names live in their own LOD object
+   * named 'label LOD' (matched by visitToggleProperty); surface places
+   * (cities, craters, landing sites) live as a `places` property on the
+   * rotating planet Object3D, set in Planet.newPlanet.  Toggling them
+   * together gives the user one knob for "all planet-related labels"
+   * — and means the global 'V' presentation toggle hides them all
+   * together too via this same method.  See DESIGN.md "Overlays &
+   * visibility groups".
+   */
   togglePlanetLabels() {
     Utils.visitToggleProperty(this.objects['sun'], 'name', 'label LOD', 'visible')
+    for (const name of Object.keys(this.objects)) {
+      const obj = this.objects[name]
+      if (obj && obj.places && typeof obj.places.visible === 'boolean') {
+        obj.places.visible = !obj.places.visible
+      }
+    }
     this._flipSetting('p')
   }
 

--- a/js/scene/Scene.test.js
+++ b/js/scene/Scene.test.js
@@ -336,10 +336,14 @@ describe('Scene.land', () => {
     expect(camera.position.y).toBeCloseTo(r + 100, 0)
   })
 
-  it('switches drag mode to pan', () => {
+  it('resets drag mode to auto so it picks pan here and orbit on zoom-out', () => {
+    // Earlier rev forced dragMode='pan' on land; that stayed sticky and
+    // never flipped back to orbit when the user later zoomed away from
+    // the surface.  'auto' resolves to pan at touchdown via pickDragMode
+    // and naturally flips to orbit past the auto-switch threshold.
     const {scene, stateBag} = makeSceneWithEarth()
     scene.land('earth', 0, 0, 0, {instant: true})
-    expect(stateBag.dragMode).toBe('pan')
+    expect(stateBag.dragMode).toBe('auto')
   })
 
   it('marks landed=true in store and Shared.targets', () => {

--- a/js/scene/Scene.test.js
+++ b/js/scene/Scene.test.js
@@ -200,6 +200,21 @@ describe('Scene settings tracking', () => {
     expect(s.objects['sun'].children[0].visible).toBe(false)
   })
 
+  it('togglePlanetLabels also flips surface place groups (planet+place labels share the p group)', () => {
+    // Surface places (cities, craters, landing sites) belong to the same
+    // 'p' overlay group as planet name labels.  Planet.newPlanet stashes
+    // the Places ref on the rotating planet Object3D as `.places`, and
+    // togglePlanetLabels walks scene.objects to flip those alongside the
+    // 'label LOD' visit.  See DESIGN.md "Overlays & visibility groups".
+    const s = makeScene()
+    s.objects['sun'] = fakeSunWithLabelLOD()
+    s.objects['earth'] = {places: {visible: true}}
+    s.togglePlanetLabels()
+    expect(s.objects['earth'].places.visible).toBe(false)
+    s.togglePlanetLabels()
+    expect(s.objects['earth'].places.visible).toBe(true)
+  })
+
   it('toggleGridEquatorial / Ecliptic / Galactic flip e / c / g respectively', () => {
     const s = makeScene()
     s.toggleGridEquatorial()

--- a/js/scene/atmos/Atmosphere.js
+++ b/js/scene/atmos/Atmosphere.js
@@ -639,51 +639,111 @@ void main() {
 
     // Extinction alpha via transmittance LUT along view ray.
     // Use the same mu_v_lut clamp (horizon angle) so extinction matches scatter.
+    // Trust the LUT: at zenith from sea level the visible-band optical
+    // depth is ~0.15, giving alpha ~0.14 — i.e. ~86% transmittance for the
+    // background (stars, milky way, distant planets).  Earlier revs forced
+    // alpha to ~1 whenever the camera was inside the atmosphere; that made
+    // the day sky look opaque blue but blocked stars on the night side.
     vec2 uvT_v    = transmittanceUV(r_e, mu_v_lut, uGroundRadius, uAtmosphereRadius);
     vec2 odView   = texture2D(tTransmittance, uvT_v).rg;
     vec3 extVec   = uRayleigh * odView.r + vec3(uMieCoeff * odView.g);
     float alpha   = 1.0 - exp(-max(extVec.r, max(extVec.g, extVec.b)));
-
-    // Alpha boost when camera is inside atmosphere (sky rays)
-    if (uAtmosphereRadius > uGroundRadius) {
-      float camDist = length(eyePos);
-      if (camDist < uAtmosphereRadius) {
-        vec2 tG = rsi(eyePos, rayDir, uGroundRadius);
-        if (!(tG.x > 0.0 && tG.x <= tG.y)) {
-          float depth = 1.0 - (camDist - uGroundRadius)
-                            / (uAtmosphereRadius - uGroundRadius);
-          alpha = max(alpha, clamp(depth, 0.0, 1.0));
-        }
-      }
+    // Cap raw extinction-alpha so horizon-grazing rays at night still let
+    // some starlight through (real physics says they shouldn't but the eye
+    // adapts; we don't simulate that yet).
+    alpha = min(alpha, 0.92);
+    // Tie alpha to inscatter brightness via a steep smoothstep — bright
+    // day sky becomes opaque (washes out star labels behind it), dim/dark
+    // night sky stays transparent.  Models eye iris dilation: the eye
+    // can't see faint sources once the sky is even faintly bright.
+    //
+    // Why smoothstep instead of a plain max(alpha, brightness): the
+    // Bruneton LUT inscatter for our atmosphere parameters tops out at
+    // ~0.5–0.7 max-channel even at noon, so a linear coupling leaves
+    // alpha at 0.7 → 30% transmittance, and the (HDR-valued) star label
+    // sprites still show through.  smoothstep snaps alpha to 1 as soon
+    // as brightness exceeds the upper bound (well below sunset).
+    //
+    // Gated on insideAtm: this boost models EYE adaptation, which only
+    // makes sense when you are the eye inside the atmosphere.  From space
+    // looking down at the day side, you're a camera viewing through a
+    // thin upper-atmosphere column — the LUT alpha already captures the
+    // real optical depth of that column, and forcing it to ~1 would hide
+    // the surface texture behind a featureless blue disc.
+    vec3 color = 1.0 - exp(-scattered);
+    float skyBrightness = max(color.r, max(color.g, color.b));
+    // Two knobs in the smoothstep:
+    // - Lower bound = brightness at which stars start fading
+    // - Upper bound = brightness at which sky goes fully opaque
+    float lowerBrightBound = 0.01;
+    float upperBrightBound = 0.1;
+    // Altitude weighting on the boost: full strength at the surface where
+    // the eye is deeply embedded in the atmosphere column, smoothly
+    // weakening to zero at the atmosphere's upper edge.  Reason: from
+    // high altitude looking at the limb, sky pixels in the dim transition
+    // zone above the bright glow have moderate brightness — full boost
+    // would push alpha to ~0.5 there, which hides stars but isn't bright
+    // enough to compensate (sky color is dim too), producing an additive
+    // "trough" that reads as a dark band between glow and starfield.
+    // Real-eye basis: at the top of the atmosphere there's barely any air
+    // to scatter, so iris dilation isn't being pushed by ambient
+    // brightness — the eye effectively becomes a camera and the LUT
+    // extinction alone is correct.
+    float camAlt = r_e - uGroundRadius;
+    float atmHeight = uAtmosphereRadius - uGroundRadius;
+    float altWeight = clamp(1.0 - camAlt / atmHeight, 0.0, 1.0);
+    if (insideAtm) {
+      alpha = max(alpha, smoothstep(lowerBrightBound, upperBrightBound, skyBrightness) * altWeight);
+    }
+    // TODO(future): tune the surface-vs-atmosphere blend coloring.  From
+    // space looking at the day side, the LUT inscatter mixes additively
+    // with the surface texture: where atmospheric column is thick (limb)
+    // the inscatter hue dominates; where thin (overhead/disc centre) the
+    // surface shows.  The transition reads OK but the saturation/hue
+    // balance over land vs ocean isn't perfectly tuned, and the coastal
+    // hand-off looks slightly washed.  Plausible knobs: per-channel
+    // inscatter scaling, a soft saturation curve on (color + scene*T),
+    // or eventually proper aerial-perspective integration over the
+    // segment from surface depth back to the camera.
+    // Gap-pixel hard occlusion: when isGap is true we KNOW the geometric
+    // ground is in front of whatever the depth buffer recorded — i.e. a
+    // sub-pixel rasterization gap let the background (sun, stars, distant
+    // planets) leak through where Earth's tessellated surface should have
+    // covered.  Force alpha=1 so the scene contribution drops out and the
+    // gap shows only inscatter (bright haze by day, dark by night) — visually
+    // matches the surrounding surface and gives a crisp horizon edge.
+    if (isGap) {
+      alpha = 1.0;
     }
 
-    vec3 color = 1.0 - exp(-scattered);
     vec4 scene = texture2D(tDiffuse, vUv);
     gl_FragColor = vec4(color + scene.rgb * (1.0 - alpha), 1.0);
     return;
   }
 
   // ── Fallback: ray-march scatter (i-loop + j-loop or j-LUT) ───────────────
+  // result.a is the extinction alpha along the view ray; trust it directly
+  // (no inside-atmosphere depth boost — see the LUT branch above for why).
   vec4 result = scatter(rayDir, eyePos, uSunDirection, uSunIntensity,
                         uGroundRadius, uAtmosphereRadius,
                         uRayleigh, uRayleighScaleHeight,
                         uMieCoeff, uMieScaleHeight, uMiePolarity,
                         tMax);
-
-  if (uAtmosphereRadius > uGroundRadius) {
-    float camDist = length(eyePos);
-    if (camDist < uAtmosphereRadius) {
-      vec2 tG = rsi(eyePos, rayDir, uGroundRadius);
-      bool hitsGround = tG.x > 0.0 && tG.x <= tG.y;
-      if (!hitsGround) {
-        float depth = 1.0 - (camDist - uGroundRadius)
-                          / (uAtmosphereRadius - uGroundRadius);
-        result.a = max(result.a, clamp(depth, 0.0, 1.0));
-      }
-    }
-  }
-
+  // Cap and brightness-tie — see the LUT branch above for the rationale.
+  // Boost weighted by camera altitude (full at surface, zero at top of
+  // atmosphere) and gated on insideAtm; both keep the boost confined to
+  // the eye-adaptation regime where it's physically meaningful.
+  result.a = min(result.a, 0.92);
   vec3 color = 1.0 - exp(-result.rgb);
+  float skyBrightness = max(color.r, max(color.g, color.b));
+  float r_eFb = length(eyePos);
+  bool insideAtmFb = (r_eFb <= uAtmosphereRadius);
+  float camAltFb = r_eFb - uGroundRadius;
+  float atmHeightFb = uAtmosphereRadius - uGroundRadius;
+  float altWeightFb = clamp(1.0 - camAltFb / atmHeightFb, 0.0, 1.0);
+  if (insideAtmFb) {
+    result.a = max(result.a, smoothstep(0.01, 0.1, skyBrightness) * altWeightFb);
+  }
   vec4 scene = texture2D(tDiffuse, vUv);
   gl_FragColor = vec4(color + scene.rgb * (1.0 - result.a), 1.0);
 }

--- a/js/scene/atmos/composition.md
+++ b/js/scene/atmos/composition.md
@@ -1,0 +1,111 @@
+# Atmosphere composition: what the post-process pass actually does
+
+Bruneton's precompute (see `BRUNETON.md`) gives us per-frame access to two LUTs:
+- `tTransmittance` — fraction of light surviving a column at `(r, μ_v)`
+- `tInScatter` — light scattered into a ray at `(r, μ_v, μ_s)`
+
+This doc covers what the fullscreen post-process does on top of those samples
+to compose the final pixel — the artistic/perceptual rules that turn
+physically-correct radiance into something that reads as sky from any
+viewpoint, day or night, surface or orbit.
+
+## Composition equation
+
+Final pixel = inscatter (sky color) + scene background (stars, surface, etc.)
+attenuated by transmittance:
+
+```glsl
+gl_FragColor.rgb = color + scene.rgb * (1.0 - alpha)
+```
+
+where `color = 1.0 - exp(-scattered)` (soft saturation of LUT inscatter), and
+`alpha = 1 - transmittance` from the LUT. This is the standard
+single-scattering equation: forward-scattered atmospheric light, plus
+attenuated background.
+
+## Why the raw equation isn't enough
+
+Two real-world phenomena aren't captured by the LUTs alone:
+
+1. **Eye adaptation under bright sky.** Real eyes' iris constricts under
+   daylight, so faint background sources (stars, distant planets) become
+   sub-threshold even though physics says ~14% of their light reaches the
+   retina at zenith from sea level. Without compensating in the renderer,
+   star labels and Hipparcos points clearly poke through the day blue.
+2. **Sub-pixel rasterization gaps in the surface mesh.** Earth's world
+   position is ~1.5e11 m; float32 precision in the model-view matrix
+   degrades to ~1m, which produces sub-pixel holes at extreme close range.
+   The depth buffer at those pixels reads "far" (sun, stars), and naive
+   compositing leaks the background through where the surface should
+   have covered.
+
+## The five composition rules
+
+Computed in this order in the LUT branch (lines ~640–700 of `Atmosphere.js`);
+the ray-march fallback applies the same rules with corresponding variables.
+
+1. **LUT alpha** — `alpha = 1 - exp(-tau_max_channel)`. Trust the
+   precompute. At zenith from sea level this is ~0.14, giving ~86% star
+   transmittance — physically correct.
+2. **Cap at 0.92** — `alpha = min(alpha, 0.92)`. Floor of 8% transmittance
+   for any background. Earlier revs forced the inside-atmosphere alpha
+   to ~1; that hid stars at the night horizon along with everything else.
+3. **Brightness-tied opacity** — `alpha = max(alpha, smoothstep(0.01, 0.1, sky_max_ch) * altWeight)`. Models eye adaptation. Two factors:
+   - `smoothstep` snaps alpha to 1 once the sky is even faintly bright,
+     so day blue overrides stars without needing physically-implausible
+     extinction.
+   - `altWeight = clamp(1 - camAlt/atmHeight, 0, 1)` weakens the boost
+     with altitude. At the surface (full weight) the eye is deeply
+     embedded in the column and adapts fully; at the top of the
+     atmosphere (zero weight) the eye effectively becomes a camera, no
+     iris dilation, just LUT extinction. Without this gate, looking
+     down at the day side from space turned the disc into featureless
+     blue and hid the surface texture.
+4. **`insideAtm` gate** — the brightness boost is also conditional on
+   the camera being inside the atmosphere shell. From space the LUT alone
+   correctly captures the thin-column transmittance; boosting it would
+   over-occlude.
+5. **Gap-pixel hard occlusion** — if `isGap` (geometric ground in front
+   of recorded depth), force `alpha = 1.0`. The sub-pixel holes show
+   only inscatter (bright haze by day, dark by night) instead of leaking
+   background. Side effect: a crisp horizon edge regardless of mesh
+   tessellation density.
+
+## Per-body sun intensity
+
+`atmosphere.sunIntensity` in each body's JSON descriptor is a tuneable
+knob that controls how bright the inscatter feels relative to the
+renderer's `toneMappingExposure` (3e-16, calibrated for sun-lumens
+scale). Earth's value is currently 60 — bumped from 20 so the day-side
+inscatter cleanly saturates the smoothstep, hides labels through the
+brightness-tied alpha, and feels like real daylight.
+
+## Knobs you might want to tune
+
+- `0.92` extinction cap — lower = stars peek through more at night
+  horizon; higher = more opaque
+- `(0.01, 0.1)` smoothstep bounds — lower bound = brightness at which
+  stars start fading at dawn; upper bound = brightness at which sky
+  goes fully opaque. Narrower band = sharper twilight star-fade.
+- `altWeight` curve — currently linear `1 - camAlt/atmHeight`. Could
+  be steepened (e.g. `pow(1 - alt/H, 2)`) so eye-adaptation drops off
+  faster with altitude.
+- Per-body `sunIntensity` — primary lever on overall day brightness.
+
+## Known gaps / future work
+
+- **Surface-vs-atmosphere coloring from space.** The additive composite
+  of inscatter + surface*T reads OK but the saturation/hue balance over
+  land vs ocean isn't perfectly tuned, and the coastal hand-off looks
+  slightly washed. Plausible knobs: per-channel inscatter scaling, a
+  soft saturation curve on the composite, or proper aerial-perspective
+  integration over the segment from surface depth back to camera.
+- **Auto-exposure (eye adaptation over time).** The `altWeight` boost
+  is a static per-pixel proxy for eye adaptation. A real implementation
+  would sample average scene luminance and adjust `toneMappingExposure`
+  with a temporal smoothing filter (~2 s constant) — letting the same
+  rendering work for stars-from-orbit and sun-disc-up-close without
+  per-context tuning.
+- **Multiple-scattering.** Current LUT is single-scatter only; the
+  twilight glow on the antisolar horizon is a multi-scattering
+  phenomenon that would need additional precompute passes.

--- a/public/data/earth.json
+++ b/public/data/earth.json
@@ -43,7 +43,7 @@
   "texture_dir": "earth/",
   "atmosphere": {
     "height": "8e4 m",
-    "sunIntensity": 20,
+    "sunIntensity": 60,
     "rayleigh": [5.8e-6, 1.35e-5, 3.31e-5],
     "rayleigh_unit": "1/m",
     "rayleighScaleHeight": "8e3 m",


### PR DESCRIPTION
## Summary
Stars now visible from the surface at night and through deep twilight, while the day sky stays opaque blue and the from-space view of the lit hemisphere correctly shows surface terrain through atmospheric haze. The atmosphere post-process pass was previously forcing inside-atmosphere alpha to ~1 unconditionally — fine for noon, broken for everything else.

The fix isn't a single tuning knob; it's a small stack of physics-grounded rules in the composition pass that work together to make day/night/dusk *and* surface-vs-orbit views all read right without violating physics anywhere it doesn't have to.

## Composition rules (Atmosphere.js, lines ~640-710)

1. **Trust the LUT alpha** — at zenith from sea level, real atmosphere transmits ~86% of starlight. Earlier rev forced this to 0; now we use it.
2. **Cap at 0.92** — night horizon has long path through atmosphere; pure physics gives near-100% extinction. Cap floors transmittance at 8% so horizon stars peek through (eye-adaptation proxy).
3. **Brightness-tied opacity (\`smoothstep\`)** — once inscatter is even faintly bright, alpha snaps to 1 so day blue covers HDR star-label sprites without needing implausible extinction. Models iris constriction.
4. **Altitude-weighted + \`insideAtm\` gate on the boost** — eye-adaptation is for the eye *embedded in the column*. From the top of atmosphere or from space, the LUT alone is correct. Without these gates: dark band in the limb transition zone at high altitude, and the day-side disc from orbit becomes featureless blue.
5. **Gap-pixel hard occlusion** — sub-pixel rasterization holes in the planet surface mesh (float32 precision at 1.5e11 m world coords gives ~1 m precision in MV matrix → sub-pixel gaps) used to leak the sun through Earth when looking nadir. Force \`alpha=1\` on those pixels: only inscatter shows.

## Other changes

- **Surface tessellation 128 → 512 segments** on planets (~262k tris/body, modest). Smaller triangles + tighter chord-to-arc fit reduce the float32-precision sub-pixel gaps that the gap-fix above defends against.
- **Earth \`sunIntensity\` 20 → 60** so the inscatter cleanly saturates the brightness-boost smoothstep at noon.
- **\`Scene.land\` resets dragMode to 'auto' instead of 'pan'**. Auto resolves to pan at touchdown but flips back to orbit when the user zooms out past the threshold — fixes the sticky pan-after-landing bug.

## Files

| File | Change |
|---|---|
| \`js/scene/atmos/Atmosphere.js\` | Composition rules 1-5 above (both LUT and ray-march fallback paths) |
| \`js/scene/atmos/composition.md\` | New sibling doc walking through what the post-process does, physical rationale per rule, knobs available for tuning, known gaps |
| \`js/scene/Planet.js\` | Surface mesh resolution 128 → 512 |
| \`js/scene/Scene.js\` | \`land()\` sets dragMode='auto' (was 'pan') |
| \`js/scene/Scene.test.js\` | Test updated to lock new contract |
| \`public/data/earth.json\` | sunIntensity 20 → 60 |

## Test plan
- [x] \`yarn test\` (297 tests) and \`yarn lint\` clean.
- [x] \`yarn precommit\` (lint + test + bundle dry-run) clean.
- [x] Land on Earth night side, look up — stars visible across the sky, dimmer near horizon. ✓
- [x] Same spot, advance time to dusk — stars fade out smoothly as sky brightens; ones near the lit horizon disappear first. ✓
- [x] Same spot, advance to noon — opaque blue sky, no stars/labels poking through. ✓
- [x] Look down through Earth toward sun (night side, nadir) — surface fully occludes sun, no leak. ✓
- [x] From space, look at Earth's day side — surface texture visible through atmospheric haze, blue limb glow. ✓
- [x] From high altitude (~50 km) look at limb — bright limb glow, smooth transition to starfield, no dark band. ✓
- [x] Land somewhere, then zoom out — drag mode flips back to orbit naturally past the threshold. ✓

## Known gaps (called out in composition.md)
- Surface-vs-atmosphere coloring from space — the additive composite reads OK but saturation/hue balance over land vs ocean isn't perfectly tuned. Plausible future work: per-channel inscatter scaling or proper aerial-perspective integration.
- No real auto-exposure yet — the altitude-weighted brightness boost is a static per-pixel proxy. Real auto-exposure (sample average luminance, smooth toward target with ~2 s constant) would let the same code work for stars-from-orbit and sun-disc-up-close without per-context tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)