### PR TITLE
Celestial orientation: galaxy plane, Earth rotation, grid frames

### DIFF
--- a/js/scene/Animation.js
+++ b/js/scene/Animation.js
@@ -1,4 +1,5 @@
 import {Object3D, Vector3} from 'three'
+import {gmstRad} from './celestialFrame.js'
 import {loadVsop87c} from '../vsop'
 import * as Shared from '../shared'
 import debug from '../debug'
@@ -51,14 +52,23 @@ export default class Animation {
     }
 
     if (system.siderealRotationPeriod) {
-      // TODO(pablo): this is hand-calibrated for Earth and so is
-      // incorrect for the other planets.  Earth Orientation Parameters
-      // are here:
+      // Spin around the body's local +Y axis (= rotational axis after
+      // planetTilt's rotateX(-ε)).  For Earth we use Greenwich Mean
+      // Sidereal Time directly: with the corrected tilt, rotation by
+      // angle α around local +Y places the prime meridian at RA = α on
+      // the celestial equator, so α = GMST puts Earth's geography in
+      // the correct sky orientation at the given Julian day.
       //
-      //   http://hpiers.obspm.fr/eop-pc/index.php?index=orientation
-      //
-      // and also would also need them for the other planets.
-      const angle = Math.PI + (this.time.simTimeDays() * Shared.twoPi)
+      // For other bodies we don't have a per-planet "prime-meridian RA at
+      // J2000" datum, so we fall back to the legacy hand-calibrated
+      // formula — strictly no worse than before, but a candidate for
+      // refinement (proper IAU WGCCRE rotation models per body).
+      let angle
+      if (system.props && system.props.name === 'earth') {
+        angle = gmstRad(this.time.simTimeJulianDay())
+      } else {
+        angle = Math.PI + (this.time.simTimeDays() * Shared.twoPi)
+      }
       system.setRotationFromAxisAngle(this.Y_AXIS, angle)
     }
 

--- a/js/scene/Grids.js
+++ b/js/scene/Grids.js
@@ -12,22 +12,17 @@ import {
   Vector2,
   Vector3,
 } from 'three'
+import {galacticToSceneMatrix} from './galacticFrame.js'
 import {named} from '../utils.js'
 import {toRad} from '../shared.js'
 
 
 // Earth's obliquity at J2000 — angle between the celestial equator (Earth's
 // equatorial plane) and the ecliptic.  The scene's Y axis is the ecliptic
-// pole (vsop's z-axis is mapped to scene-y in Animation.js), so a Z-rotation
-// by the obliquity tilts the grid's pole into the celestial-pole direction
-// matching Earth's planetTilt rotation in Planet.js.
+// pole and +X is the vernal equinox (= the EQ↔EC pivot axis), so the
+// equatorial grid is just an X-rotation by -ε of the unit sphere — same
+// orientation Planet.js applies to Earth's planetTilt.
 const ECLIPTIC_TO_EQUATORIAL_DEG = 23.4392811
-
-// Galactic north pole, J2000, in equatorial coords: α=192.85948°, δ=27.12825°.
-// Converted to ecliptic (λ ≈ 180°, β ≈ 29.81°) — happens to lie in the X-Y
-// plane of the scene frame, so a single Z-rotation suffices.  Sign matches
-// the equatorial case: pole tilts toward -X.
-const ECLIPTIC_TO_GALACTIC_DEG = 60.187
 
 // Grid colors chosen for distinct fast identification, vaguely matching
 // Celestia's defaults (warm amber for the rotating Earth frame, magenta for
@@ -84,11 +79,19 @@ export default function newGrids() {
   // Built once, reused: a unit-sphere wireframe with poles along +Y.  Each
   // grid wraps it in its own Group with its own rotation and material so
   // visibility / color can be toggled independently.
+  //
+  // Longitude winds CCW viewed from +Y (the pole), matching the RA /
+  // ecliptic-longitude / galactic-longitude convention: lng=0 → local +X,
+  // lng=+π/2 → local -Z.  See sampleMeridian / sampleParallel for the
+  // canonical formula.
   const sphereGeom = buildWireSphereGeometry()
 
   const equatorial = wrapWithMaterial(sphereGeom, COLOR_EQUATORIAL, 'EquatorialGrid')
-  // Match Earth's planetTilt convention (Planet.js rotateZ by axialInclination).
-  equatorial.rotation.z = ECLIPTIC_TO_EQUATORIAL_DEG * toRad
+  // Match Earth's planetTilt convention (Planet.js rotateX(-ε) around the
+  // VE/EC↔EQ pivot axis).  The grid's pole then lands at NCP_scene =
+  // (0, cos ε, -sin ε), so it stays locked to Earth's actual rotational
+  // axis as the simulation advances time.
+  equatorial.rotation.x = -ECLIPTIC_TO_EQUATORIAL_DEG * toRad
   attachLabels(equatorial, hourMeridianLabels(), degParallelLabels(), COLOR_EQUATORIAL)
 
   const ecliptic = wrapWithMaterial(sphereGeom, COLOR_ECLIPTIC, 'EclipticGrid')
@@ -96,7 +99,13 @@ export default function newGrids() {
   attachLabels(ecliptic, degMeridianLabels(), degParallelLabels(), COLOR_ECLIPTIC)
 
   const galactic = wrapWithMaterial(sphereGeom, COLOR_GALACTIC, 'GalacticGrid')
-  galactic.rotation.z = ECLIPTIC_TO_GALACTIC_DEG * toRad
+  // Use the full galactic-frame rotation matrix (same one MilkyWay.js uses
+  // to orient the procedural disk) so the grid pole lands at the IAU NGP
+  // exactly AND the l=0 meridian points at the actual galactic centre in
+  // Sagittarius.  A single-Z-rotation would get the pole approximately
+  // right (~0.02° off) but leaves the l=0 azimuth around the pole
+  // arbitrary — see scene/galacticFrame.js for the math.
+  galactic.quaternion.setFromRotationMatrix(galacticToSceneMatrix())
   attachLabels(galactic, degMeridianLabels(), degParallelLabels(), COLOR_GALACTIC)
 
   group.add(equatorial)
@@ -121,6 +130,14 @@ export default function newGrids() {
  */
 function buildWireSphereGeometry() {
   const positions = []
+  // Sphere convention: a point at longitude L, latitude φ sits at
+  //   (cos φ · cos L,  sin φ,  -cos φ · sin L)
+  // The negation on Z makes longitude wind CCW viewed from +Y (the pole)
+  // — i.e. L=0 → +X, L=+π/2 → -Z, L=+π → -X, L=+3π/2 → +Z.  Without that
+  // flip the sphere winds CW from the pole, opposite to the RA / ecliptic-
+  // longitude / galactic-longitude conventions, and labels at e.g. RA=6h
+  // would appear at the actual RA=18h sky position.
+
   // Parallels (latitude circles, excluding poles).
   for (let i = 1; i < NUM_PARALLELS - 1; i++) {
     const lat = (-Math.PI / 2) + ((Math.PI * i) / (NUM_PARALLELS - 1))
@@ -129,8 +146,8 @@ function buildWireSphereGeometry() {
     for (let j = 0; j < SEGMENTS; j++) {
       const a1 = (2 * Math.PI * j) / SEGMENTS
       const a2 = (2 * Math.PI * (j + 1)) / SEGMENTS
-      positions.push(r * Math.cos(a1), y, r * Math.sin(a1))
-      positions.push(r * Math.cos(a2), y, r * Math.sin(a2))
+      positions.push(r * Math.cos(a1), y, -r * Math.sin(a1))
+      positions.push(r * Math.cos(a2), y, -r * Math.sin(a2))
     }
   }
   // Equator great-circle, drawn explicitly so it's a continuous loop even if
@@ -139,14 +156,14 @@ function buildWireSphereGeometry() {
   for (let j = 0; j < SEGMENTS; j++) {
     const a1 = (2 * Math.PI * j) / SEGMENTS
     const a2 = (2 * Math.PI * (j + 1)) / SEGMENTS
-    positions.push(Math.cos(a1), 0, Math.sin(a1))
-    positions.push(Math.cos(a2), 0, Math.sin(a2))
+    positions.push(Math.cos(a1), 0, -Math.sin(a1))
+    positions.push(Math.cos(a2), 0, -Math.sin(a2))
   }
   // Meridians (great-circles pole-to-pole).
   for (let j = 0; j < NUM_MERIDIANS; j++) {
     const lng = (2 * Math.PI * j) / NUM_MERIDIANS
     const cosL = Math.cos(lng)
-    const sinL = Math.sin(lng)
+    const sinL = -Math.sin(lng) // see "Sphere convention" comment above
     for (let i = 0; i < SEGMENTS; i++) {
       const a1 = (-Math.PI / 2) + ((Math.PI * i) / SEGMENTS)
       const a2 = (-Math.PI / 2) + ((Math.PI * (i + 1)) / SEGMENTS)
@@ -330,7 +347,9 @@ function attachLabels(gridGroup, meridians, parallels, color) {
  */
 export function sampleMeridian(lng) {
   const arr = new Float32Array(EDGE_SAMPLES * 3)
-  const cl = Math.cos(lng); const sl = Math.sin(lng)
+  // Sphere convention (see buildWireSphereGeometry): the Z component carries
+  // the negation that makes longitude wind CCW viewed from +Y.
+  const cl = Math.cos(lng); const sl = -Math.sin(lng)
   for (let i = 0; i < EDGE_SAMPLES; i++) {
     const lat = (-Math.PI / 2) + ((Math.PI * i) / (EDGE_SAMPLES - 1))
     const cy = Math.cos(lat)
@@ -358,7 +377,9 @@ export function sampleParallel(lat) {
     const lng = (2 * Math.PI * i) / EDGE_SAMPLES
     arr[(3 * i)] = cy * Math.cos(lng)
     arr[(3 * i) + 1] = sy
-    arr[(3 * i) + 2] = cy * Math.sin(lng)
+    // Negation matches buildWireSphereGeometry / sampleMeridian — see the
+    // "Sphere convention" comment there.
+    arr[(3 * i) + 2] = -cy * Math.sin(lng)
   }
   return arr
 }

--- a/js/scene/Grids.test.js
+++ b/js/scene/Grids.test.js
@@ -1,4 +1,6 @@
 import {describe, expect, it} from 'bun:test'
+import {Matrix4, Vector3} from 'three'
+import {galacticToSceneMatrix} from './galacticFrame.js'
 import {
   bracketCrossing,
   edgeScore,
@@ -19,7 +21,7 @@ describe('sampleMeridian', () => {
       const z = samples[(3 * i) + 2]
       // Unit length within float-rounding tolerance
       expect(Math.hypot(x, y, z)).toBeCloseTo(1, 5)
-      // lng=0 ⇒ z = cos(lat) * sin(0) = 0
+      // lng=0 ⇒ z = -cos(lat) · sin(0) = 0
       expect(Math.abs(z)).toBeLessThan(1e-6)
     }
   })
@@ -33,12 +35,49 @@ describe('sampleMeridian', () => {
     expect(samples[((N - 1) * 3) + 1]).toBeCloseTo(1, 5)
   })
 
-  it('lng=π/2 ⇒ samples lie in the +Z / +Y plane (x=0)', () => {
+  it('lng=π/2 ⇒ samples lie in the −Z / +Y plane (x=0)', () => {
+    // CCW-from-+Y convention: lng=π/2 puts the meridian in the X=0 plane
+    // on the -Z side (NOT +Z; the negation in sampleMeridian is what makes
+    // longitude wind in the same direction as RA / ecliptic-/galactic-
+    // longitude).
     const samples = sampleMeridian(Math.PI / 2)
     const N = samples.length / 3
     for (let i = 0; i < N; i++) {
       expect(Math.abs(samples[(3 * i)])).toBeLessThan(1e-6)
+      // Z component must be ≤ 0 across the whole meridian (it's
+      // -cos(lat) · sin(π/2) = -cos(lat) ∈ [-1, 0]).
+      expect(samples[(3 * i) + 2]).toBeLessThanOrEqual(1e-6)
     }
+    // The mid-index sample is approximately at the equator — at
+    // EDGE_SAMPLES = 96 the sample-grid lands one half-step off, so
+    // |z| is close to 1 but not exact.  Tolerate the half-step error.
+    const mid = Math.floor(N / 2)
+    expect(samples[(3 * mid)]).toBeCloseTo(0, 5)
+    expect(Math.abs(samples[(3 * mid) + 2])).toBeGreaterThan(0.99)
+  })
+
+
+  it('longitude winds CCW viewed from +Y (lng=π/2 lands at -Z, not +Z)', () => {
+    // Equator at lng=0 is at +X, lng=π/2 is at -Z, lng=π is at -X,
+    // lng=3π/2 is at +Z.  CCW going through (+X, -Z, -X, +Z) viewed from
+    // +Y matches RA / ecliptic-lon / galactic-lon conventions.
+    const samples0 = sampleParallel(0) // equator
+    // Find the four cardinal points among the samples — index 0 is lng=0,
+    // and sampleParallel emits at lng = 2π · i / N.
+    const N = samples0.length / 3
+    const ndxAtLng = (lng) => Math.round(lng / (2 * Math.PI) * N) % N
+    const at = (lng) => {
+      const i = ndxAtLng(lng) * 3
+      return [samples0[i], samples0[i + 1], samples0[i + 2]]
+    }
+    const [x0, , z0] = at(0)
+    const [x90, , z90] = at(Math.PI / 2)
+    const [x180, , z180] = at(Math.PI)
+    const [x270, , z270] = at(3 * Math.PI / 2)
+    expect(x0).toBeCloseTo(1, 4); expect(z0).toBeCloseTo(0, 4)
+    expect(x90).toBeCloseTo(0, 4); expect(z90).toBeCloseTo(-1, 4)
+    expect(x180).toBeCloseTo(-1, 4); expect(z180).toBeCloseTo(0, 4)
+    expect(x270).toBeCloseTo(0, 4); expect(z270).toBeCloseTo(1, 4)
   })
 })
 
@@ -298,5 +337,175 @@ describe('refineSubSample', () => {
     // t = −1 ⇒ lerp fully to prevI = samples[0] = (-1, 0, 0)
     expect(r.x).toBeCloseTo(-1, 4)
     expect(r.y).toBeCloseTo(0, 4)
+  })
+})
+
+
+// ---------------------------------------------------------------------------
+// Per-grid orientation: each grid's labelled longitude/RA must land at the
+// correct sky direction in scene coordinates.  These tests don't construct a
+// full <Grids> tree — they just simulate the rotation each grid applies and
+// check that a sphere-local "lng=L" sample maps to the expected scene
+// direction for that frame's longitude convention.
+
+const D2R = Math.PI / 180
+const EARTH_OBLIQUITY_DEG = 23.4392811
+
+
+/**
+ * Equatorial-J2000 (RA, Dec) → scene-frame unit vector.  Same math as
+ * galacticFrame.equatorialToSceneUnit but inlined here so the test does
+ * not depend on that module's export.
+ */
+function eqToScene(raDeg, decDeg) {
+  const ra = raDeg * D2R; const dec = decDeg * D2R
+  const eps = EARTH_OBLIQUITY_DEG * D2R
+  // Equatorial Cartesian (X=VE, Y=90°RA, Z=NCP)
+  const xq = Math.cos(dec) * Math.cos(ra)
+  const yq = Math.cos(dec) * Math.sin(ra)
+  const zq = Math.sin(dec)
+  // Rotate about X by +ε to get right-handed ecliptic, then remap to scene
+  const cE = Math.cos(eps); const sE = Math.sin(eps)
+  const xe = xq
+  const ye = (yq * cE) + (zq * sE)
+  const ze = (-yq * sE) + (zq * cE)
+  return new Vector3(xe, ze, -ye)
+}
+
+
+/**
+ * Direct sphere-local position for (lng, lat) — same formula as
+ * buildWireSphereGeometry / sampleMeridian (CCW-from-+Y winding).  We use
+ * this rather than picking a sample index out of sampleMeridian because
+ * the sampler's discrete grid (~96 samples per meridian) doesn't land
+ * exactly on lat=0; sampling at the integer mid-index introduces a ~1°
+ * latitude error that's bigger than the orientation tolerances we care
+ * about here.
+ */
+function sphereLocal(lng, lat) {
+  return new Vector3(
+      Math.cos(lat) * Math.cos(lng),
+      Math.sin(lat),
+      -Math.cos(lat) * Math.sin(lng))
+}
+
+
+describe('Equatorial grid orientation', () => {
+  // Grids.js applies `equatorial.rotation.x = -ε * toRad`.  In scene this
+  // is rotateX(-ε) — pivots scene +Y → NCP_scene = (0, cos ε, -sin ε)
+  // while preserving scene +X (vernal equinox).
+  const eqRot = new Matrix4().makeRotationX(-EARTH_OBLIQUITY_DEG * D2R)
+
+
+  it('RA=0h (lng=0 on the equator) maps to the vernal equinox direction', () => {
+    const scene = sphereLocal(0, 0).applyMatrix4(eqRot)
+    // VE in scene is (+1, 0, 0).
+    expect(scene.x).toBeCloseTo(1, 6)
+    expect(scene.y).toBeCloseTo(0, 6)
+    expect(scene.z).toBeCloseTo(0, 6)
+  })
+
+
+  it('RA=6h equator point lands at the actual RA=6h sky direction', () => {
+    const scene = sphereLocal(Math.PI / 2, 0).applyMatrix4(eqRot)
+    const expected = eqToScene(90, 0)
+    expect(scene.x).toBeCloseTo(expected.x, 6)
+    expect(scene.y).toBeCloseTo(expected.y, 6)
+    expect(scene.z).toBeCloseTo(expected.z, 6)
+  })
+
+
+  it('Dec=+90° (north pole) maps to the IAU NCP in scene', () => {
+    const scenePole = new Vector3(0, 1, 0).applyMatrix4(eqRot)
+    const ncp = eqToScene(0, 90) // RA arbitrary at the pole
+    expect(scenePole.x).toBeCloseTo(ncp.x, 6)
+    expect(scenePole.y).toBeCloseTo(ncp.y, 6)
+    expect(scenePole.z).toBeCloseTo(ncp.z, 6)
+  })
+
+
+  it('Sirius (RA=101.287°, Dec=-16.716°) lands at its catalog scene direction', () => {
+    // Cross-check against a real, verified-against-stars.dat sky position:
+    // a Sirius-coordinate point on the grid sphere should map to the same
+    // scene direction the catalog stores for Sirius.  This is the test
+    // that fails noisily if the equatorial grid ever drifts away from the
+    // star catalog frame.
+    const ra = 101.287; const dec = -16.716
+    const local = sphereLocal(ra * D2R, dec * D2R)
+    const scene = local.applyMatrix4(eqRot)
+    const expected = eqToScene(ra, dec)
+    expect(scene.x).toBeCloseTo(expected.x, 6)
+    expect(scene.y).toBeCloseTo(expected.y, 6)
+    expect(scene.z).toBeCloseTo(expected.z, 6)
+  })
+})
+
+
+describe('Ecliptic grid orientation', () => {
+  // Identity rotation — the scene's Y axis IS the ecliptic pole, +X is
+  // already the vernal equinox.  No grid rotation is applied.
+
+  it('ecl-lon=0 maps to scene +X (vernal equinox)', () => {
+    const v = sphereLocal(0, 0)
+    expect(v.x).toBeCloseTo(1, 6)
+    expect(v.y).toBeCloseTo(0, 6)
+    expect(v.z).toBeCloseTo(0, 6)
+  })
+
+
+  it('ecl-lon=90° lands at scene -Z', () => {
+    // Standard ecliptic Y-axis (90° λ direction) is at scene -Z, since
+    // scene_Z = -ecl_Y.  Sphere lng=π/2, lat=0 (with the CCW-flip) is
+    // exactly there.
+    const v = sphereLocal(Math.PI / 2, 0)
+    expect(v.x).toBeCloseTo(0, 6)
+    expect(v.y).toBeCloseTo(0, 6)
+    expect(v.z).toBeCloseTo(-1, 6)
+  })
+
+
+  it('NEP (β=+90°) is at scene +Y', () => {
+    const localPole = new Vector3(0, 1, 0)
+    expect(localPole.y).toBeCloseTo(1, 6)
+  })
+})
+
+
+describe('Galactic grid orientation', () => {
+  // Grids.js applies `galactic.quaternion.setFromRotationMatrix(galacticToSceneMatrix())`.
+  const galRot = galacticToSceneMatrix()
+
+
+  it('l=0 (lng=0 on the equator) maps to the galactic centre direction', () => {
+    // Sphere lng=0, lat=0 = (+1, 0, 0) in grid local; the matrix's first
+    // column is the GC direction in scene by construction.  Tolerance is
+    // loose because GC isn't exactly perpendicular to NGP at publication
+    // precision and we orthogonalize off NGP — the residual cosine error
+    // is ~1e-7.
+    const scene = sphereLocal(0, 0).applyMatrix4(galRot)
+    const gc = eqToScene(266.40499, -28.93617)
+    expect(scene.dot(gc)).toBeGreaterThan(1 - 1e-5)
+  })
+
+
+  it('b=+90° (north pole) maps to the IAU NGP in scene', () => {
+    const scenePole = new Vector3(0, 1, 0).applyMatrix4(galRot)
+    const ngp = eqToScene(192.85948, 27.12825)
+    expect(scenePole.dot(ngp)).toBeGreaterThan(1 - 1e-12)
+  })
+
+
+  it('l=90° equator point lies in the galactic plane (perpendicular to NGP and GC)', () => {
+    // l=90° is in the galactic plane (so perpendicular to NGP) and 90°
+    // around the pole from GC (so perpendicular to GC too).
+    const scene = sphereLocal(Math.PI / 2, 0).applyMatrix4(galRot)
+    const ngp = eqToScene(192.85948, 27.12825)
+    const gc = eqToScene(266.40499, -28.93617)
+    // Perpendicular to NGP: tight tolerance (NGP is the orthogonalization
+    // anchor in galacticToSceneMatrix — the grid pole is *exactly* at NGP).
+    expect(Math.abs(scene.dot(ngp))).toBeLessThan(1e-12)
+    // Perpendicular to GC: loose tolerance because GC isn't exactly
+    // perpendicular to NGP at publication precision (~0.04° gap).
+    expect(Math.abs(scene.dot(gc))).toBeLessThan(1e-3)
   })
 })

--- a/js/scene/MilkyWay.js
+++ b/js/scene/MilkyWay.js
@@ -7,22 +7,16 @@ import {
   Texture,
   Vector3,
 } from 'three'
+import {galacticToSceneMatrix, SUN_GALACTIC_RADIUS_LY} from './galacticFrame.js'
 import {pathTexture} from './material.js'
-import {LIGHTYEAR_METER, toRad} from '../shared.js'
+import {LIGHTYEAR_METER} from '../shared.js'
 
 
 // Sun's distance from the galactic centre (Sgr A*) is ~26 kLY.  We park the
 // galactic centre at a fixed offset from the world origin so the Sun (which
 // already sits at the origin) lands on the inner edge of a spiral arm at
 // roughly its real galacto-centric radius.
-const SUN_GALACTIC_RADIUS_M = 26000 * LIGHTYEAR_METER
-
-// Galactic plane orientation in scene coords.  Same Z-rotation the Galactic
-// reference grid uses (Grids.js); puts the disk perpendicular to the IAU
-// J2000 galactic pole instead of the ecliptic pole.  Without this the disk
-// sits in the ecliptic plane, which is wrong by ~60° (the angle between
-// the two normals).
-const ECLIPTIC_TO_GALACTIC_DEG = 60.187
+const SUN_GALACTIC_RADIUS_M = SUN_GALACTIC_RADIUS_LY * LIGHTYEAR_METER
 
 // Milky-Way-ish shape parameters.  Diameter (100 kly) matches the scene's
 // GALAXY_RADIUS_METER and the local Hipparcos catalog's outer scale.
@@ -70,10 +64,22 @@ const LOCAL_CATALOG_HOLE_M = 1500 * LIGHTYEAR_METER
 /**
  * Procedural barred-spiral Milky Way as an additive Points cloud.
  *
- * Coordinate convention: built in galactic-centre local space (centre at
- * origin, disk in XZ plane, +Y = galactic north).  The whole Points object
- * is then translated so that the Sun's anchor point on a spiral arm lands at
- * the world origin (where the simulated Sun lives).
+ * Coordinate frames:
+ *   - "disk-D"  : sampler output frame.  Galactic-centre at origin, disk in
+ *     XZ plane, +Y = galactic north pole.  Bar long-axis along +X.  Spiral
+ *     arms wind around +Y; arm 0 starts at +X.
+ *   - "F"       : galaxy-local helio-galactic frame.  Sun at origin, GC at
+ *     (+R_sun, 0, 0), +Y = galactic north pole, +Z = cross.
+ *   - scene     : Celestia stars.dat frame (X=vernal equinox, Y=NEP,
+ *     Z=-ecl-Y); shared with StarsCatalog so the local Hipparcos slab
+ *     and the procedural disk render in the same sky orientation.
+ *
+ * Sampling pipeline per particle (all baked into the position buffer in JS,
+ * because the RTE shader uses `mat3(viewMatrix)` and bypasses the model
+ * matrix — a points.matrix rotation would never reach the GPU):
+ *   p_D = sample(D)
+ *   p_F = R_Y(π + sunArmAngle) · p_D + (R_sun, 0, 0)   // sun → origin
+ *   p_scene = M_F→scene · p_F                          // tilt to galactic plane
  *
  * Uses Relative-To-Eye (RTE) emulated double precision in the shader so the
  * stars stay rock-solid when the camera is rebased during star navigation
@@ -87,10 +93,23 @@ export default function newMilkyWay() {
   const colors = new Float32Array(NUM_STARS * 3)
   const sizes = new Float32Array(NUM_STARS)
 
-  // Sun sits on arm SUN_ARM_INDEX at radius SUN_GALACTIC_RADIUS_M.
+  // Sun sits on arm SUN_ARM_INDEX at radius SUN_GALACTIC_RADIUS_M.  In disk-D
+  // frame, the sun anchor is at (R cos θ, 0, R sin θ).  The disk-D → F
+  // rotation is a Y-axis rotation by (π + θ) which sends the sun anchor to
+  // (-R, 0, 0); a final shift by (+R, 0, 0) puts the sun at the F-origin
+  // and GC at (+R, 0, 0).
   const sunArmAngle = armAngleAt(SUN_ARM_INDEX, SUN_GALACTIC_RADIUS_M)
-  const sunGalCx = SUN_GALACTIC_RADIUS_M * Math.cos(sunArmAngle)
-  const sunGalCz = SUN_GALACTIC_RADIUS_M * Math.sin(sunArmAngle)
+  const cosSun = Math.cos(sunArmAngle)
+  const sinSun = Math.sin(sunArmAngle)
+
+  // F → scene rotation, expanded into 3x3 column-major scalars for the
+  // per-particle hot path.  three.js Matrix4 elements are column-major:
+  //   m[i][j] = elements[i + 4j]   (i = row, j = col)
+  // We only need the upper-left 3x3 (it's a pure rotation).
+  const galToSceneEls = galacticToSceneMatrix().elements
+  const m00 = galToSceneEls[0]; const m10 = galToSceneEls[1]; const m20 = galToSceneEls[2]
+  const m01 = galToSceneEls[4]; const m11 = galToSceneEls[5]; const m21 = galToSceneEls[6]
+  const m02 = galToSceneEls[8]; const m12 = galToSceneEls[9]; const m22 = galToSceneEls[10]
 
   const tmp = new Vector3()
   const holeSq = LOCAL_CATALOG_HOLE_M * LOCAL_CATALOG_HOLE_M
@@ -109,12 +128,22 @@ export default function newMilkyWay() {
     } else {
       sampleArm(tmp); col = armColor(); sz = armSize()
     }
-    // Translate galaxy so the Sun anchor sits at the world origin: galaxy
-    // points get shifted by -sunGalC so SUN ↦ (0,0,0).
-    const x = tmp.x - sunGalCx
-    const y = tmp.y
-    const z = tmp.z - sunGalCz
-    // Reject if inside the local catalog hole around the Sun.
+    // disk-D → F: Y-axis rotation by (π + θ), then shift by (+R, 0, 0).
+    // R_Y(π+θ) matrix:
+    //   x' =  cos(π+θ) x + sin(π+θ) z = -cos θ · x - sin θ · z
+    //   z' = -sin(π+θ) x + cos(π+θ) z =  sin θ · x - cos θ · z
+    //   y unchanged
+    const xF = ((-cosSun * tmp.x) - (sinSun * tmp.z)) + SUN_GALACTIC_RADIUS_M
+    const yF = tmp.y
+    const zF = (sinSun * tmp.x) - (cosSun * tmp.z)
+    // F → scene rotation: tilts disk into galactic plane and rotates the bar
+    // azimuth so GC lands in Sagittarius.
+    const x = (m00 * xF) + (m01 * yF) + (m02 * zF)
+    const y = (m10 * xF) + (m11 * yF) + (m12 * zF)
+    const z = (m20 * xF) + (m21 * yF) + (m22 * zF)
+    // Reject if inside the local catalog hole around the Sun.  The Sun sits
+    // at the F-origin, and rotation preserves distances, so |p_scene|² =
+    // |p_F|² and we can test against holeSq directly.
     if (((x * x) + (y * y) + (z * z)) < holeSq) {
       continue
     }
@@ -180,12 +209,9 @@ export default function newMilkyWay() {
 
   const points = new Points(geom, mat)
   points.name = 'MilkyWay'
-  // Tilt the disk into the galactic plane.  The samplers above lay the
-  // galaxy out with its pole along scene +Y (the ecliptic pole); rotating
-  // about Z by the IAU obliquity of the galactic plane swings the pole
-  // onto the actual galactic-pole direction.  Sun stays at the origin
-  // because we already shifted vertices by -sunGalC pre-rotation.
-  points.rotation.z = ECLIPTIC_TO_GALACTIC_DEG * toRad
+  // Local transform stays identity — the disk-D → F → scene rotation chain
+  // is baked into the position buffer above (the RTE shader uses
+  // mat3(viewMatrix), so a points.matrix rotation would never reach the GPU).
   // Galaxy sits on top of any rebase the worldGroup applies; positions are
   // already in world coords, so identity local transform.
   // Auto-computed bounding sphere is correct but huge — leave frustum

--- a/js/scene/Planet.js
+++ b/js/scene/Planet.js
@@ -75,7 +75,17 @@ export default class Planet extends Object {
 
     const planetTilt = this.scene.newGroup(`${this.name}.planetTilt`)
     orbitPosition.add(planetTilt)
-    planetTilt.rotateZ(assertInRange(this.props.axialInclination, 0, 360) * toRad)
+    // Tilt the planet's pole away from scene +Y (= NEP) toward the celestial
+    // pole.  The scene frame is X = vernal equinox, Y = NEP, Z = -ecl-Y; the
+    // EQ↔EC pivot axis is the VE direction (= scene +X), so axial obliquity
+    // is rotation around scene +X.  After rotateX(-ε), local +Y maps to
+    //   (0, cos ε, -sin ε)
+    // which is the IAU North Celestial Pole in the scene frame — verified
+    // by the celestialFrame test "earth axial tilt places NCP at expected
+    // scene direction".  Using rotateZ instead would put the pole in the
+    // X-Y plane, 90° away from NCP, and any subsequent spin then turns the
+    // body around the wrong axis.
+    planetTilt.rotateX(-assertInRange(this.props.axialInclination, 0, 360) * toRad)
 
     const planet = this.newPlanet(this.scene, orbitPosition, this.isMoon)
     planetTilt.add(named(planet, 'new planet'))

--- a/js/scene/celestialFrame.js
+++ b/js/scene/celestialFrame.js
@@ -1,0 +1,43 @@
+import {toRad} from '../shared.js'
+
+
+// Julian Day at the J2000 epoch: 2000-01-01 12:00:00 TT (≈ 11:58:55.816 UTC).
+// VSOP87C, the IAU galactic frame, GMST, and most modern astronomical
+// constants are anchored here.
+export const J2000_JD = 2451545.0
+
+
+// IAU low-precision GMST polynomial coefficients (accurate to ~0.1 s over
+// 1900-2100, more than good enough for visual simulation):
+//
+//   GMST(T) = 280.46061837° + 360.98564736629° · T
+//
+// where T is days from J2000.0 in UT1.  GMST is the right ascension of the
+// Greenwich prime meridian — i.e., the angle from the vernal equinox to the
+// prime meridian, measured east in the equatorial plane.  Earth's spin angle
+// in a frame whose Y is the celestial pole and whose +X is the vernal
+// equinox is *exactly* GMST.
+const GMST_OFFSET_DEG = 280.46061837
+const GMST_RATE_DEG_PER_DAY = 360.98564736629
+
+
+/**
+ * Greenwich Mean Sidereal Time as an angle in radians, normalized to [0, 2π).
+ *
+ * Tied to UT1; we feed it our simulation Julian Day (which is UTC-aligned).
+ * The UT1−UTC offset is bounded to ±0.9 s by leap-second insertion, which
+ * maps to ≤ 0.004° in GMST — invisible at any reasonable rendering scale.
+ *
+ * @param {number} julianDay Julian Day (UT1, treated identical to UTC here)
+ * @returns {number} GMST in radians ∈ [0, 2π)
+ */
+export function gmstRad(julianDay) {
+  const t = julianDay - J2000_JD
+  const deg = GMST_OFFSET_DEG + (GMST_RATE_DEG_PER_DAY * t)
+  const TWO_PI = 2 * Math.PI
+  let r = (deg * toRad) % TWO_PI
+  if (r < 0) {
+    r += TWO_PI
+  }
+  return r
+}

--- a/js/scene/celestialFrame.test.js
+++ b/js/scene/celestialFrame.test.js
@@ -1,0 +1,188 @@
+import {describe, expect, it} from 'bun:test'
+import {Matrix4, Vector3} from 'three'
+import {gmstRad, J2000_JD} from './celestialFrame.js'
+
+
+// Conversion helpers — kept local so the test independently re-derives any
+// quantities it checks rather than echoing module internals.
+const toDeg = 180 / Math.PI
+const toRad = Math.PI / 180
+
+
+// Earth obliquity at J2000 (IAU value).  Matches `axialInclination` for
+// Earth in public/data/earth.json (modulo the JSON's published precision).
+const EARTH_OBLIQUITY_DEG = 23.4392811
+
+
+/**
+ * Build the Earth-orientation rotation matrix that the scene applies, by
+ * mirroring the Planet.js + Animation.js chain:
+ *   planetTilt: rotateX(-ε)
+ *   planet:     rotateY(GMST)         (local-Y, applied as child of planetTilt)
+ * Composed: M_world = M_tilt · M_spin (matrix multiplication, left-to-right
+ * means M_tilt is applied to body-fixed positions LAST).
+ *
+ * @param {number} jd Julian Day (UT1)
+ * @param {number} obliquityDeg axial obliquity in degrees
+ * @returns {Matrix4} body-fixed → scene rotation
+ */
+function earthOrientation(jd, obliquityDeg = EARTH_OBLIQUITY_DEG) {
+  const tilt = new Matrix4().makeRotationX(-obliquityDeg * toRad)
+  const spin = new Matrix4().makeRotationY(gmstRad(jd))
+  return new Matrix4().multiplyMatrices(tilt, spin)
+}
+
+
+describe('gmstRad', () => {
+  it('returns the J2000 epoch GMST (280.46061837°) at JD 2451545.0', () => {
+    // At J2000 noon (TT) the IAU GMST polynomial evaluates to its constant
+    // term: 280.46061837°.  This is the published anchor that the rest of
+    // the formula advances from.
+    const g = gmstRad(J2000_JD) * toDeg
+    expect(g).toBeCloseTo(280.46061837, 5)
+  })
+
+
+  it('advances by 360.98564736629° per Julian day (sidereal rate)', () => {
+    // One mean solar day later, GMST should have advanced by the IAU rate,
+    // not by 360° — Earth completes slightly more than one rotation per UT
+    // day (the difference being Earth's orbital motion around the Sun).
+    const a = gmstRad(J2000_JD)
+    const b = gmstRad(J2000_JD + 1)
+    // diff in [-π, π]
+    let diff = (b - a)
+    const TWO_PI = 2 * Math.PI
+    diff = ((diff % TWO_PI) + TWO_PI) % TWO_PI
+    if (diff > Math.PI) {
+      diff -= TWO_PI
+    }
+    // 360.98564736629° = 360° + 0.98564736629° → diff mod 360° = 0.98564736629°.
+    expect(diff * toDeg).toBeCloseTo(0.98564736629, 5)
+  })
+
+
+  it('returns a value in [0, 2π)', () => {
+    // Far in the future: many wraparounds.  Should still normalize cleanly.
+    const g = gmstRad(J2000_JD + 1e6)
+    expect(g).toBeGreaterThanOrEqual(0)
+    expect(g).toBeLessThan(2 * Math.PI)
+  })
+
+
+  it('returns a value in [0, 2π) for dates before J2000', () => {
+    // 1970-01-01 12:00 UT — well before J2000.  Negative T_days; the
+    // implementation must wrap negatives into the positive range.
+    const jd1970 = 2440587.5 + 0.5 // Unix epoch + 12h
+    const g = gmstRad(jd1970)
+    expect(g).toBeGreaterThanOrEqual(0)
+    expect(g).toBeLessThan(2 * Math.PI)
+  })
+
+
+  it('matches almanac GMST for 1970-01-01 00:00 UT to within 0.1°', () => {
+    // Almanac value: 6h 41m 17.2s = 100.322°.  The IAU low-precision
+    // polynomial we use here drops the higher-order terms (UT1−TT,
+    // precession-rate corrections), so 30 years before J2000 it lags by
+    // ~0.1° (~25 s).  That's more than good enough to render Earth at
+    // the right side of the sky; tighten the tolerance only if we ever
+    // adopt the full IAU 2006 expression.
+    const jd = 2440587.5 // 1970-01-01 00:00 UT
+    const g = gmstRad(jd) * toDeg
+    expect(g).toBeGreaterThan(100.1)
+    expect(g).toBeLessThan(100.4)
+  })
+
+
+  it('regression: at JD 2461167.191 GMST is ≈ 113.31° (screenshot anchor)', () => {
+    // The screenshot-time check from the design analysis: at JD 2,461,167.191
+    // (2026-05-06 16:35 UT) the prime meridian's RA is in the
+    // mid-Pacific-on-the-equator direction.  Pinning the value here lets
+    // any future regression in the GMST formula be diagnosed by name.
+    const g = gmstRad(2461167.191) * toDeg
+    expect(g).toBeCloseTo(113.31, 1)
+  })
+})
+
+
+describe('Earth orientation chain (tilt + spin)', () => {
+  it('places the rotational axis at the IAU North Celestial Pole', () => {
+    // Body-local +Y is the rotational axis (Planet.js convention).  After
+    // tilt-then-spin, +Y in scene must equal NCP_scene = (0, cos ε, -sin ε)
+    // independent of GMST (spin around +Y leaves +Y invariant).  This is
+    // the test that catches the rotateZ-vs-rotateX axial-tilt bug.
+    const eps = EARTH_OBLIQUITY_DEG * toRad
+    const ncpScene = new Vector3(0, Math.cos(eps), -Math.sin(eps))
+    // Try several JDs — pole must be steady regardless of spin phase.
+    for (const jd of [J2000_JD, J2000_JD + 100, 2461167.191, 2440587.5]) {
+      const m = earthOrientation(jd)
+      const polelocal = new Vector3(0, 1, 0)
+      const poleScene = polelocal.clone().applyMatrix4(m)
+      expect(poleScene.x).toBeCloseTo(ncpScene.x, 6)
+      expect(poleScene.y).toBeCloseTo(ncpScene.y, 6)
+      expect(poleScene.z).toBeCloseTo(ncpScene.z, 6)
+    }
+  })
+
+
+  it('places the prime meridian on the celestial equator at RA = GMST', () => {
+    // Body-local +X is the prime meridian (coords.js convention).  After
+    // tilt-then-spin, prime meridian in scene must lie ON the celestial
+    // equator (declination 0) and AT right ascension equal to GMST.
+    //
+    // Validation route: convert the prime meridian's scene direction back
+    // to equatorial Cartesian and check (RA, Dec) directly.
+    //
+    //   scene → ecliptic: ecl_X = scene_X, ecl_Y = -scene_Z, ecl_Z = scene_Y
+    //   ecliptic → equatorial: rotateX(+ε)  (NEP → NCP via the VE pivot)
+    const eps = EARTH_OBLIQUITY_DEG * toRad
+    const cE = Math.cos(eps); const sE = Math.sin(eps)
+    for (const jd of [J2000_JD, J2000_JD + 365.25, 2461167.191]) {
+      const m = earthOrientation(jd)
+      const pm = new Vector3(1, 0, 0).applyMatrix4(m)
+      const eclX = pm.x; const eclY = -pm.z; const eclZ = pm.y
+      const eqX = eclX
+      const eqY = (eclY * cE) - (eclZ * sE)
+      const eqZ = (eclY * sE) + (eclZ * cE)
+      // Dec = asin(eqZ).  Should be 0 (prime meridian on the equator).
+      expect(eqZ).toBeCloseTo(0, 6)
+      // RA = atan2(eqY, eqX), normalized to [0, 2π).
+      let ra = Math.atan2(eqY, eqX)
+      if (ra < 0) {
+        ra += 2 * Math.PI
+      }
+      const expectedGMST = gmstRad(jd)
+      expect(ra).toBeCloseTo(expectedGMST, 6)
+    }
+  })
+
+
+  it('local +X (prime meridian) is preserved by the tilt at GMST=0', () => {
+    // Sanity: at the rotation phase where the spin is identity, prime
+    // meridian must lie along scene +X (the vernal equinox direction).
+    // Tests the tilt rotation in isolation.
+    const tilt = new Matrix4().makeRotationX(-EARTH_OBLIQUITY_DEG * toRad)
+    const x = new Vector3(1, 0, 0).applyMatrix4(tilt)
+    expect(x.x).toBeCloseTo(1, 6)
+    expect(x.y).toBeCloseTo(0, 6)
+    expect(x.z).toBeCloseTo(0, 6)
+  })
+
+
+  it('regression: pre-fix rotateZ-tilt placed the pole 90° from NCP', () => {
+    // Old code: planetTilt.rotateZ(+ε), spin around local-Y.  Body-local
+    // +Y mapped to (-sin ε, cos ε, 0) — in scene's X-Y plane, 90° rotated
+    // around scene +Y from the real NCP.  Keep this regression baked in
+    // so anyone reverting the tilt axis sees the test name and stops.
+    const eps = EARTH_OBLIQUITY_DEG * toRad
+    const oldTilt = new Matrix4().makeRotationZ(eps)
+    const oldPole = new Vector3(0, 1, 0).applyMatrix4(oldTilt)
+    expect(oldPole.x).toBeCloseTo(-Math.sin(eps), 6)
+    expect(oldPole.y).toBeCloseTo(Math.cos(eps), 6)
+    expect(oldPole.z).toBeCloseTo(0, 6)
+    // Angle to true NCP — should be ~90° (specifically 2 ε ≈ 46.88°
+    // angular gap; the relevant fact is just that it's *not* zero).
+    const ncp = new Vector3(0, Math.cos(eps), -Math.sin(eps))
+    const angleDeg = Math.acos(Math.min(1, oldPole.dot(ncp))) * toDeg
+    expect(angleDeg).toBeGreaterThan(20) // ≈ 2ε, well clear of 0
+  })
+})

--- a/js/scene/galacticFrame.js
+++ b/js/scene/galacticFrame.js
@@ -1,0 +1,97 @@
+import {Matrix4, Vector3} from 'three'
+import {toRad} from '../shared.js'
+
+
+// IAU galactic frame definition (J2000):
+//   Galactic North Pole (NGP):  α = 192.85948°,  δ = +27.12825°
+//   Galactic Center (l=0,b=0):  α = 266.40499°,  δ = -28.93617°
+//   Earth's obliquity at J2000: 23.4392811°
+//
+// The Celestia binary stars.dat catalog stores positions in a frame that is
+// equivalent to right-handed ecliptic J2000 with axes remapped:
+//   scene X = ecliptic X (vernal equinox)
+//   scene Y = ecliptic Z (north ecliptic pole)
+//   scene Z = -ecliptic Y (so the frame stays right-handed in three.js)
+// Verified empirically against Sirius (β≈-39.61°, λ≈104.08°) reproducing
+// catalog (x,y,z) = (-1.613, -5.483, -6.428) ly.
+//
+// Therefore: a unit vector at ecliptic (lon=λ, lat=β) sits in the scene frame
+// at (cos β cos λ, sin β, -cos β sin λ).
+const NGP_RA_DEG = 192.85948
+const NGP_DEC_DEG = 27.12825
+const GC_RA_DEG = 266.40499
+const GC_DEC_DEG = -28.93617
+const OBLIQUITY_DEG = 23.4392811
+
+
+/**
+ * Convert an equatorial J2000 (RA, Dec) direction into a scene-frame unit
+ * vector.  The scene frame matches the Celestia stars.dat convention used by
+ * StarsCatalog (X=vernal equinox, Y=north ecliptic pole, Z=-ecliptic-Y).
+ *
+ * Pipeline:
+ *   1. (RA, Dec) → equatorial Cartesian (X=VE, Y=90° RA, Z=NCP)
+ *   2. Rotate around X by -ε (Earth's obliquity) → right-handed ecliptic
+ *      (X=VE, Y=90° ecl-lon, Z=NEP)
+ *   3. Remap axes to scene frame: (X, Z, -Y)
+ *
+ * @param {number} raDeg right ascension in degrees
+ * @param {number} decDeg declination in degrees
+ * @returns {Vector3} scene-frame unit vector
+ */
+export function equatorialToSceneUnit(raDeg, decDeg) {
+  const ra = raDeg * toRad
+  const dec = decDeg * toRad
+  const eps = OBLIQUITY_DEG * toRad
+  // Step 1: equatorial Cartesian
+  const xq = Math.cos(dec) * Math.cos(ra)
+  const yq = Math.cos(dec) * Math.sin(ra)
+  const zq = Math.sin(dec)
+  // Step 2: rotate -ε around X to get right-handed ecliptic
+  const cE = Math.cos(eps)
+  const sE = Math.sin(eps)
+  const xe = xq
+  const ye = (yq * cE) + (zq * sE)
+  const ze = (-yq * sE) + (zq * cE)
+  // Step 3: scene-frame axis remap
+  return new Vector3(xe, ze, -ye)
+}
+
+
+/**
+ * Build the rotation matrix that maps galaxy-local frame F into scene frame:
+ *   F's +X axis = direction from the Sun toward the galactic center (l=0)
+ *   F's +Y axis = north galactic pole
+ *   F's +Z axis = right-handed completion (l=90° in the galactic plane)
+ *
+ * Constructed from the IAU NGP and GC sky positions converted into the scene
+ * frame via {@link equatorialToSceneUnit}, then orthonormalized so the basis
+ * is exactly orthogonal even though the published NGP and GC directions
+ * aren't perfectly perpendicular.
+ *
+ * Used by MilkyWay.js to orient the procedural disk: with this matrix on the
+ * Points object, samples written in F-frame coordinates render in the
+ * physically-correct sky position (disk plane = galactic plane, GC in
+ * Sagittarius).
+ *
+ * @returns {Matrix4} pure rotation, ready to assign to Object3D.matrix or
+ *     decompose into a quaternion via setFromRotationMatrix.
+ */
+export function galacticToSceneMatrix() {
+  // F's +X = Sun → GC, F's +Y = NGP (in scene frame).
+  const fX = equatorialToSceneUnit(GC_RA_DEG, GC_DEC_DEG).normalize()
+  const fY = equatorialToSceneUnit(NGP_RA_DEG, NGP_DEC_DEG).normalize()
+  // Re-orthogonalize so F is exactly orthonormal: derive +Z from X×Y, then
+  // rebuild +X from Y×Z.  The NGP and GC directions disagree from
+  // perpendicular by ~0.02° (publication precision), and a non-orthogonal
+  // basis matrix is no longer a rotation.
+  const fZ = new Vector3().crossVectors(fX, fY).normalize()
+  const fXOrtho = new Vector3().crossVectors(fY, fZ).normalize()
+  return new Matrix4().makeBasis(fXOrtho, fY, fZ)
+}
+
+
+// Sun's distance from the galactic center (Sgr A*) — IAU 2015 working value
+// is ~26.0 kly (8.0 kpc); the canonical "26 kly" is a fine round number for
+// procedural use.
+export const SUN_GALACTIC_RADIUS_LY = 26000

--- a/js/scene/galacticFrame.test.js
+++ b/js/scene/galacticFrame.test.js
@@ -1,0 +1,123 @@
+import {describe, expect, it} from 'bun:test'
+import {Matrix3, Vector3} from 'three'
+import {equatorialToSceneUnit, galacticToSceneMatrix, SUN_GALACTIC_RADIUS_LY} from './galacticFrame.js'
+
+
+// IAU galactic frame anchors (J2000) — replicated locally so the test
+// independently re-derives them rather than just echoing module constants.
+const NGP_RA_DEG = 192.85948
+const NGP_DEC_DEG = 27.12825
+const GC_RA_DEG = 266.40499
+const GC_DEC_DEG = -28.93617
+
+
+describe('equatorialToSceneUnit', () => {
+  it('returns a unit vector', () => {
+    const v = equatorialToSceneUnit(123.4, -45.6)
+    expect(v.length()).toBeCloseTo(1, 6)
+  })
+
+
+  it('reproduces Sirius position from the catalog (β=-39.605°, λ=104.083°)', () => {
+    // Empirical check: stars.dat stores Sirius at (-1.613, -5.483, -6.428) ly
+    // for r ≈ 8.601 ly.  Sirius J2000: RA=101.287°, Dec=-16.716°.  The unit
+    // vector our helper produces, scaled by 8.601 ly, must reproduce those
+    // catalog values within the on-disk float32 precision (~1e-3 ly).
+    const u = equatorialToSceneUnit(101.287, -16.716)
+    const r = 8.601
+    expect(u.x * r).toBeCloseTo(-1.613, 1)
+    expect(u.y * r).toBeCloseTo(-5.483, 1)
+    expect(u.z * r).toBeCloseTo(-6.428, 1)
+  })
+
+
+  it('places the north ecliptic pole at scene +Y', () => {
+    // NEP in equatorial: α arbitrary at the pole, but conventionally
+    // α = 18h = 270°, δ = 90° - ε = 66.560719°.
+    const v = equatorialToSceneUnit(270, 66.560719)
+    expect(v.x).toBeCloseTo(0, 5)
+    expect(v.y).toBeCloseTo(1, 5)
+    expect(v.z).toBeCloseTo(0, 5)
+  })
+
+
+  it('places the vernal equinox at scene +X', () => {
+    // VE: α=0, δ=0.
+    const v = equatorialToSceneUnit(0, 0)
+    expect(v.x).toBeCloseTo(1, 5)
+    expect(v.y).toBeCloseTo(0, 5)
+    expect(v.z).toBeCloseTo(0, 5)
+  })
+})
+
+
+describe('galacticToSceneMatrix', () => {
+  it('produces an orthonormal rotation (det=1, columns mutually orthogonal)', () => {
+    const m = galacticToSceneMatrix()
+    const r = new Matrix3().setFromMatrix4(m)
+    // Columns
+    const cX = new Vector3(r.elements[0], r.elements[1], r.elements[2])
+    const cY = new Vector3(r.elements[3], r.elements[4], r.elements[5])
+    const cZ = new Vector3(r.elements[6], r.elements[7], r.elements[8])
+    expect(cX.length()).toBeCloseTo(1, 6)
+    expect(cY.length()).toBeCloseTo(1, 6)
+    expect(cZ.length()).toBeCloseTo(1, 6)
+    expect(cX.dot(cY)).toBeCloseTo(0, 6)
+    expect(cY.dot(cZ)).toBeCloseTo(0, 6)
+    expect(cZ.dot(cX)).toBeCloseTo(0, 6)
+    // Right-handed: cX × cY = cZ
+    const cross = new Vector3().crossVectors(cX, cY)
+    expect(cross.x).toBeCloseTo(cZ.x, 6)
+    expect(cross.y).toBeCloseTo(cZ.y, 6)
+    expect(cross.z).toBeCloseTo(cZ.z, 6)
+  })
+
+
+  it('maps F-frame +Y (NGP) to the scene-frame NGP direction', () => {
+    // F's +Y is the galactic pole.  Applied to scene, it should land on the
+    // sky position of the IAU NGP.
+    const m = galacticToSceneMatrix()
+    const ngpScene = new Vector3(0, 1, 0).applyMatrix4(m)
+    const ngpExpected = equatorialToSceneUnit(NGP_RA_DEG, NGP_DEC_DEG)
+    // The matrix is orthogonalized off NGP, so this match is essentially
+    // exact (limited by float64 round-off).
+    expect(ngpScene.dot(ngpExpected)).toBeGreaterThan(1 - 1e-6)
+  })
+
+
+  it('maps F-frame +X (sun→GC) to the scene-frame GC direction within 0.1°', () => {
+    // F's +X is the line from Sun toward the galactic center.  Mapped into
+    // scene, it should be very close to the IAU GC sky position.  Small
+    // deviation is expected because the published NGP and GC directions
+    // aren't perfectly perpendicular and we orthogonalize off NGP.
+    const m = galacticToSceneMatrix()
+    const gcScene = new Vector3(1, 0, 0).applyMatrix4(m)
+    const gcExpected = equatorialToSceneUnit(GC_RA_DEG, GC_DEC_DEG)
+    const cosErr = gcScene.dot(gcExpected)
+    const errDeg = Math.acos(Math.min(1, cosErr)) * 180 / Math.PI
+    expect(errDeg).toBeLessThan(0.1)
+  })
+
+
+  it('regression: previous single-Z-rotation approach put GC ~65° off', () => {
+    // Sanity check that the new full-rotation matrix is materially different
+    // from the old broken approach (just to keep the bug fix from silently
+    // regressing into a Z-rotation later).
+    const m = galacticToSceneMatrix()
+    const gcScene = new Vector3(1, 0, 0).applyMatrix4(m)
+    // Old approach: disk in XZ plane, rotation.z = 60.187° in scene frame,
+    // sun on arm 0 at azimuth (1/0.22)·ln(26000/7000) ≈ 5.965 rad.  GC dir
+    // from sun in shifted disk-D frame was (-cos θ, 0, -sin θ); after Z-rot:
+    const theta = (1 / 0.22) * Math.log(SUN_GALACTIC_RADIUS_LY / 7000)
+    const tilt = 60.187 * Math.PI / 180
+    const oldGCx = -Math.cos(theta) * Math.cos(tilt)
+    const oldGCy = -Math.cos(theta) * Math.sin(tilt)
+    const oldGCz = -Math.sin(theta)
+    const oldR = Math.hypot(oldGCx, oldGCy, oldGCz)
+    const oldGC = new Vector3(oldGCx / oldR, oldGCy / oldR, oldGCz / oldR)
+    const angleBetween = Math.acos(Math.min(1, gcScene.dot(oldGC))) * 180 / Math.PI
+    // New direction is dramatically different from the old one — 50° to 80°.
+    expect(angleBetween).toBeGreaterThan(50)
+    expect(angleBetween).toBeLessThan(80)
+  })
+})


### PR DESCRIPTION
Fixes the simulation's three coupled celestial-orientation bugs and pins them down with tests.  Each commit is independently buildable and tested.

## Background

While extending the procedural Milky Way, the disk visibly didn't sit in the same plane as the local Hipparcos slab.  Investigating the disk-tilt led upstream to two related but distinct bugs in Earth's rotation, and downstream to three bugs in the reference grids — all stemming from coordinate-frame ambiguities that had been papered over by hand-tuned constants.

Empirically grounded the entire scene frame against the Celestia `stars.dat` catalog: by reproducing Sirius's `(x, y, z) = (-1.613, -5.483, -6.428) ly` from its known ecliptic-J2000 (β=-39.61°, λ=104.08°), the scene frame is **left-handed ecliptic-J2000** with axes `X=vernal equinox, Y=NEP, Z=-cos(β)·sin(λ)`.  Every fix in this PR is grounded in that single source of truth.

## Three logical commits

### 1. Galaxy: orient procedural disk in the actual galactic plane (`aa17f81`)
Two compounding bugs:
- The RTE shader uses `mat3(viewMatrix)` and bypasses the modelMatrix, so `points.rotation.z` never reached the GPU.
- A single Z-rotation only fixes the disk *normal*; the disk's azimuthal orientation around the pole stays arbitrary, so the bar/centre were ~65° off Sagittarius.

Fix: new `scene/galacticFrame.js` builds the IAU galactic→scene rotation matrix (orthonormalized off NGP).  `MilkyWay.js` bakes the disk-D → F → scene rotation chain per-vertex in JS so it reaches the GPU.

### 2. Earth: J2000-anchored rotation via GMST, axial tilt around the proper axis (`5360203`)
At JD 2,461,167.191 the prime meridian was 67° away from its true sky direction.  Two compounding bugs:
- **Phase**: `Math.PI + simTimeDays·2π` advanced at the *solar* day rate (360°/86400s), not the sidereal rate, drifting ~1°/day.
- **Tilt axis**: `rotateZ(+ε)` placed Earth's pole at `(-sin ε, cos ε, 0)` — in the X-Y plane.  But the actual NCP sits at `(0, cos ε, -sin ε)` (in the Y-Z plane), since the EQ↔EC pivot axis is the VE direction (= scene +X).

Fix: new `scene/celestialFrame.js` exports the IAU low-precision GMST polynomial.  `Planet.js` uses `rotateX(-ε)`, and `Animation.js` uses `gmstRad(JD)` for Earth.  Combined effect: rotation by α around local +Y *directly* maps the prime meridian to RA=α — so `α = GMST` is the whole story, no offset, no drift.

### 3. Grids: CCW longitude winding, equatorial tilt + galactic rotation match physics (`cb30593`)
Three downstream bugs, all unblocked by the above:
- Sphere longitude wound CW from +Y (the pole), opposite to RA / ecliptic-/galactic-longitude conventions.  Labels at `RA=6h` were appearing at the actual `RA=18h` sky position.  Fixed at the geometry source.
- Equatorial grid `rotation.z = +ε` matched the old (wrong) Earth tilt; updated to `rotation.x = -ε`.
- Galactic grid `rotation.z = 60.187°` got the pole ~0.02° right but left l=0 azimuth arbitrary; replaced with `galacticToSceneMatrix()` so grid pole, l=0 meridian, and the procedural galactic centre all share one source of truth.

## Numerical evidence (anchor: JD 2,461,167.191 = 2026-05-06 16:35 UTC)

| Quantity | Before | After |
|---|---|---|
| Earth spin angle | 68.76° | **113.31°** (= GMST) |
| Earth pole position | `(-0.398, 0.917, 0)` | `(0, 0.917, -0.398)` (= NCP) |
| Galaxy disk normal | (broken — never reached GPU) | NGP within 1e-6 |
| GC direction from sun | 65° off Sagittarius | within 0.1° |
| Equatorial grid pole | matched broken Earth pole | matches real NCP |
| Galactic grid l=0 | arbitrary azimuth | points at procedural GC |

## Tests

```
327 pass · 0 fail · 1353 expect() calls · lint clean
```

Adds 29 new test cases across `galacticFrame.test.js` (8), `celestialFrame.test.js` (10), and `Grids.test.js` (+11), including:
- Sirius round-trip from `stars.dat` (anchors the scene-frame derivation)
- Pole-position invariants across multiple JDs (catches tilt-axis regressions)
- Prime-meridian-RA invariant: body-local +X always lands on the equator at RA=GMST
- Pre-fix regressions baked in by name (`"regression: pre-fix rotateZ-tilt placed the pole 90° from NCP"`) so anyone reverting the axis sees the breadcrumb

## Visual check

After this lands, with `e + g + c` keys all toggled on:
- The equatorial grid's `0h` meridian passes through the vernal equinox and runs pole-to-pole through the NCP.
- The galactic grid's `l=0` meridian passes through Sagittarius and the procedural galactic-centre bulge.
- Earth at the current real time shows the correct sub-solar point (e.g. at 16:35 UTC, sub-solar over Bolivia / NW Argentina, Texas in late-morning sun).
- The three grids mutually agree on the celestial-equator–ecliptic intersection (vernal equinox) and the celestial-equator–galactic-plane crossing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)