### PR TITLE
Mobile AR sky view: device sensors → camera orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ node_modules
 # Website is built by GHA, so don't commit
 docs
 
+# Local TLS certs for HTTPS dev server (yarn cert:dev)
+dev-certs
+
 # Temp files
 *~
 #*

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -48,6 +48,7 @@ Celestiary            Main controller (window.c for debug)
   │     ├── Star      Individual named star (LOD, Perlin noise surface shader, PointLight)
   │     ├── Planet    Planet or moon (LOD, orbit shape, surface mesh, atmosphere, labels)
   │     └── Galaxy    Invisible grouping root (Milky Way container)
+  ├── ARController    Mobile sky view: device sensors → camera orientation
   ├── Loader          Async JSON fetcher for celestial object descriptors
   ├── ControlPanel    DOM-based nav display (breadcrumb path)
   └── Keys            Keyboard shortcut registry
@@ -399,3 +400,46 @@ and the provider extension contract.
 | `js/scene/PickLabels.js` | Label picking and marker display |
 | `js/scene/atmos/Atmosphere.js` | Atmosphere mesh + fullscreen post-process pass |
 | `js/scene/atmos/AtmospherePrecompute.js` | Bruneton transmittance + in-scatter LUT precomputation |
+
+### AR sky view (`js/ar/`)
+
+Pin the camera to a body surface and drive its orientation from device
+sensors so the rendered sky overlays the user's real-life view.  The
+heavy lifting — the rotating-body parent, the body-fixed lat/lng frame,
+the sidereal-rotation animation — already exists for the landed
+view; the AR module composes those with a sensor-driven camera→ENU
+quaternion to close the loop.
+
+Frame chain (per frame):
+
+```
+camera.quaternion =
+    enu_to_bodyFixed(lat, lng)   // js/ar/enuFrame.js
+  · q_calibration_enu             // js/ar/Calibration.js (optional)
+  · q_camera_to_enu               // js/ar/PoseSource.js (sensors)
+```
+
+The body-fixed → inertial step is inherited from the scene graph
+(camera.platform reparented to the rotating body via `Scene.land`).
+ARController.updateFrame writes the composed quaternion AFTER all other
+camera-orientation logic in `ThreeUI.renderLoop`, so AR pose always wins
+while active.
+
+Stage 1a (current): no camera-passthrough video, atmosphere disabled in
+AR mode (`Scene.enterAR` sets `ui._arMode`, `ThreeUI._updateAtmUniforms`
+honors it).  Stage 1b enables WebXR when supported.  Stage 1c adds
+`navigator.geolocation`.  Stage 1d wires the gear-icon calibration
+flow.  Stage 2 adds `<video>` passthrough behind the canvas with
+premultiplied-alpha atmosphere blending.
+
+| Path | Role |
+|---|---|
+| `js/ar/ARController.js` | Lifecycle (enter/exit), per-frame pose compose, calibration capture |
+| `js/ar/PoseSource.js` | Pose-source contract + factory; auto-probes WebXR → DeviceOrientation → Null |
+| `js/ar/NullPoseSource.js` | Identity-pose fallback (desktop / no sensors) |
+| `js/ar/DeviceOrientationPoseSource.js` | W3C DeviceOrientation → camera→ENU quaternion |
+| `js/ar/WebXRPoseSource.js` | WebXR `immersive-ar` / viewer-space (stub in stage 1a) |
+| `js/ar/enuFrame.js` | `enuTriadAtLatLng`, `enuToBodyFixedQuat` — body-agnostic ENU↔body-fixed math |
+| `js/ar/Calibration.js` | Single-vector calibration solver + per-(source, screen-angle) localStorage |
+| `js/ui/ARButton.jsx` | Mobile-only entry button + gear toggle when calibration is needed |
+| `js/store/ARSlice.js` | Zustand slice tracking active AR state for UI subscriptions |

--- a/esbuild/proxy.js
+++ b/esbuild/proxy.js
@@ -1,14 +1,18 @@
 import http from 'node:http'
+import https from 'node:https'
 
 
 /**
  * @param {string} proxiedHost The host to which traffic will be sent. E.g. localhost
  * @param {number} port The port to which traffic will be sent.  E.g. 8079
+ * @param {{key: Buffer, cert: Buffer}} [tlsOptions] When supplied, the
+ *   proxy listens on HTTPS using these credentials.  esbuild stays HTTP
+ *   on `host:port`; TLS terminates at the proxy.
  * @see https://esbuild.github.io/api/#serve-proxy
  * @returns {object} Proxy server
  */
-export function createProxyServer(host, port) {
-  return http.createServer((req, res) => {
+export function createProxyServer(host, port, tlsOptions) {
+  const handler = (req, res) => {
     const options = {
       hostname: host,
       port: port,
@@ -33,7 +37,8 @@ export function createProxyServer(host, port) {
 
     // Forward the body of the request to esbuild
     req.pipe(proxyReq, {end: true})
-  })
+  }
+  return tlsOptions ? https.createServer(tlsOptions, handler) : http.createServer(handler)
 }
 
 

--- a/esbuild/serve.js
+++ b/esbuild/serve.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+import os from 'node:os'
 import esbuild from 'esbuild'
 import config from './common.js'
 import {createProxyServer} from './proxy.js'
@@ -23,6 +25,53 @@ const {host, port} = await ctx.serve({
   port: SERVE_PORT - 1,
   servedir: config.outdir,
 })
-createProxyServer(host, port).listen(SERVE_PORT)
 
-console.log(`serving on http://localhost:${SERVE_PORT} and watching...`)
+const tlsOptions = loadTlsOptions()
+createProxyServer(host, port, tlsOptions).listen(SERVE_PORT)
+
+const scheme = tlsOptions ? 'https' : 'http'
+const lanIp = firstLanIPv4()
+console.log(`serving on ${scheme}://localhost:${SERVE_PORT} and watching...`)
+if (lanIp) {
+  console.log(`  LAN: ${scheme}://${lanIp}:${SERVE_PORT}`)
+}
+if (!tlsOptions) {
+  console.log('  (set DEV_HTTPS_KEY + DEV_HTTPS_CERT, or run `yarn cert:dev`, to enable HTTPS for mobile sensor APIs)')
+}
+
+
+/**
+ * Read PEM key/cert paths from env.  HTTPS is opt-in: both `DEV_HTTPS_KEY`
+ * and `DEV_HTTPS_CERT` must be set (which `yarn serve:https` does).  Plain
+ * `yarn serve` always speaks HTTP, even if `dev-certs/` files exist — this
+ * matters for `adb reverse` from a phone, where `localhost` is already a
+ * secure context and TLS just gets in the way.
+ *
+ * @returns {{key: Buffer, cert: Buffer} | undefined}
+ */
+function loadTlsOptions() {
+  const keyPath = process.env.DEV_HTTPS_KEY
+  const certPath = process.env.DEV_HTTPS_CERT
+  if (!keyPath || !certPath) {
+    return undefined
+  }
+  return {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  }
+}
+
+
+/**
+ * @returns {string | undefined} First non-internal IPv4 address, or undefined
+ */
+function firstLanIPv4() {
+  for (const ifaces of Object.values(os.networkInterfaces())) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        return iface.address
+      }
+    }
+  }
+  return undefined
+}

--- a/js/App.jsx
+++ b/js/App.jsx
@@ -5,8 +5,10 @@ import Box from '@mui/material/Box'
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline'
 import Stack from '@mui/material/Stack'
 import Celestiary from './Celestiary'
+import useIsMobile from './useIsMobile'
 import useStore from './store/useStore'
 import About from './ui/About'
+import ARButton from './ui/ARButton'
 import DragModeToggle from './ui/DragModeToggle'
 import SearchBar from './ui/SearchBar'
 import Settings from './ui/Settings'
@@ -25,6 +27,7 @@ export default function App() {
   const [celestiary, setCelestiary] = useState(null)
   const [isPaused, setIsPaused] = useState(false)
   const [timeStr, setTimeStr] = useState('')
+  const isMobile = useIsMobile()
 
   const sceneRef = useRef(null)
   const navInfoRef = useRef(null)
@@ -62,6 +65,8 @@ export default function App() {
       <Stack id='top-right' className='panel' direction='column' justifyContent='flex-start' alignItems='flex-end'>
         {celestiary && <TimePanel time={celestiary.time} timeStr={timeStr} isPaused={isPaused} setIsPaused={setIsPaused}/>}
         {celestiary && <DragModeToggle/>}
+        {celestiary && isMobile && typeof window !== 'undefined' && 'DeviceOrientationEvent' in window &&
+          <ARButton celestiary={celestiary}/>}
         <div id='text-buttons'>
           {celestiary &&
             <Box sx={{position: 'fixed', bottom: 0, left: 0, m: '1em'}}>

--- a/js/App.jsx
+++ b/js/App.jsx
@@ -9,6 +9,7 @@ import useIsMobile from './useIsMobile'
 import useStore from './store/useStore'
 import About from './ui/About'
 import ARButton from './ui/ARButton'
+import ARDebugHUD from './ui/ARDebugHUD'
 import DragModeToggle from './ui/DragModeToggle'
 import SearchBar from './ui/SearchBar'
 import Settings from './ui/Settings'
@@ -65,18 +66,18 @@ export default function App() {
       <Stack id='top-right' className='panel' direction='column' justifyContent='flex-start' alignItems='flex-end'>
         {celestiary && <TimePanel time={celestiary.time} timeStr={timeStr} isPaused={isPaused} setIsPaused={setIsPaused}/>}
         {celestiary && <DragModeToggle/>}
-        {celestiary && isMobile && typeof window !== 'undefined' && 'DeviceOrientationEvent' in window &&
-          <ARButton celestiary={celestiary}/>}
+        {celestiary && isMobile && <ARButton celestiary={celestiary}/>}
+        {celestiary && <ARDebugHUD celestiary={celestiary}/>}
         <div id='text-buttons'>
           {celestiary &&
             <Box sx={{position: 'fixed', bottom: 0, left: 0, m: '1em'}}>
-              <TooltipToggleButton tip='About' icon={<StarsIcon/>} onClick={() => navigate('/about')}/>
-              <Route path='/about'>
-                <About/>
-              </Route>
               <TooltipToggleButton tip='Settings' icon={<SettingsIcon/>} onClick={() => navigate('/settings')}/>
               <Route path='/settings'>
                 <Settings keys={celestiary.keys}/>
+              </Route>
+              <TooltipToggleButton tip='About' icon={<StarsIcon/>} onClick={() => navigate('/about')}/>
+              <Route path='/about'>
+                <About/>
               </Route>
             </Box>
           }

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -709,25 +709,10 @@ export default class Celestiary {
 
 
   /**
-   * @returns {?string} Name of the current target body if it's a planet/
-   *   moon (has a radius and is not a star); null for stars or empty
-   *   state.  Stars are excluded so AR's "stand on this body" default
-   *   doesn't silently land the user on the photosphere of the Sun when
-   *   the current target happened to be a star.  Detected via
-   *   `props.spectralType` — present on Star, absent on Planet.
+   * @returns {?string} See `landableBodyName(target)`.
    */
   _currentBodyName() {
-    const cur = Shared.targets.cur
-    if (!cur || !cur.props || !cur.props.name) {
-      return null
-    }
-    if (!cur.props.radius || !cur.props.radius.scalar) {
-      return null
-    }
-    if (cur.props.spectralType !== undefined) {
-      return null
-    }
-    return cur.props.name
+    return landableBodyName(Shared.targets.cur)
   }
 
 
@@ -769,3 +754,30 @@ export default class Celestiary {
 
 const DEFAULT_TARGET = 'sun'
 const J2000_JD = 2451545.0
+
+
+/**
+ * Decide whether a scene-graph target is a body the user can plausibly
+ * "stand on" for AR purposes.  Returns the body's name if it has a
+ * surface (radius > 0) AND isn't a star (lacks `spectralType`); null
+ * otherwise.  Stars are excluded so tapping AR while viewing the Sun
+ * doesn't silently teleport the user to the photosphere — the AR
+ * caller falls back to a sensible default body (Earth) when this
+ * returns null.
+ *
+ * @param {?object} target  Scene-graph node (typically `Shared.targets.cur`)
+ * @returns {?string}
+ */
+export function landableBodyName(target) {
+  const props = target?.props
+  if (!props || !props.name) {
+    return null
+  }
+  if (!props.radius || !props.radius.scalar) {
+    return null
+  }
+  if (props.spectralType !== undefined) {
+    return null
+  }
+  return props.name
+}

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -361,141 +361,210 @@ export default class Celestiary {
   setupKeyListeners(useStore) {
     const k = new Keys(window, useStore)
 
-    // Nav panels (HTML chrome only)
+    // === Info ===
     k.map('v', () => this._toggleNav(),
-        'Hide/show navigation panels (HTML overlay)')
-
-    // Presentation mode — hide every scene annotation at once.
+        'Target properties HUD (HTML overlay)',
+        () => this.scene.getSetting('v'),
+        'Info')
+    k.addAction(() => useStore.getState().toggleARDebug(),
+        'AR debug HUD',
+        () => useStore.getState().arDebugVisible,
+        'Info')
+    // Presentation mode — hide every scene annotation at once.  No clean
+    // single-state representation, so it stays an action button.
     k.map('V', () => this._toggleAllSceneInfo(),
-        'Hide/show all scene annotations (labels, orbits, asterisms, grids)')
+        'Hide/show all scene annotations (labels, orbits, asterisms, grids)',
+        undefined,
+        'Info')
 
-    // Scene elements
-    k.map('a', () => {
-      this.scene.toggleAsterisms()
-    },
-    'Show/hide constellations')
+    // === Labels ===
     k.map('p', () => {
       this.scene.togglePlanetLabels()
     },
-    'Show/hide planet and moon names')
+    'Planets',
+    () => this.scene.getSetting('p'),
+    'Labels')
     k.map('s', () => {
       this.scene.toggleStarLabels()
     },
-    'Show/hide star names')
+    'Stars',
+    () => this.scene.getSetting('l'),
+    'Labels')
+    k.map('a', () => {
+      this.scene.toggleAsterisms()
+    },
+    'Constellations',
+    () => this.scene.getSetting('a'),
+    'Labels')
+    k.map('U', () => {
+      this.scene.toggleGalaxy()
+    },
+    'Milky Way (procedural background galaxy)',
+    () => this.scene.getSetting('U'),
+    'Labels')
+
+    // === Orbits ===
     k.map('o', () => {
       this.scene.toggleOrbits()
     },
-    'Show/hide orbits')
+    'Orbits',
+    () => this.scene.getSetting('o'),
+    'Orbits')
+
+    // === Grids ===
     k.map(';', () => {
       this.scene.toggleGridEquatorial()
     },
-    'Show/hide equatorial reference grid')
+    'Equatorial',
+    () => this.scene.getSetting('e'),
+    'Grids')
+    k.addAction(() => {
+      this.scene.toggleGridEcliptic()
+    },
+    'Ecliptic',
+    () => this.scene.getSetting('c'),
+    'Grids')
+    k.addAction(() => {
+      this.scene.toggleGridGalactic()
+    },
+    'Galactic',
+    () => this.scene.getSetting('g'),
+    'Grids')
+
+    // === Time ===
+    k.map(' ', () => {
+      this.setIsPaused(this.time.togglePause())
+    },
+    'Toggle time pause',
+    undefined,
+    'Time')
+    k.map('\\', () => {
+      this.time.changeTimeScale(0)
+    },
+    'Change time scale to real-time',
+    undefined,
+    'Time')
+    k.map('!', () => {
+      this.time.setTimeToNow()
+    },
+    'Set time to now',
+    undefined,
+    'Time')
+    k.map('j', () => {
+      this.time.invertTimeScale()
+    },
+    'Reverse time',
+    undefined,
+    'Time')
+    k.map('k', () => {
+      this.time.changeTimeScale(-1)
+    },
+    'Slow down time',
+    undefined,
+    'Time')
+    k.map('l', () => {
+      this.time.changeTimeScale(1)
+    },
+    'Speed up time',
+    undefined,
+    'Time')
+    k.map('n', () => {
+      this.time.setTimeToNow()
+    },
+    'Set time to now',
+    undefined,
+    'Time')
+
+    // === Camera ===
+    k.map(',', () => {
+      this.ui.multFov(0.9)
+    },
+    'Narrow field-of-vision',
+    undefined,
+    'Camera')
+    k.map('.', () => {
+      this.ui.multFov(1.1)
+    },
+    'Broaden field-of-vision',
+    undefined,
+    'Camera')
+    k.map('/', () => {
+      this.ui.resetFov()
+    },
+    `Reset field-of-vision to ${ Shared.INITIAL_FOV }º`,
+    undefined,
+    'Camera')
     k.map('m', () => {
       const s = useStore.getState()
       const next = {auto: 'pan', pan: 'orbit', orbit: 'auto'}[s.dragMode] ?? 'auto'
       s.setDragMode(next)
     },
-    'Cycle camera drag mode (Auto / Drag Pan / Move)')
-    // No keys for ecliptic / galactic per Celestia convention; click-only
-    // entries appear in Settings after the keyed shortcuts.
-    k.addAction(() => {
-      this.scene.toggleGridEcliptic()
-    },
-    'Show/hide ecliptic reference grid')
-    k.addAction(() => {
-      this.scene.toggleGridGalactic()
-    },
-    'Show/hide galactic reference grid')
-
-    // Time
-    k.map(' ', () => {
-      this.setIsPaused(this.time.togglePause())
-    },
-    'Toggle time pause')
-    k.map('\\', () => {
-      this.time.changeTimeScale(0)
-    },
-    'Change time scale to real-time')
-    k.map('!', () => {
-      this.time.setTimeToNow()
-    },
-    'Set time to now')
-    k.map('j', () => {
-      this.time.invertTimeScale()
-    },
-    'Reverse time')
-    k.map('k', () => {
-      this.time.changeTimeScale(-1)
-    },
-    'Slow down time')
-    k.map('l', () => {
-      this.time.changeTimeScale(1)
-    },
-    'Speed up time')
-    k.map('n', () => {
-      this.time.setTimeToNow()
-    },
-    'Set time to now')
-
-    // View
-    k.map(',', () => {
-      this.ui.multFov(0.9)
-    },
-    'Narrow field-of-vision')
-    k.map('.', () => {
-      this.ui.multFov(1.1)
-    },
-    'Broaden field-of-vision')
-    k.map('/', () => {
-      this.ui.resetFov()
-    },
-    `Reset field-of-vision to ${ Shared.INITIAL_FOV }º`)
-
-    // Numbered views
+    'Cycle camera drag mode (Auto / Drag Pan / Move)',
+    undefined,
+    'Camera')
+    // Numbered views — pin a child of current system as look-target.
     k.map('0', () => {
       this.scene.targetCurNode()
     },
-    'Target current system')
+    'Target current system',
+    undefined,
+    'Camera')
     for (let i = 1; i <= 9; i++) {
       k.map(`${i}`, () => {
         const ndx = i
         this.scene.targetNode(ndx)
       },
-      `Look at child ${i} of current system`)
+      `Look at child ${i} of current system`,
+      undefined,
+      'Camera')
     }
+
+    // === Targeting ===
     k.map('c', () => {
       this.scene.lookAtTarget()
     },
-    'Look at target')
+    'Look at target',
+    undefined,
+    'Targeting')
     k.map('f', () => {
       this.scene.follow()
     },
-    'Follow current node')
+    'Follow current node',
+    undefined,
+    'Targeting')
     k.map('g', () => {
       this.goTo()
     },
-    'Go to target node')
+    'Go to target node',
+    undefined,
+    'Targeting')
     k.map('h', () => {
       // Just retarget — travel is 'g'.  setTarget syncs the store, which
       // clears committedStar so a stale "at Rigel" breadcrumb doesn't
       // linger after aiming back at the Sun.
       this.scene.targetNamed('sun')
     },
-    'Set target to Sun (use "g" to travel)')
+    'Set target to Sun (use "g" to travel)',
+    undefined,
+    'Targeting')
     k.map('t', () => {
       this.scene.track()
     },
-    'Track target node')
+    'Track target node',
+    undefined,
+    'Targeting')
     k.map('u', () => {
       this.scene.targetParent()
     },
-    'Look at parent of current system')
+    'Look at parent of current system',
+    undefined,
+    'Targeting')
 
     // Arrow keys use held-key logic in ThreeUI._initArrowKeys; no-op here for Settings listing.
-    k.map('ArrowUp', () => {/* no-op */}, 'Pitch camera up (hold)')
-    k.map('ArrowDown', () => {/* no-op */}, 'Pitch camera down (hold)')
-    k.map('ArrowLeft', () => {/* no-op */}, 'Roll camera left (hold)')
-    k.map('ArrowRight', () => {/* no-op */}, 'Roll camera right (hold)')
+    k.map('ArrowUp', () => {/* no-op */}, 'Pitch camera up (hold)', undefined, 'Camera')
+    k.map('ArrowDown', () => {/* no-op */}, 'Pitch camera down (hold)', undefined, 'Camera')
+    k.map('ArrowLeft', () => {/* no-op */}, 'Roll camera left (hold)', undefined, 'Camera')
+    k.map('ArrowRight', () => {/* no-op */}, 'Roll camera right (hold)', undefined, 'Camera')
     k.msgs['MOUSEDRAG'] = 'Drag to pitch/yaw camera'
     k.msgs['ALT+MOUSEDRAG'] = 'Option+drag to orbit target'
 
@@ -629,8 +698,23 @@ export default class Celestiary {
 
 
   /**
-   * @returns {?string} Name of the current target body if it's a body
-   *   (has a radius); null for stars or empty state.
+   * Forward an alpha-axis damping preset change to the AR controller.
+   * No-op while AR is inactive — preset applies on next enterAR().
+   *
+   * @param {string} name  One of `getAlphaDampingNames()`
+   */
+  setARAlphaDamping(name) {
+    this.ar.setAlphaDamping(name)
+  }
+
+
+  /**
+   * @returns {?string} Name of the current target body if it's a planet/
+   *   moon (has a radius and is not a star); null for stars or empty
+   *   state.  Stars are excluded so AR's "stand on this body" default
+   *   doesn't silently land the user on the photosphere of the Sun when
+   *   the current target happened to be a star.  Detected via
+   *   `props.spectralType` — present on Star, absent on Planet.
    */
   _currentBodyName() {
     const cur = Shared.targets.cur
@@ -638,6 +722,9 @@ export default class Celestiary {
       return null
     }
     if (!cur.props.radius || !cur.props.radius.scalar) {
+      return null
+    }
+    if (cur.props.spectralType !== undefined) {
       return null
     }
     return cur.props.name

--- a/js/Celestiary.js
+++ b/js/Celestiary.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import ARController from './ar/ARController'
 import Animation from './scene/Animation'
 import ControlPanel from './ControlPanel'
 import Keys from './Keys'
@@ -67,6 +68,16 @@ export default class Celestiary {
     this.firstTime = true
     this._pendingPermalink = null
     this._permalinkTimer = null
+    // AR (mobile sky-view).  Constructed lazily — most users won't enter
+    // AR mode, and the controller has no per-frame cost when inactive
+    // (ThreeUI.renderLoop checks isActive() before calling updateFrame).
+    this.ar = new ARController({
+      scene: this.scene,
+      ui: this.ui,
+      time: this.time,
+      useStore: useStore,
+    })
+    this.ui.arController = this.ar
     this._registerSearchProviders()
     this._subscribePreview()
     this.load()
@@ -256,6 +267,17 @@ export default class Celestiary {
           const wantedSettings = pl?.settings ?? decodeSettings(undefined)
           this.scene.applySettings(wantedSettings)
           this.firstTime = false
+        }
+        // AR-fallback resolution: if the permalink was captured in AR
+        // mode (s=A), try to re-enter AR at the saved lat/lng.
+        // Best-effort — on iOS Safari `requestPermission()` requires a
+        // user gesture, so this auto-attempt rejects silently and the
+        // user can tap the AR button (which is a real gesture) to enter.
+        if (pl?.settings?.A && typeof pl.lat === 'number' && typeof pl.lng === 'number') {
+          this.ar?.enter({lat: pl.lat, lng: pl.lng, alt: pl.alt}).catch(() => {
+            // Silent — sensor unavailability or permission denial just
+            // leaves the static permalink view as the visible result.
+          })
         }
       }, this._pendingPermalink ? 0 : (this.firstTime ? 1000 : 0))
     }
@@ -564,10 +586,61 @@ export default class Celestiary {
       )
       const d2000 = this.time.simTimeJulianDay() - J2000_JD
       const settings = this.scene.getSettings ? this.scene.getSettings() : null
+      // Mark AR-active so a recipient device with sensors can re-enter
+      // AR at this lat/lng.  Saved quaternion is left as-is; the AR
+      // resolution path overwrites camera orientation from sensors each
+      // frame, so the saved value is harmlessly ignored on AR replay.
+      if (settings && this.ar && this.ar.isActive()) {
+        settings.A = true
+      }
       const fragment = encodePermalink(
           path, d2000, lat, lng, alt, cam.quaternion, cam.fov, settings)
       history.replaceState(null, '', `#${fragment}`)
     }, 1000)
+  }
+
+
+  /**
+   * Enter AR sky-view mode.  Must be called from within a user gesture
+   * (button tap) so iOS Safari's `DeviceOrientationEvent.requestPermission`
+   * can prompt — the browser silently rejects the prompt otherwise.
+   *
+   * Requires explicit lat/lng (we add geoid-derived geolocation later).
+   * Body defaults to the currently committed target if it's a planet/moon
+   * with a radius; otherwise to 'earth'.
+   *
+   * @param {object} opts
+   * @param {string} [opts.body]
+   * @param {number} opts.lat
+   * @param {number} opts.lng
+   * @param {number} [opts.alt]
+   * @returns {Promise<void>}
+   */
+  enterAR(opts) {
+    const body = opts.body ?? this._currentBodyName() ?? 'earth'
+    return this.ar.enter({...opts, body})
+  }
+
+
+  /** Exit AR sky-view mode and restore the prior view state. */
+  exitAR() {
+    this.ar.exit()
+  }
+
+
+  /**
+   * @returns {?string} Name of the current target body if it's a body
+   *   (has a radius); null for stars or empty state.
+   */
+  _currentBodyName() {
+    const cur = Shared.targets.cur
+    if (!cur || !cur.props || !cur.props.name) {
+      return null
+    }
+    if (!cur.props.radius || !cur.props.radius.scalar) {
+      return null
+    }
+    return cur.props.name
   }
 
 

--- a/js/Keys.js
+++ b/js/Keys.js
@@ -5,9 +5,17 @@ export default class Keys {
     this.window = win
     this.keymap = {}
     this.msgs = {}
+    // Per-key state getter for boolean toggles: the Settings UI renders
+    // these as checkboxes (with current state) instead of plain buttons.
+    // Pure read-side — caller is responsible for passing the same fn on
+    // every refresh.  Absent for one-shot action keys ('h', 'g', etc.).
+    this.toggleStates = {}
+    // Per-key group label, drives the Settings panel section grouping.
+    // Entries without a group land in `MISC_GROUP_NAME` at the bottom.
+    this.groups = {}
     // Click-only actions: items the user can toggle from Settings but which
-    // don't have a keyboard shortcut.  Each entry: {fn, msg}.  Listed in
-    // Settings after the keyed shortcuts.
+    // don't have a keyboard shortcut.  Each entry: {fn, msg, getState?, group?}.
+    // Listed in Settings after the keyed shortcuts.
     this.actions = []
     this.bindToWindow(useStore)
   }
@@ -58,10 +66,20 @@ export default class Keys {
    *   different handlers).
    * @param {Function} fn
    * @param {string} msg
+   * @param {Function} [getState] Optional zero-arg boolean getter; when
+   *   supplied, Settings renders this entry as a checkbox reflecting the
+   *   current state instead of a click-only button.
+   * @param {string} [group] Optional Settings-panel section heading.
    */
-  map(c, fn, msg) {
+  map(c, fn, msg, getState, group) {
     this.keymap[c] = fn
     this.msgs[c] = msg
+    if (typeof getState === 'function') {
+      this.toggleStates[c] = getState
+    }
+    if (typeof group === 'string') {
+      this.groups[c] = group
+    }
   }
 
 
@@ -70,8 +88,19 @@ export default class Keys {
    *
    * @param {Function} fn
    * @param {string} msg
+   * @param {Function} [getState] Optional zero-arg boolean getter; when
+   *   supplied, Settings renders this action as a checkbox reflecting the
+   *   current state instead of a click-only button.
+   * @param {string} [group] Optional Settings-panel section heading.
    */
-  addAction(fn, msg) {
-    this.actions.push({fn, msg})
+  addAction(fn, msg, getState, group) {
+    const entry = {fn, msg}
+    if (typeof getState === 'function') {
+      entry.getState = getState
+    }
+    if (typeof group === 'string') {
+      entry.group = group
+    }
+    this.actions.push(entry)
   }
 }

--- a/js/ThreeUI.js
+++ b/js/ThreeUI.js
@@ -296,6 +296,12 @@ export default class ThreeUi {
       }
     }
     this._applyCameraArrowKeys()
+    // AR mode (when active) owns camera.quaternion absolutely.  Run last so
+    // anything else's writes are overwritten.  Set by Celestiary.enterAR
+    // through this.arController; null when AR is inactive (the common case).
+    if (this.arController && this.arController.isActive()) {
+      this.arController.updateFrame()
+    }
     this._publishEffectiveDragMode()
     // Render scene to RT, then composite atmosphere fullscreen pass to screen
     this.renderer.setRenderTarget(this._sceneRT)
@@ -356,6 +362,15 @@ export default class ThreeUi {
     u.uNear.value = this.camera.near
     u.uFar.value = this.camera.far
     u.uProjectionMatrixInverse.value.copy(this.camera.projectionMatrixInverse)
+
+    if (this._arMode) {
+      // AR mode: skip the atmosphere altogether so daytime sky doesn't
+      // paint over the stars and asterism overlay.  Set by Scene.enterAR
+      // and cleared by Scene.exitAR.  Stage 2 (camera passthrough) will
+      // re-enable the atmosphere with premultiplied-alpha blending.
+      u.uAtmEnabled.value = 0.0
+      return
+    }
 
     const tObj = targets.obj
     // Determine which planet's atmosphere to render.

--- a/js/Time.test.js
+++ b/js/Time.test.js
@@ -1,19 +1,29 @@
 import {timeToDateStr} from './Time'
 
 
+// `toLocaleDateString` formats with an ICU-version-dependent separator
+// between the date and the clock — "Apr 5 at 10:13" on some ICU builds,
+// "Apr 5, 10:13" on others.  Both renderings are meaningfully equivalent
+// for the human readers of the time HUD, so the assertions here only
+// pin the year + month + day + clock components and accept either glue
+// token.
+const SEP = '(?:,| at)'
+
+
 describe('Time', () => {
   describe('timeToDateStr', () => {
     it('handles start of unix epoch', () => {
-      expect(timeToDateStr(0).toString()).toEqual('1970 Jan 1 at 12:00:00 AM')
+      expect(timeToDateStr(0).toString()).toMatch(new RegExp(`^1970 Jan 1${SEP} 12:00:00 AM$`))
     })
 
     it('handles future', () => {
-      expect(timeToDateStr(1000000000000000).toString()).toEqual('33,658 Sep 27 at 1:46:40 AM')
+      expect(timeToDateStr(1000000000000000).toString())
+          .toMatch(new RegExp(`^33,658 Sep 27${SEP} 1:46:40 AM$`))
     })
 
     it('handles past', () => {
-      expect(timeToDateStr(-1000000000000000).toString()).toEqual('-29,719 Apr 5 at 10:13:20 PM')
+      expect(timeToDateStr(-1000000000000000).toString())
+          .toMatch(new RegExp(`^-29,719 Apr 5${SEP} 10:13:20 PM$`))
     })
   })
 })
-

--- a/js/ar/ARController.js
+++ b/js/ar/ARController.js
@@ -2,6 +2,8 @@ import {Quaternion, Vector3} from 'three'
 import {CalibrationStore} from './Calibration.js'
 import {createPoseSource} from './PoseSource.js'
 import {enuToBodyFixedQuat} from './enuFrame.js'
+import {worldToLatLngAlt} from '../coords.js'
+import * as Shared from '../shared.js'
 
 
 /** Per-frame slerp factor for sensor-pose smoothing.  See updateFrame(). */
@@ -105,9 +107,16 @@ export default class ARController {
    * by-design tradeoff so AR doesn't silently teleport the user away
    * from the spot they chose.
    *
+   * If the camera is already over a body's surface (typical: user
+   * clicked a place, then tapped AR), the live camera-derived position
+   * wins over `opts.lat / opts.lng` — keeps the math honest about
+   * where the user actually is in the simulation, regardless of what
+   * geolocation the OS reported.  `opts` is still the fallback for the
+   * in-space case.
+   *
    * @param {object} opts
    * @param {string} [opts.body]  Defaults to 'earth' — used only for the
-   *   ENU→body-fixed math seed; nothing is moved.
+   *   ENU→body-fixed math seed when the in-camera fallback fails.
    * @param {number} opts.lat
    * @param {number} opts.lng
    * @param {number} [opts.alt]  Defaults to 2 m (eye-height)
@@ -119,6 +128,19 @@ export default class ARController {
     }
     if (typeof lat !== 'number' || typeof lng !== 'number') {
       throw new Error(`ARController.enter: lat/lng required (got ${lat}, ${lng})`)
+    }
+    // Prefer the camera's actual world-position-on-current-target over the
+    // caller-supplied opts when the camera is already over a body's
+    // surface (typical: user clicked a place to land, then tapped AR).
+    // This makes the ENU→body-fixed math seed match where the user
+    // *visually* is, and keeps the HUD's reported observer position
+    // honest.  Fall back to opts when no body is targeted (in space).
+    const live = this._observerFromCamera()
+    if (live !== null) {
+      body = live.body
+      lat = live.lat
+      lng = live.lng
+      alt = live.alt
     }
     this._body = body
     this._lat = lat
@@ -294,6 +316,39 @@ export default class ARController {
       const angle = readScreenAngle()
       this.calibrationStore.clear(this._poseSource.kind, angle)
     }
+  }
+
+
+  /**
+   * If the camera is currently sitting over a body with a known radius,
+   * return the body's name + lat/lng/alt derived from the camera's
+   * world position.  Returns null when no such body is targeted (e.g.
+   * the user is looking at a star or empty space) — caller falls back
+   * to whatever lat/lng the AR-entry call supplied.
+   *
+   * @returns {?{body: string, lat: number, lng: number, alt: number}}
+   */
+  _observerFromCamera() {
+    const cur = Shared?.targets?.cur
+    const props = cur?.props
+    if (!props || !props.name || !props.radius || !props.radius.scalar) {
+      return null
+    }
+    if (props.spectralType !== undefined) {
+      // Star — body-fixed math doesn't make sense (no surface to stand on).
+      return null
+    }
+    if (!this.ui?.camera || !cur.getWorldQuaternion || !cur.getWorldPosition) {
+      return null
+    }
+    const camWorld = this._scratchVec.set(0, 0, 0)
+    const planetWorld = new Vector3()
+    const planetWorldQuat = new Quaternion()
+    this.ui.camera.getWorldPosition(camWorld)
+    cur.getWorldPosition(planetWorld)
+    cur.getWorldQuaternion(planetWorldQuat)
+    const {lat, lng, alt} = worldToLatLngAlt(camWorld, planetWorld, planetWorldQuat, props.radius.scalar)
+    return {body: props.name, lat, lng, alt}
   }
 
 

--- a/js/ar/ARController.js
+++ b/js/ar/ARController.js
@@ -1,0 +1,290 @@
+import {Quaternion, Vector3} from 'three'
+import {CalibrationStore} from './Calibration.js'
+import {createPoseSource} from './PoseSource.js'
+import {enuToBodyFixedQuat} from './enuFrame.js'
+
+
+/**
+ * Top-level orchestrator for the AR sky-view feature.
+ *
+ * Lifecycle: `enter()` lands the camera on a body (via Scene.land), starts
+ * the pose source (may prompt for permissions), and registers a per-frame
+ * callback that overrides camera.quaternion with the sensor pose.
+ * `exit()` unwinds all of the above.  The render loop in ThreeUI calls
+ * `updateFrame()` once per frame, AFTER any other code that touches
+ * camera.quaternion (TrackballControls, arrow-key tween, goTo tween) — so
+ * the AR pose always wins.
+ *
+ * Frame chain (when active):
+ *
+ *   camera.quaternion  =  enu_to_bodyFixed(lat, lng)
+ *                       · q_calibration_enu        (optional)
+ *                       · q_camera_to_enu          (from PoseSource)
+ *
+ * The body-fixed → inertial step is delivered by the scene graph: in
+ * Scene.land the camera platform is reparented to the *rotating* body
+ * Object3D, so the parent's world quaternion already includes axial tilt
+ * and sidereal rotation.  See coords.js / Scene.js for the bodyFixed
+ * convention.
+ *
+ * Stage 1 (this commit): black background, no atmosphere, no camera
+ * passthrough.  Validates the frame chain.  Stage 2 will add `<video>`
+ * passthrough and re-enable the atmosphere with premultiplied-alpha
+ * blending.
+ */
+export default class ARController {
+  /**
+   * @param {object} deps
+   * @param {object} deps.scene  Celestiary Scene instance (must expose enterAR/exitAR)
+   * @param {object} deps.ui  ThreeUI instance (provides camera + renderer)
+   * @param {object} deps.time  Time instance (so we can switch to real-time on enter)
+   * @param {Function} deps.useStore  Zustand store accessor
+   * @param {CalibrationStore} [deps.calibrationStore]  Optional override for tests
+   * @param {Function} [deps.poseSourceFactory]  Optional async () => PoseSource;
+   *   defaults to createPoseSource().  Tests inject a deterministic source.
+   */
+  constructor({scene, ui, time, useStore, calibrationStore, poseSourceFactory}) {
+    this.scene = scene
+    this.ui = ui
+    this.time = time
+    this.useStore = useStore
+    this.calibrationStore = calibrationStore ?? new CalibrationStore()
+    this._poseSourceFactory = poseSourceFactory ?? createPoseSource
+    this._active = false
+    this._poseSource = null
+    this._body = null
+    this._lat = 0
+    this._lng = 0
+    this._alt = 0
+    // Pre-allocated scratch — updateFrame runs every frame.  No per-frame
+    // allocations here keeps the pose-update path GC-free.
+    this._qCamToEnu = new Quaternion()
+    this._qEnuToBody = new Quaternion()
+    this._qCalibration = new Quaternion()
+    this._qOut = new Quaternion()
+    this._scratchVec = new Vector3()
+  }
+
+
+  /** @returns {boolean} */
+  isActive() {
+    return this._active
+  }
+
+
+  /**
+   * Enter AR mode.
+   *
+   * Order of operations is deliberate:
+   *   1. Switch sim-time to real wall-clock and 1× scale, so the sky's
+   *      sidereal rotation and planetary ephemerides are accurate at this
+   *      very moment.  Done first so step 2's land() places the observer
+   *      on a body whose orientation matches reality.
+   *   2. Land on the requested body at the requested lat/lng/alt.  This
+   *      reparents camera.platform to the rotating body — the body-fixed
+   *      → inertial step happens automatically thereafter.
+   *   3. Apply the AR scene-visibility preset (atmosphere off, planet
+   *      meshes hidden, asterisms + labels on).
+   *   4. Construct and start the pose source (may prompt for permissions).
+   *
+   * If step 4 throws (permissions denied, no sensors), the prior steps
+   * are unwound so the user is left in a sensible non-AR state.
+   *
+   * @param {object} opts
+   * @param {string} [opts.body]  Defaults to 'earth'
+   * @param {number} opts.lat
+   * @param {number} opts.lng
+   * @param {number} [opts.alt]  Defaults to 2 m (eye-height)
+   * @returns {Promise<void>}
+   */
+  async enter({body = 'earth', lat, lng, alt = 2}) {
+    if (this._active) {
+      return
+    }
+    if (typeof lat !== 'number' || typeof lng !== 'number') {
+      throw new Error(`ARController.enter: lat/lng required (got ${lat}, ${lng})`)
+    }
+    this._body = body
+    this._lat = lat
+    this._lng = lng
+    this._alt = alt
+    this._qEnuToBody.copy(enuToBodyFixedQuat(lat, lng))
+
+    // Real-time sim — AR is meaningless if the simulated sky doesn't match
+    // wall-clock reality.  Save prior state so exit() can restore.
+    this._priorTimeScale = this.time.timeScale
+    this._priorTimeScaleSteps = this.time.timeScaleSteps
+    this._priorSimTime = this.time.simTime
+    this._priorIsPaused = this.time.isPaused
+    if (this.time.isPaused) {
+      this.time.togglePause()
+    }
+    this.time.setTimeToNow()
+
+    // Land — reparents camera.platform onto the rotating body.
+    try {
+      this.scene.land(body, lat, lng, alt, {instant: true})
+    } catch (e) {
+      this._active = false
+      throw new Error(`ARController.enter: scene.land failed: ${e.message}`)
+    }
+
+    // Scene visibility preset.
+    if (typeof this.scene.enterAR === 'function') {
+      this._priorSceneState = this.scene.enterAR()
+    }
+
+    // Construct + start the pose source last — it may prompt and reject.
+    try {
+      this._poseSource = await this._poseSourceFactory()
+      await this._poseSource.start()
+    } catch (e) {
+      // Roll back.  Best-effort: scene state restore + bail out.
+      if (this._priorSceneState && typeof this.scene.exitAR === 'function') {
+        this.scene.exitAR(this._priorSceneState)
+      }
+      this._poseSource = null
+      throw e
+    }
+
+    // Load any persisted calibration for this source / orientation.
+    const angle = readScreenAngle()
+    const cal = this.calibrationStore.load(this._poseSource.kind, angle)
+    if (cal) {
+      this._qCalibration.copy(cal)
+    } else {
+      this._qCalibration.identity()
+    }
+
+    this._active = true
+
+    // Publish to the store so the AR HUD can mount its gear icon and
+    // status pill.  We write through the slice setter rather than direct
+    // mutation so React subscriptions fire.
+    const setter = this.useStore?.getState?.()?.setARMode
+    if (typeof setter === 'function') {
+      setter({
+        active: true,
+        body, lat, lng, alt,
+        sourceKind: this._poseSource.kind,
+        needsCalibration: this._poseSource.needsCalibration,
+      })
+    }
+  }
+
+
+  /** Tear down AR mode and restore prior view state. */
+  exit() {
+    if (!this._active) {
+      return
+    }
+    if (this._poseSource) {
+      this._poseSource.stop()
+      this._poseSource = null
+    }
+    if (this._priorSceneState && typeof this.scene.exitAR === 'function') {
+      this.scene.exitAR(this._priorSceneState)
+      this._priorSceneState = null
+    }
+    // Restore time state if we changed it.
+    if (this._priorTimeScale !== undefined) {
+      this.time.timeScale = this._priorTimeScale
+      this.time.timeScaleSteps = this._priorTimeScaleSteps
+      // Don't roll back simTime — the user may want the sim to keep
+      // running from "now".  Restoring it would teleport them backwards
+      // unexpectedly.
+      if (this._priorIsPaused) {
+        this.time.togglePause()
+      }
+    }
+    this._active = false
+    const setter = this.useStore?.getState?.()?.setARMode
+    if (typeof setter === 'function') {
+      setter({active: false})
+    }
+  }
+
+
+  /**
+   * Per-frame update.  No-op when AR is inactive or the pose source has
+   * not yet delivered a sample.  When active, overwrites camera.quaternion
+   * with the composed AR pose — this must be called AFTER any other
+   * per-frame code that touches camera.quaternion, so the AR pose wins.
+   */
+  updateFrame() {
+    if (!this._active || !this._poseSource) {
+      return
+    }
+    if (!this._poseSource.getQuaternion(this._qCamToEnu)) {
+      return // no sample yet
+    }
+    // camera.quaternion = enu_to_bodyFixed · q_calibration · q_cam_to_enu
+    this._qOut.copy(this._qEnuToBody).multiply(this._qCalibration).multiply(this._qCamToEnu)
+    this.ui.camera.quaternion.copy(this._qOut)
+  }
+
+
+  /**
+   * Capture a one-shot calibration sample.  Called by the AR HUD's gear
+   * icon.  The caller supplies the *true* direction (in ENU coords at
+   * the observer's location) to a known reference body — Polaris, Sun,
+   * Sirius, etc.  The current sensor reading provides the device's idea
+   * of where the camera is currently aimed; the difference is the bias
+   * we save.
+   *
+   * @param {Vector3} trueDirEnu  Unit vector, true direction in ENU
+   */
+  captureCalibration(trueDirEnu) {
+    if (!this._active || !this._poseSource) {
+      return
+    }
+    if (!this._poseSource.getQuaternion(this._qCamToEnu)) {
+      return
+    }
+    // Camera-forward in screen frame is (0, 0, −1) (Three.js convention).
+    // Apply current sensor pose to get the device-aimed direction in ENU.
+    const deviceAim = this._scratchVec.set(0, 0, -1).applyQuaternion(this._qCamToEnu)
+    this._qCalibration.setFromUnitVectors(deviceAim, trueDirEnu)
+    const angle = readScreenAngle()
+    this.calibrationStore.save(this._poseSource.kind, angle, this._qCalibration)
+  }
+
+
+  /** Reset calibration to identity and clear persistent storage. */
+  clearCalibration() {
+    this._qCalibration.identity()
+    if (this._poseSource) {
+      const angle = readScreenAngle()
+      this.calibrationStore.clear(this._poseSource.kind, angle)
+    }
+  }
+
+
+  /**
+   * @returns {?{kind: string, needsCalibration: boolean, lat: number, lng: number}}
+   *   null when AR is inactive
+   */
+  getStatus() {
+    if (!this._active || !this._poseSource) {
+      return null
+    }
+    return {
+      kind: this._poseSource.kind,
+      needsCalibration: this._poseSource.needsCalibration,
+      lat: this._lat,
+      lng: this._lng,
+    }
+  }
+}
+
+
+/** @returns {number} screen.orientation.angle in degrees, 0 if unavailable */
+function readScreenAngle() {
+  if (typeof screen !== 'undefined' && screen.orientation && typeof screen.orientation.angle === 'number') {
+    return screen.orientation.angle
+  }
+  if (typeof window !== 'undefined' && typeof window.orientation === 'number') {
+    return window.orientation
+  }
+  return 0
+}

--- a/js/ar/ARController.js
+++ b/js/ar/ARController.js
@@ -4,6 +4,10 @@ import {createPoseSource} from './PoseSource.js'
 import {enuToBodyFixedQuat} from './enuFrame.js'
 
 
+/** Per-frame slerp factor for sensor-pose smoothing.  See updateFrame(). */
+const POSE_SLERP_T = 0.35
+
+
 /**
  * Top-level orchestrator for the AR sky-view feature.
  *
@@ -56,6 +60,10 @@ export default class ARController {
     this._lat = 0
     this._lng = 0
     this._alt = 0
+    // First-sample-after-enter snaps to the composed pose; subsequent
+    // samples slerp from prior so magnetometer noise on the alpha axis
+    // doesn't show up as visible left/right jitter.  See updateFrame().
+    this._hasAppliedSample = false
     // Pre-allocated scratch — updateFrame runs every frame.  No per-frame
     // allocations here keeps the pose-update path GC-free.
     this._qCamToEnu = new Quaternion()
@@ -80,18 +88,26 @@ export default class ARController {
    *      sidereal rotation and planetary ephemerides are accurate at this
    *      very moment.  Done first so step 2's land() places the observer
    *      on a body whose orientation matches reality.
-   *   2. Land on the requested body at the requested lat/lng/alt.  This
-   *      reparents camera.platform to the rotating body — the body-fixed
-   *      → inertial step happens automatically thereafter.
-   *   3. Apply the AR scene-visibility preset (atmosphere off, planet
+   *   2. Apply the AR scene-visibility preset (atmosphere off, planet
    *      meshes hidden, asterisms + labels on).
-   *   4. Construct and start the pose source (may prompt for permissions).
+   *   3. Construct and start the pose source (may prompt for permissions).
    *
-   * If step 4 throws (permissions denied, no sensors), the prior steps
+   * If step 3 throws (permissions denied, no sensors), the prior steps
    * are unwound so the user is left in a sensible non-AR state.
    *
+   * Camera position / parenting is *not* changed.  AR engages wherever
+   * the camera is.  If the user has previously landed on a body's
+   * surface (via Scene.land or place-click), the body-fixed → inertial
+   * chain is already correct via the scene-graph parenting and AR will
+   * align with the local sky.  If the user is in space, sensor pose
+   * still drives the camera quaternion, but the celestial-sphere
+   * composition won't be aligned to a particular ground frame —
+   * by-design tradeoff so AR doesn't silently teleport the user away
+   * from the spot they chose.
+   *
    * @param {object} opts
-   * @param {string} [opts.body]  Defaults to 'earth'
+   * @param {string} [opts.body]  Defaults to 'earth' — used only for the
+   *   ENU→body-fixed math seed; nothing is moved.
    * @param {number} opts.lat
    * @param {number} opts.lng
    * @param {number} [opts.alt]  Defaults to 2 m (eye-height)
@@ -108,6 +124,7 @@ export default class ARController {
     this._lat = lat
     this._lng = lng
     this._alt = alt
+    this._hasAppliedSample = false
     this._qEnuToBody.copy(enuToBodyFixedQuat(lat, lng))
 
     // Real-time sim — AR is meaningless if the simulated sky doesn't match
@@ -120,14 +137,6 @@ export default class ARController {
       this.time.togglePause()
     }
     this.time.setTimeToNow()
-
-    // Land — reparents camera.platform onto the rotating body.
-    try {
-      this.scene.land(body, lat, lng, alt, {instant: true})
-    } catch (e) {
-      this._active = false
-      throw new Error(`ARController.enter: scene.land failed: ${e.message}`)
-    }
 
     // Scene visibility preset.
     if (typeof this.scene.enterAR === 'function') {
@@ -207,9 +216,19 @@ export default class ARController {
 
   /**
    * Per-frame update.  No-op when AR is inactive or the pose source has
-   * not yet delivered a sample.  When active, overwrites camera.quaternion
-   * with the composed AR pose — this must be called AFTER any other
+   * not yet delivered a sample.  When active, slerps camera.quaternion
+   * toward the composed AR pose — this must be called AFTER any other
    * per-frame code that touches camera.quaternion, so the AR pose wins.
+   *
+   * Slerp factor (`POSE_SLERP_T`): the magnetometer-fused alpha axis on
+   * `deviceorientationabsolute` is noisy on most phones, especially
+   * indoors and before the figure-8 calibration dance — snapping to it
+   * raw produces visible left/right jitter.  At 60fps a slerp of 0.35
+   * settles in ~3 frames (~50ms), which is below the perceptual lag
+   * threshold but kills the jitter.  A 1-Euro filter would be better
+   * for stage 2 (camera passthrough) where every ms of lag is
+   * registered against the live video; for stage 1 sky-only this is
+   * plenty.
    */
   updateFrame() {
     if (!this._active || !this._poseSource) {
@@ -220,7 +239,12 @@ export default class ARController {
     }
     // camera.quaternion = enu_to_bodyFixed · q_calibration · q_cam_to_enu
     this._qOut.copy(this._qEnuToBody).multiply(this._qCalibration).multiply(this._qCamToEnu)
-    this.ui.camera.quaternion.copy(this._qOut)
+    // First sample of this AR session: snap, so the camera lands on the
+    // sensor pose immediately rather than tweening from the prior view.
+    // Subsequent samples slerp toward target — see POSE_SLERP_T.
+    const t = this._hasAppliedSample ? POSE_SLERP_T : 1.0
+    this.ui.camera.quaternion.slerp(this._qOut, t)
+    this._hasAppliedSample = true
   }
 
 
@@ -250,6 +274,19 @@ export default class ARController {
   }
 
 
+  /**
+   * Forward an alpha-axis damping preset change to the active pose source.
+   * No-op when AR isn't running (preset will be applied on next enter).
+   *
+   * @param {string} name  One of `getAlphaDampingNames()`
+   */
+  setAlphaDamping(name) {
+    if (this._poseSource && typeof this._poseSource.setAlphaDamping === 'function') {
+      this._poseSource.setAlphaDamping(name)
+    }
+  }
+
+
   /** Reset calibration to identity and clear persistent storage. */
   clearCalibration() {
     this._qCalibration.identity()
@@ -275,6 +312,59 @@ export default class ARController {
       lng: this._lng,
     }
   }
+
+
+  /**
+   * Snapshot for the AR debug HUD.  Always safe to call; returns an
+   * `active: false` payload when AR is not running.  Includes the raw
+   * sensor sample so we can tell at a glance whether the browser is
+   * delivering DeviceOrientationEvents at all (the most common failure
+   * mode is a permissions / secure-context issue that leaves the
+   * listener attached but events never firing).
+   *
+   * @returns {object}
+   */
+  getDebugSnapshot() {
+    const screenAngle = readScreenAngle()
+    if (!this._active) {
+      return {active: false, screenAngle}
+    }
+    const poseSrc = this._poseSource?.getDebugSnapshot?.() ?? {kind: this._poseSource?.kind ?? null}
+    const cam = this.ui?.camera
+    const camQuat = cam ? {
+      x: round3(cam.quaternion.x),
+      y: round3(cam.quaternion.y),
+      z: round3(cam.quaternion.z),
+      w: round3(cam.quaternion.w),
+    } : null
+    // Renderer-state cross-checks: the AR-mode preset is supposed to gate
+    // the atmosphere post-pass (`uAtmEnabled = 0`).  If the user reports
+    // atmosphere colors leaking through, surface the live values so we can
+    // tell whether _arMode got cleared or the gate isn't taking effect.
+    const arMode = this.ui?._arMode === true
+    const atmMesh = this.ui?._atmMesh
+    const uAtmEnabled = atmMesh?.material?.uniforms?.uAtmEnabled?.value ?? null
+    return {
+      active: true,
+      body: this._body,
+      lat: this._lat,
+      lng: this._lng,
+      screenAngle,
+      poseSrc,
+      camQuat,
+      arMode,
+      uAtmEnabled,
+    }
+  }
+}
+
+
+/**
+ * @param {number} v
+ * @returns {number} v rounded to 3 decimal places
+ */
+function round3(v) {
+  return Math.round(v * 1000) / 1000
 }
 
 

--- a/js/ar/ARController.test.js
+++ b/js/ar/ARController.test.js
@@ -1,0 +1,295 @@
+import {beforeEach, describe, expect, it} from 'bun:test'
+import {Object3D, PerspectiveCamera, Scene as ThreeScene, Vector3} from 'three'
+import ARController from './ARController.js'
+import {CalibrationStore} from './Calibration.js'
+import NullPoseSource from './NullPoseSource.js'
+import {enuToBodyFixedQuat} from './enuFrame.js'
+
+
+/**
+ * Build a minimal ARController harness:
+ *   - real ThreeScene + PerspectiveCamera + camera.platform
+ *   - fake Scene with land() that reparents the camera platform onto the
+ *     "earth" Object3D, mirroring the real Scene.land contract
+ *   - fake Time (records what gets called)
+ *   - in-memory CalibrationStore
+ *   - injectable PoseSource so we can drive deterministic poses in tests
+ */
+function makeHarness({poseSource} = {}) {
+  const threeScene = new ThreeScene()
+  const camera = new PerspectiveCamera(45, 1, 1, 1e12)
+  camera.platform = new Object3D()
+  camera.platform.add(camera)
+  threeScene.add(camera.platform)
+
+  const earth = new Object3D()
+  earth.name = 'earth'
+  earth.props = {name: 'earth', radius: {scalar: 6.371e6}}
+  threeScene.add(earth)
+
+  const sceneCalls = []
+  const fakeScene = {
+    land(name, lat, lng, alt, opts) {
+      sceneCalls.push({op: 'land', name, lat, lng, alt, opts})
+      // Reparent the camera platform onto earth (mirrors real Scene.land,
+      // which children-of-rotating-body auto-inherits sidereal rotation).
+      earth.add(camera.platform)
+      camera.platform.position.set(0, 0, 0)
+      camera.platform.quaternion.identity()
+    },
+    enterAR() {
+      sceneCalls.push({op: 'enterAR'})
+      return {snapshot: 'fake'}
+    },
+    exitAR(prior) {
+      sceneCalls.push({op: 'exitAR', prior})
+    },
+  }
+
+  const time = {
+    timeScale: 1,
+    timeScaleSteps: 0,
+    simTime: 1234,
+    isPaused: false,
+    setTimeToNowCalls: 0,
+    togglePause() {
+      this.isPaused = !this.isPaused
+    },
+    setTimeToNow() {
+      this.setTimeToNowCalls += 1
+      this.timeScale = 1
+      this.timeScaleSteps = 0
+    },
+  }
+
+  // Minimal store with the AR slice setter.
+  const arState = {value: null}
+  const useStore = {
+    getState: () => ({setARMode: (v) => {
+      arState.value = v
+    }}),
+  }
+
+  const calibrationStore = new CalibrationStore({storage: makeFakeStorage()})
+  const ps = poseSource ?? new NullPoseSource()
+  const ctrl = new ARController({
+    scene: fakeScene,
+    ui: {camera},
+    time,
+    useStore,
+    calibrationStore,
+    poseSourceFactory: () => Promise.resolve(ps),
+  })
+  return {ctrl, threeScene, camera, earth, fakeScene, sceneCalls, time, calibrationStore, arState, poseSource: ps}
+}
+
+
+function makeFakeStorage() {
+  const map = new Map()
+  return {
+    getItem: (k) => map.has(k) ? map.get(k) : null,
+    setItem: (k, v) => map.set(k, v),
+    removeItem: (k) => map.delete(k),
+  }
+}
+
+
+async function enterWith(ctrl, opts) {
+  // Pose-source factory is injected via the constructor in makeHarness,
+  // so enter() runs straight through with the harness-supplied source.
+  await ctrl.enter(opts)
+}
+
+
+describe('ARController.enter / exit', () => {
+  let harness
+  beforeEach(() => {
+    harness = makeHarness()
+  })
+
+
+  it('lands the camera platform on the requested body at the requested lat/lng', async () => {
+    const {ctrl, sceneCalls} = harness
+    await enterWith(ctrl, {body: 'earth', lat: 37.77, lng: -122.42, alt: 2})
+    expect(ctrl.isActive()).toBe(true)
+    const landCall = sceneCalls.find((c) => c.op === 'land')
+    expect(landCall).toBeDefined()
+    expect(landCall.name).toBe('earth')
+    expect(landCall.lat).toBeCloseTo(37.77, 6)
+    expect(landCall.lng).toBeCloseTo(-122.42, 6)
+    expect(landCall.alt).toBe(2)
+    expect(landCall.opts.instant).toBe(true)
+  })
+
+
+  it('switches sim-time to real-time on enter', async () => {
+    const {ctrl, time} = harness
+    time.timeScaleSteps = 5 // some weird non-real-time state
+    time.timeScale = 32
+    await enterWith(ctrl, {lat: 0, lng: 0})
+    expect(time.setTimeToNowCalls).toBe(1)
+  })
+
+
+  it('rejects when lat/lng are not numbers', async () => {
+    const {ctrl} = harness
+    let threw = false
+    try {
+      await ctrl.enter({lat: 'oops', lng: 0})
+    } catch (e) {
+      threw = true
+      expect(e.message).toMatch(/lat\/lng required/)
+    }
+    expect(threw).toBe(true)
+    expect(ctrl.isActive()).toBe(false)
+  })
+
+
+  it('publishes AR state to the store on enter and exit', async () => {
+    const {ctrl, arState} = harness
+    await enterWith(ctrl, {body: 'earth', lat: 1, lng: 2, alt: 0})
+    expect(arState.value.active).toBe(true)
+    expect(arState.value.body).toBe('earth')
+    expect(arState.value.lat).toBe(1)
+    expect(arState.value.lng).toBe(2)
+    ctrl.exit()
+    expect(ctrl.isActive()).toBe(false)
+    expect(arState.value.active).toBe(false)
+  })
+
+
+  it('calls scene.enterAR on enter and scene.exitAR on exit', async () => {
+    const {ctrl, sceneCalls} = harness
+    await enterWith(ctrl, {lat: 0, lng: 0})
+    expect(sceneCalls.some((c) => c.op === 'enterAR')).toBe(true)
+    ctrl.exit()
+    expect(sceneCalls.some((c) => c.op === 'exitAR')).toBe(true)
+  })
+})
+
+
+describe('ARController.updateFrame — pose composition', () => {
+  it('composes camera.quaternion = enu_to_bodyFixed · q_cal · q_cam_to_enu', async () => {
+    // Use a Null pose source (identity quat) so the chain reduces to:
+    //   camera.quaternion = enu_to_bodyFixed(lat, lng) · I · I
+    //                     = enu_to_bodyFixed(lat, lng)
+    // We can compare element-by-element.
+    const harness = makeHarness()
+    const {ctrl, camera} = harness
+    const lat = 30
+    const lng = 60
+    await enterWith(ctrl, {lat, lng})
+    ctrl.updateFrame()
+    const expected = enuToBodyFixedQuat(lat, lng)
+    expect(camera.quaternion.x).toBeCloseTo(expected.x, 9)
+    expect(camera.quaternion.y).toBeCloseTo(expected.y, 9)
+    expect(camera.quaternion.z).toBeCloseTo(expected.z, 9)
+    expect(camera.quaternion.w).toBeCloseTo(expected.w, 9)
+  })
+
+
+  it('is a no-op when AR is inactive', () => {
+    const harness = makeHarness()
+    const {ctrl, camera} = harness
+    camera.quaternion.set(0.1, 0.2, 0.3, 0.9)
+    ctrl.updateFrame()
+    expect(camera.quaternion.x).toBe(0.1)
+    expect(camera.quaternion.y).toBe(0.2)
+    expect(camera.quaternion.z).toBe(0.3)
+    expect(camera.quaternion.w).toBe(0.9)
+  })
+
+
+  it('camera-forward (0,0,−1) lands on body-fixed Up at observer location', async () => {
+    // With a Null source (camera→ENU identity), the camera is by
+    // construction "looking straight up" in ENU.  Composing with
+    // enu_to_bodyFixed(lat, lng) should map camera-forward to the body's
+    // outward radial at that observer location — i.e. body-fixed Up.
+    const harness = makeHarness()
+    const {ctrl, camera} = harness
+    const lat = 45
+    const lng = -90
+    await enterWith(ctrl, {lat, lng})
+    ctrl.updateFrame()
+    // Camera forward is local −Z = camera frame (0, 0, -1), but
+    // applyQuaternion gives the world-frame direction in the camera
+    // platform's frame.  Since platform is at body-origin with identity,
+    // platform-local = body-fixed.
+    const fwd = new Vector3(0, 0, -1).applyQuaternion(camera.quaternion)
+    // Wait — for a NullPoseSource, the camera→ENU rotation is identity,
+    // meaning the camera's −Z forward equals ENU −Z = "Down".  In body-
+    // fixed coords at (45, -90), Down points toward planet center, the
+    // negation of the up vector at that location.
+    // Recover Up via the helper to compare against.
+    const {up} = await import('./enuFrame.js').then((m) => ({
+      up: m.enuTriadAtLatLng(lat, lng).up,
+    }))
+    // fwd should equal -up.
+    expect(fwd.x).toBeCloseTo(-up.x, 9)
+    expect(fwd.y).toBeCloseTo(-up.y, 9)
+    expect(fwd.z).toBeCloseTo(-up.z, 9)
+  })
+})
+
+
+describe('ARController calibration', () => {
+  it('captureCalibration aligns sensor-aimed direction to a true direction', async () => {
+    const harness = makeHarness()
+    const {ctrl, camera} = harness
+    await enterWith(ctrl, {lat: 0, lng: 0})
+
+    // After capture-calibration with deviceAim = ENU forward, trueDir =
+    // ENU North, the next frame's camera-forward (in ENU) should equal
+    // North.
+    //
+    // With a NullPoseSource the device's idea of camera-forward (in ENU)
+    // is camera-forward * camToEnu(=I) = camera (0,0,-1) → ENU (0,0,-1)
+    // which is straight Down.  We *tell* the controller the true
+    // direction is North = (0,1,0) → calibration solves rotation Down→
+    // North = 90° about ENU +X.
+    ctrl.captureCalibration(new Vector3(0, 1, 0))
+    ctrl.updateFrame()
+
+    // Camera-forward in body-fixed coords after compose:
+    //   body = enu_to_bodyFixed(0,0) · q_cal · q_cam_to_enu · (0,0,-1)
+    //        = enu_to_bodyFixed(0,0) · q_cal · (0,0,-1) ENU
+    // q_cal rotates (0,0,-1) ENU into (0,1,0) ENU (= North), so the
+    // bracketed term equals (0,1,0) ENU.  Then enu_to_bodyFixed(0,0)
+    // maps ENU (0,1,0) = North to body-fixed +Y (the rotation axis).
+    const fwd = new Vector3(0, 0, -1).applyQuaternion(camera.quaternion)
+    expect(fwd.x).toBeCloseTo(0, 6)
+    expect(fwd.y).toBeCloseTo(1, 6) // body-fixed +Y = north pole
+    expect(fwd.z).toBeCloseTo(0, 6)
+  })
+
+
+  it('clearCalibration resets to identity', async () => {
+    const harness = makeHarness()
+    const {ctrl} = harness
+    await enterWith(ctrl, {lat: 0, lng: 0})
+    ctrl.captureCalibration(new Vector3(1, 0, 0))
+    ctrl.clearCalibration()
+    expect(ctrl._qCalibration.x).toBeCloseTo(0, 9)
+    expect(ctrl._qCalibration.y).toBeCloseTo(0, 9)
+    expect(ctrl._qCalibration.z).toBeCloseTo(0, 9)
+    expect(Math.abs(ctrl._qCalibration.w)).toBeCloseTo(1, 9)
+  })
+
+
+  it('persists calibration across enter/exit/enter', async () => {
+    const harness = makeHarness()
+    const {ctrl} = harness
+    await enterWith(ctrl, {lat: 0, lng: 0})
+    ctrl.captureCalibration(new Vector3(0, 1, 0))
+    const savedX = ctrl._qCalibration.x
+    const savedY = ctrl._qCalibration.y
+    const savedZ = ctrl._qCalibration.z
+    const savedW = ctrl._qCalibration.w
+    ctrl.exit()
+    await enterWith(ctrl, {lat: 0, lng: 0})
+    expect(ctrl._qCalibration.x).toBeCloseTo(savedX, 5)
+    expect(ctrl._qCalibration.y).toBeCloseTo(savedY, 5)
+    expect(ctrl._qCalibration.z).toBeCloseTo(savedZ, 5)
+    expect(ctrl._qCalibration.w).toBeCloseTo(savedW, 5)
+  })
+})

--- a/js/ar/ARController.test.js
+++ b/js/ar/ARController.test.js
@@ -108,17 +108,17 @@ describe('ARController.enter / exit', () => {
   })
 
 
-  it('lands the camera platform on the requested body at the requested lat/lng', async () => {
+  it('does NOT call scene.land — AR engages wherever the camera is', async () => {
+    // Removing the implied goto was an explicit decision: AR should
+    // never silently teleport the camera away from the spot the user
+    // chose (e.g. landed at Cairo, then taps AR — they should stay at
+    // Cairo, not get warped to their device-geolocation).  The math
+    // composition still uses the supplied lat/lng for ENU→body-fixed,
+    // so callers should pass the user's intended observer position.
     const {ctrl, sceneCalls} = harness
     await enterWith(ctrl, {body: 'earth', lat: 37.77, lng: -122.42, alt: 2})
     expect(ctrl.isActive()).toBe(true)
-    const landCall = sceneCalls.find((c) => c.op === 'land')
-    expect(landCall).toBeDefined()
-    expect(landCall.name).toBe('earth')
-    expect(landCall.lat).toBeCloseTo(37.77, 6)
-    expect(landCall.lng).toBeCloseTo(-122.42, 6)
-    expect(landCall.alt).toBe(2)
-    expect(landCall.opts.instant).toBe(true)
+    expect(sceneCalls.some((c) => c.op === 'land')).toBe(false)
   })
 
 

--- a/js/ar/ARController.test.js
+++ b/js/ar/ARController.test.js
@@ -9,8 +9,9 @@ import {enuToBodyFixedQuat} from './enuFrame.js'
 /**
  * Build a minimal ARController harness:
  *   - real ThreeScene + PerspectiveCamera + camera.platform
- *   - fake Scene with land() that reparents the camera platform onto the
- *     "earth" Object3D, mirroring the real Scene.land contract
+ *   - fake Scene exposing only enterAR / exitAR (no `land` — AR no
+ *     longer teleports on entry; the camera is left wherever the user
+ *     left it before tapping AR)
  *   - fake Time (records what gets called)
  *   - in-memory CalibrationStore
  *   - injectable PoseSource so we can drive deterministic poses in tests
@@ -29,14 +30,6 @@ function makeHarness({poseSource} = {}) {
 
   const sceneCalls = []
   const fakeScene = {
-    land(name, lat, lng, alt, opts) {
-      sceneCalls.push({op: 'land', name, lat, lng, alt, opts})
-      // Reparent the camera platform onto earth (mirrors real Scene.land,
-      // which children-of-rotating-body auto-inherits sidereal rotation).
-      earth.add(camera.platform)
-      camera.platform.position.set(0, 0, 0)
-      camera.platform.quaternion.identity()
-    },
     enterAR() {
       sceneCalls.push({op: 'enterAR'})
       return {snapshot: 'fake'}

--- a/js/ar/AlphaPipeline.js
+++ b/js/ar/AlphaPipeline.js
@@ -1,0 +1,108 @@
+/**
+ * Three-stage processing for the noisiest axis (alpha / yaw):
+ *
+ *   raw °  ─►  unwrap  ─►  optional notch  ─►  base 1€ filter
+ *
+ * Each stage owns one specific concern:
+ *
+ *   - **unwrap** turns the raw [0, 360) reading into a continuous
+ *     real-valued signal so the subsequent IIR / EMA stages don't see
+ *     huge fake transients at the 0 / 360 boundary.
+ *   - **notch** (when configured) removes a known periodic carrier —
+ *     e.g. the ~1 Hz oscillation magnetometer fusion picks up from the
+ *     device's own electronics or carrier frequencies in the ambient
+ *     field.  A narrow biquad notch leaves all other frequencies
+ *     essentially untouched, so legitimate slow pans pass through with
+ *     no plateau-style staircase artifacts that velocity-based
+ *     deadband heuristics introduce.
+ *   - **base 1€ filter** smooths the residual broadband noise, with
+ *     adaptive cutoff so fast pans aren't lagged.
+ *
+ * The base filter is injected so callers can swap our local 1€ impl
+ * for the canonical `1eurofilter` package (see DeviceOrientationPoseSource
+ * where USE_LIB_FILTER picks one).  Both expose the same `filter(x, t)`
+ * + `reset()` shape.
+ */
+export default class AlphaPipeline {
+  /**
+   * @param {object} opts
+   * @param {Function} opts.BaseFilter    Constructor for the base 1€ filter
+   *   (`new BaseFilter(oneEuroOpts)` must yield an object with
+   *   `filter(x, t)` and `reset()`).
+   * @param {object} opts.oneEuroOpts     Passed straight to `BaseFilter`.
+   * @param {object} [opts.notch]         Optional `BiquadNotch` instance.
+   *   Pass `null` / omit to disable the notch stage.
+   */
+  constructor({BaseFilter, oneEuroOpts, notch = null}) {
+    this._base = new BaseFilter(oneEuroOpts)
+    this._notch = notch
+    this._lastRawDeg = null
+    this._unwrapped = 0
+    this._tPrev = null
+    this._lastUnwrapped = 0
+    this._lastNotched = 0
+  }
+
+
+  /** Drop all filter state. */
+  reset() {
+    this._base.reset()
+    if (this._notch) {
+      this._notch.reset()
+    }
+    this._lastRawDeg = null
+    this._unwrapped = 0
+    this._tPrev = null
+    this._lastUnwrapped = 0
+    this._lastNotched = 0
+  }
+
+
+  /**
+   * @param {number} rawDeg   Raw alpha in degrees, any range.
+   * @param {number} t        Timestamp in seconds.
+   * @returns {number}        Filtered, unwrapped alpha (degrees).
+   */
+  filter(rawDeg, t) {
+    // Stage 1: unwrap.
+    if (this._lastRawDeg === null) {
+      this._unwrapped = rawDeg
+    } else {
+      let d = rawDeg - this._lastRawDeg
+      if (d > HALF_TURN) {
+        d -= FULL_TURN
+      } else if (d < -HALF_TURN) {
+        d += FULL_TURN
+      }
+      this._unwrapped += d
+    }
+    this._lastRawDeg = rawDeg
+    this._lastUnwrapped = this._unwrapped
+
+    // Stage 2: notch (optional).
+    let value = this._unwrapped
+    if (this._notch) {
+      const dt = this._tPrev !== null ? t - this._tPrev : (1.0 / 60.0)
+      value = this._notch.filter(value, dt)
+    }
+    this._tPrev = t
+    this._lastNotched = value
+
+    // Stage 3: base 1€ filter.
+    return this._base.filter(value, t)
+  }
+
+
+  /**
+   * @returns {{unwrapped: number, notched: number}}  Latest intermediate
+   *   values from each stage.  Surface to the AR debug HUD so we can
+   *   plot raw vs unwrapped vs notched vs filtered together.
+   */
+  getDebugIntermediates() {
+    return {unwrapped: this._lastUnwrapped, notched: this._lastNotched}
+  }
+}
+
+
+const HALF_TURN = 180
+const FULL_TURN = 360

--- a/js/ar/AlphaPipeline.test.js
+++ b/js/ar/AlphaPipeline.test.js
@@ -1,0 +1,101 @@
+import {describe, expect, it} from 'bun:test'
+import AlphaPipeline from './AlphaPipeline.js'
+import BiquadNotch from './BiquadNotch.js'
+import OneEuroFilter from './OneEuroFilter.js'
+
+
+describe('AlphaPipeline', () => {
+  it('first sample passes through unchanged', () => {
+    const p = new AlphaPipeline({
+      BaseFilter: OneEuroFilter,
+      oneEuroOpts: {minCutoff: 1.0, beta: 0.0},
+    })
+    expect(p.filter(180, 0)).toBe(180)
+  })
+
+
+  it('unwraps a 359° → 1° crossing as a small positive delta', () => {
+    const p = new AlphaPipeline({
+      BaseFilter: OneEuroFilter,
+      oneEuroOpts: {minCutoff: 1.0, beta: 0.0},
+    })
+    const dt = 1 / 60
+    let t = 0
+    p.filter(359, t); t += dt
+    p.filter(0, t); t += dt
+    const out = p.filter(1, t)
+    expect(out).toBeGreaterThan(358)
+    expect(out).toBeLessThan(362)
+  })
+
+
+  it('with notch enabled, a steady 1 Hz oscillation in raw is suppressed', () => {
+    // Apply a 1 Hz tone offset around a constant heading.  The pipeline's
+    // notch should kill the oscillation before it reaches the 1€ stage,
+    // leaving the filtered output close to the underlying mean.
+    const p = new AlphaPipeline({
+      BaseFilter: OneEuroFilter,
+      oneEuroOpts: {minCutoff: 1.0, beta: 0.0}, // pure 1 Hz fixed LP
+      notch: new BiquadNotch({f0Hz: 1.0, Q: 5}),
+    })
+    const fs = 60
+    const dt = 1 / fs
+    const baseAlpha = 100
+    const noiseAmp = 5
+    let t = 0
+    let peak = 0
+    // Settle the notch over many samples, then measure deviation.
+    for (let i = 0; i < 3600; i++) {
+      const x = baseAlpha + (noiseAmp * Math.sin(2 * Math.PI * 1.0 * t))
+      const y = p.filter(x, t)
+      if (i > 1800) {
+        const dev = Math.abs(y - baseAlpha)
+        if (dev > peak) {
+          peak = dev
+        }
+      }
+      t += dt
+    }
+    // Without notch the filtered output would track the 5° oscillation.
+    // With notch + 1€ at minCutoff=1, residual should be << noise amp.
+    expect(peak).toBeLessThan(0.5)
+  })
+
+
+  it('with notch enabled, a slow legitimate pan still gets through', () => {
+    // 5°/s sustained pan — well outside the notch's 0.2 Hz bandwidth at
+    // f0=1 Hz, Q=5.  Output should track the pan with at most ~filter lag,
+    // not freeze near the seed value.
+    const p = new AlphaPipeline({
+      BaseFilter: OneEuroFilter,
+      oneEuroOpts: {minCutoff: 1.0, beta: 0.5},
+      notch: new BiquadNotch({f0Hz: 1.0, Q: 5}),
+    })
+    const fs = 60
+    const dt = 1 / fs
+    const seed = 100
+    const panRate = 5
+    let t = 0
+    let last = seed
+    for (let i = 0; i < 1200; i++) {
+      last = p.filter(seed + (panRate * t), t)
+      t += dt
+    }
+    // After 20 s of 5°/s pan = 100°, output should have tracked most of it.
+    expect(last - seed).toBeGreaterThan(80)
+  })
+
+
+  it('reset() drops all state', () => {
+    const p = new AlphaPipeline({
+      BaseFilter: OneEuroFilter,
+      oneEuroOpts: {minCutoff: 1.0, beta: 0.0},
+      notch: new BiquadNotch({f0Hz: 1.0, Q: 5}),
+    })
+    const dt = 1 / 60
+    p.filter(180, 0)
+    p.filter(180, dt)
+    p.reset()
+    expect(p.filter(45, 2 * dt)).toBe(45)
+  })
+})

--- a/js/ar/BiquadNotch.js
+++ b/js/ar/BiquadNotch.js
@@ -1,0 +1,100 @@
+/**
+ * Single-band IIR notch filter (biquad, direct form I), RBJ cookbook
+ * formulation — https://www.w3.org/TR/audio-eq-cookbook/
+ *
+ * Transfer function (after normalising by a0 = 1 + α):
+ *   H(z) = (b0 + b1·z⁻¹ + b2·z⁻²) / (1 + a1·z⁻¹ + a2·z⁻²)
+ *   ω₀ = 2π·f₀/fs
+ *   α  = sin(ω₀) / (2·Q)
+ *   b0 = 1,                    b1 = -2·cos(ω₀),                b2 = 1
+ *   a0 = 1 + α,                a1 = -2·cos(ω₀),                a2 = 1 - α
+ *
+ * Properties:
+ *   - Unity gain at DC and at Nyquist (key vs the simpler pole-zero
+ *     form — that one has DC gain (2−2c)/(1+r²−2rc) which is < 1 unless
+ *     r → 1, and would scale slow drift down along with the notch).
+ *   - Deep null at f₀ (limit: −∞ dB; in practice limited by float
+ *     precision, ~−300 dB).
+ *   - −3 dB bandwidth Δf ≈ f₀ / Q.  Q ≈ 5 means Δf = 0.2 f₀, which
+ *     is sharp enough to leave nearby motion frequencies untouched
+ *     while crushing the carrier.
+ *
+ * Coefficients are recomputed per sample from the actual `dt`, so
+ * a varying event rate (DeviceOrientation can deliver anywhere from
+ * 30–100 Hz across vendors) doesn't shift the notch frequency in the
+ * time domain.  Cost is a few trig + muls per sample — negligible.
+ */
+export default class BiquadNotch {
+  /**
+   * @param {object} opts
+   * @param {number} opts.f0Hz   Frequency to null out (Hz).
+   * @param {number} [opts.Q]    Quality factor; higher = narrower notch,
+   *   slower settle.  Default 5 (≈ 0.2·f₀ bandwidth).
+   */
+  constructor({f0Hz, Q = 5} = {}) {
+    if (!(f0Hz > 0)) {
+      throw new Error(`BiquadNotch: f0Hz must be > 0 (got ${f0Hz})`)
+    }
+    if (!(Q > 0)) {
+      throw new Error(`BiquadNotch: Q must be > 0 (got ${Q})`)
+    }
+    this.f0Hz = f0Hz
+    this.Q = Q
+    this._x1 = 0
+    this._x2 = 0
+    this._y1 = 0
+    this._y2 = 0
+    this._initialized = false
+  }
+
+
+  /** Drop all delay-line state. */
+  reset() {
+    this._x1 = 0
+    this._x2 = 0
+    this._y1 = 0
+    this._y2 = 0
+    this._initialized = false
+  }
+
+
+  /**
+   * @param {number} x   New raw sample.
+   * @param {number} dt  Time since previous sample (seconds, > 0).  On
+   *   the very first call, the delay lines are seeded with `x` so a
+   *   constant input rides through clean (no startup ring).
+   * @returns {number}   Filtered sample.
+   */
+  filter(x, dt) {
+    if (!(dt > 0)) {
+      // Repeated / out-of-order timestamp — no update, return last output.
+      return this._y1
+    }
+    if (!this._initialized) {
+      this._x1 = this._x2 = x
+      this._y1 = this._y2 = x
+      this._initialized = true
+      return x
+    }
+    const fs = 1.0 / dt
+    const omega = (2.0 * Math.PI * this.f0Hz) / fs
+    const sinW = Math.sin(omega)
+    const cosW = Math.cos(omega)
+    const alpha = sinW / (2.0 * this.Q)
+    const a0 = 1.0 + alpha
+    // Normalised coefficients (b0/a0, b1/a0, ...).  Hoist 1/a0 once.
+    const inv = 1.0 / a0
+    const b0 = inv
+    const b1 = -2.0 * cosW * inv
+    const b2 = inv
+    const a1 = -2.0 * cosW * inv
+    const a2 = (1.0 - alpha) * inv
+    const y = (b0 * x) + (b1 * this._x1) + (b2 * this._x2) -
+              (a1 * this._y1) - (a2 * this._y2)
+    this._x2 = this._x1
+    this._x1 = x
+    this._y2 = this._y1
+    this._y1 = y
+    return y
+  }
+}

--- a/js/ar/BiquadNotch.test.js
+++ b/js/ar/BiquadNotch.test.js
@@ -1,0 +1,118 @@
+import {describe, expect, it} from 'bun:test'
+import BiquadNotch from './BiquadNotch.js'
+
+
+describe('BiquadNotch', () => {
+  it('first sample passes through unchanged', () => {
+    const f = new BiquadNotch({f0Hz: 1.0})
+    expect(f.filter(7.0, 1 / 60)).toBe(7.0)
+  })
+
+
+  it('passes DC unchanged at steady state', () => {
+    const f = new BiquadNotch({f0Hz: 1.0})
+    const dt = 1 / 60
+    let last = 0
+    for (let i = 0; i < 200; i++) {
+      last = f.filter(5.0, dt)
+    }
+    expect(Math.abs(last - 5.0)).toBeLessThan(0.001)
+  })
+
+
+  it('attenuates a tone at the notch frequency to deep null (≥ 50 dB) at steady state', () => {
+    const fs = 60
+    const f0 = 1.0
+    const dt = 1 / fs
+    const f = new BiquadNotch({f0Hz: f0, Q: 5})
+    let t = 0
+    let peak = 0
+    // Q=5 settles in ~Q/(π·f0) = 1.6 s per time-constant, but reaching
+    // a deep null takes many τ.  Run for 60 s, observe last 30 s.
+    for (let i = 0; i < 3600; i++) {
+      const x = Math.sin(2 * Math.PI * f0 * t)
+      const y = f.filter(x, dt)
+      if (i > 1800 && Math.abs(y) > peak) {
+        peak = Math.abs(y)
+      }
+      t += dt
+    }
+    // Input amplitude 1.0 → ≥ 50 dB rejection means |y| ≤ 0.00316.
+    expect(peak).toBeLessThan(0.00316)
+  })
+
+
+  it('passes frequencies well below the notch nearly unchanged', () => {
+    // Compare peak ratio (output/input) to handle discrete-sampling
+    // artifacts: at 0.05 Hz with fs=60 the samples don't always land
+    // on the analog peak, so absolute output peak < amplitude even
+    // for unity gain.  RMS or pre-sample comparison would also work.
+    const fs = 60
+    const f0 = 1.0
+    const dt = 1 / fs
+    const f = new BiquadNotch({f0Hz: f0, Q: 5})
+    let t = 0
+    let inPeak = 0
+    let outPeak = 0
+    for (let i = 0; i < 1200; i++) {
+      const x = Math.sin(2 * Math.PI * 0.05 * t) // 0.05 Hz, 20× below notch
+      const y = f.filter(x, dt)
+      if (i > 600) {
+        if (Math.abs(x) > inPeak) {
+          inPeak = Math.abs(x)
+        }
+        if (Math.abs(y) > outPeak) {
+          outPeak = Math.abs(y)
+        }
+      }
+      t += dt
+    }
+    expect(outPeak / inPeak).toBeGreaterThan(0.95)
+  })
+
+
+  it('passes frequencies well above the notch nearly unchanged', () => {
+    const fs = 60
+    const f0 = 1.0
+    const dt = 1 / fs
+    const f = new BiquadNotch({f0Hz: f0, Q: 5})
+    let t = 0
+    let inPeak = 0
+    let outPeak = 0
+    for (let i = 0; i < 1200; i++) {
+      const x = Math.sin(2 * Math.PI * 10.0 * t) // 10 Hz, 10× above notch
+      const y = f.filter(x, dt)
+      if (i > 600) {
+        if (Math.abs(x) > inPeak) {
+          inPeak = Math.abs(x)
+        }
+        if (Math.abs(y) > outPeak) {
+          outPeak = Math.abs(y)
+        }
+      }
+      t += dt
+    }
+    expect(outPeak / inPeak).toBeGreaterThan(0.95)
+  })
+
+
+  it('reset() clears state', () => {
+    const f = new BiquadNotch({f0Hz: 1.0})
+    f.filter(5.0, 1 / 60)
+    f.filter(5.0, 1 / 60)
+    f.reset()
+    expect(f.filter(99.0, 1 / 60)).toBe(99.0)
+  })
+
+
+  it('throws on invalid f0Hz', () => {
+    expect(() => new BiquadNotch({f0Hz: 0})).toThrow()
+    expect(() => new BiquadNotch({f0Hz: -1})).toThrow()
+  })
+
+
+  it('throws on invalid Q', () => {
+    expect(() => new BiquadNotch({f0Hz: 1, Q: 0})).toThrow()
+    expect(() => new BiquadNotch({f0Hz: 1, Q: -1})).toThrow()
+  })
+})

--- a/js/ar/Calibration.js
+++ b/js/ar/Calibration.js
@@ -1,0 +1,164 @@
+import {Quaternion, Vector3} from 'three'
+
+
+/** localStorage namespace for AR calibration entries. */
+const STORAGE_KEY = 'celestiary.ar.cal'
+
+
+/**
+ * Solve for the calibration quaternion that corrects the sensor's idea of
+ * "where the camera is aimed" so that it matches a known true direction.
+ *
+ * Inputs are unit vectors in the same frame (typically ENU at the
+ * observer):
+ *   - `deviceAim`: the direction the sensor currently reports the camera
+ *     forward as pointing toward.
+ *   - `trueAim`:  the actual direction to the reference body (from the
+ *     scene's world model, projected back through the rotating-body and
+ *     ENU-mapping transforms into ENU coords).
+ *
+ * Output `q_cal` satisfies `q_cal · deviceAim = trueAim`, applied as
+ * `q_cal_enu` in ARController's chain:
+ *
+ *   camera.quaternion =
+ *     enu_to_bodyFixed(lat, lng) · q_cal_enu · q_camera_to_enu
+ *
+ * Three.js `Quaternion.setFromUnitVectors` returns the minimal-arc
+ * rotation between two unit vectors — i.e. a 2-DoF correction.  This is
+ * a slight over-fit relative to a pure-yaw heading correction (for which
+ * we'd need at least two reference samples to disambiguate), but for the
+ * single-tap UX it's the right shape: any one bias source — hard-iron,
+ * miscalibrated zero, slight tilt — is absorbed in one shot.
+ *
+ * @param {Vector3} deviceAim  Unit vector, sensor's camera-forward in ENU
+ * @param {Vector3} trueAim  Unit vector, scene's true body direction in ENU
+ * @returns {Quaternion}
+ */
+export function solveCalibration(deviceAim, trueAim) {
+  return new Quaternion().setFromUnitVectors(deviceAim, trueAim)
+}
+
+
+/**
+ * Encode a calibration quaternion as a compact JSON string for
+ * localStorage round-tripping.  Trims to 6 dp — calibration is a
+ * sub-degree correction at most, and we don't need 17-digit precision.
+ *
+ * @param {Quaternion} q
+ * @returns {string}
+ */
+export function encodeCalibration(q) {
+  return JSON.stringify({
+    x: roundTo6(q.x),
+    y: roundTo6(q.y),
+    z: roundTo6(q.z),
+    w: roundTo6(q.w),
+  })
+}
+
+
+/**
+ * @param {string} s  JSON-encoded calibration
+ * @returns {?Quaternion}  null if input is malformed
+ */
+export function decodeCalibration(s) {
+  if (!s) {
+    return null
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(s)
+  } catch (e) {
+    void e
+    return null
+  }
+  const {x, y, z, w} = parsed
+  if ([x, y, z, w].some((v) => typeof v !== 'number' || !Number.isFinite(v))) {
+    return null
+  }
+  return new Quaternion(x, y, z, w).normalize()
+}
+
+
+/**
+ * Per-pose-source / per-screen-orientation storage of a calibration
+ * quaternion.  Scoped by source kind + screen angle so a re-orientation
+ * (portrait → landscape) and a switch between WebXR / DeviceOrientation
+ * each have their own slot — calibration meaning depends on which sensor
+ * stack produced the bias.
+ */
+export class CalibrationStore {
+  /**
+   * @param {object} [opts]
+   * @param {{getItem: Function, setItem: Function, removeItem: Function}} [opts.storage]
+   *   Defaults to `window.localStorage` when present, otherwise an
+   *   in-memory shim — keeps the class usable in tests / SSR.
+   */
+  constructor({storage} = {}) {
+    this._storage = storage ?? defaultStorage()
+  }
+
+
+  _key(sourceKind, screenAngle) {
+    return `${STORAGE_KEY}:${sourceKind}:${screenAngle | 0}`
+  }
+
+
+  /**
+   * @param {string} sourceKind  PoseSource.kind
+   * @param {number} screenAngle  screen.orientation.angle (degrees, integer)
+   * @returns {?Quaternion}
+   */
+  load(sourceKind, screenAngle) {
+    const raw = this._storage.getItem(this._key(sourceKind, screenAngle))
+    return decodeCalibration(raw)
+  }
+
+
+  /**
+   * @param {string} sourceKind
+   * @param {number} screenAngle
+   * @param {Quaternion} q
+   */
+  save(sourceKind, screenAngle, q) {
+    this._storage.setItem(this._key(sourceKind, screenAngle), encodeCalibration(q))
+  }
+
+
+  /**
+   * @param {string} sourceKind
+   * @param {number} screenAngle
+   */
+  clear(sourceKind, screenAngle) {
+    this._storage.removeItem(this._key(sourceKind, screenAngle))
+  }
+}
+
+
+/**
+ * @param {number} v
+ * @returns {number}
+ */
+function roundTo6(v) {
+  return Math.round(v * 1e6) / 1e6
+}
+
+
+/** @returns {{getItem: Function, setItem: Function, removeItem: Function}} */
+function defaultStorage() {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage
+  }
+  // In-memory shim for SSR / Bun tests.  Module-scoped Map so multiple
+  // CalibrationStore instances in the same process share a backing store
+  // (matches localStorage's process-wide semantics).
+  const m = inMemoryStore
+  return {
+    getItem: (k) => m.has(k) ? m.get(k) : null,
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+  }
+}
+
+
+const inMemoryStore = new Map()

--- a/js/ar/Calibration.test.js
+++ b/js/ar/Calibration.test.js
@@ -1,0 +1,146 @@
+import {describe, expect, it} from 'bun:test'
+import {Quaternion, Vector3} from 'three'
+import {
+  CalibrationStore,
+  decodeCalibration,
+  encodeCalibration,
+  solveCalibration,
+} from './Calibration.js'
+
+
+describe('solveCalibration', () => {
+  it('returns identity when device aim already matches truth', () => {
+    const v = new Vector3(0, 1, 0)
+    const q = solveCalibration(v, v)
+    expect(q.x).toBeCloseTo(0, 9)
+    expect(q.y).toBeCloseTo(0, 9)
+    expect(q.z).toBeCloseTo(0, 9)
+    expect(Math.abs(q.w)).toBeCloseTo(1, 9)
+  })
+
+
+  it('produces a yaw-only correction for a pure heading bias', () => {
+    // Sensor reports the camera aimed at North; reality is East.  The
+    // correction is a 90° rotation around the world Up axis (+Z in ENU).
+    const device = new Vector3(0, 1, 0) // North
+    const truth = new Vector3(1, 0, 0) // East
+    const q = solveCalibration(device, truth)
+    // Apply correction; result must equal truth.
+    const corrected = device.clone().applyQuaternion(q)
+    expect(corrected.x).toBeCloseTo(1, 9)
+    expect(corrected.y).toBeCloseTo(0, 9)
+    expect(corrected.z).toBeCloseTo(0, 9)
+    // The rotation axis should be pure Up (+Z) since both vectors lie in
+    // the horizontal plane.  Quaternion (sin(45°)·axis, cos(45°)·1) → z
+    // component = sin(45°), x and y components zero.
+    expect(q.x).toBeCloseTo(0, 9)
+    expect(q.y).toBeCloseTo(0, 9)
+    expect(Math.abs(q.z)).toBeCloseTo(Math.SQRT1_2, 9)
+  })
+
+
+  it('produces a tilt correction when the bias is out of plane', () => {
+    // Device thinks it's aimed at the horizon; really aimed 30° up.
+    const device = new Vector3(0, 1, 0)
+    const truth = new Vector3(0, Math.cos(30 * Math.PI / 180), Math.sin(30 * Math.PI / 180))
+    const q = solveCalibration(device, truth)
+    const corrected = device.clone().applyQuaternion(q)
+    expect(corrected.x).toBeCloseTo(truth.x, 9)
+    expect(corrected.y).toBeCloseTo(truth.y, 9)
+    expect(corrected.z).toBeCloseTo(truth.z, 9)
+  })
+
+
+  it('round-trips through encode/decode at 6 dp', () => {
+    const device = new Vector3(0.5, 0.6, 0.6).normalize()
+    const truth = new Vector3(-0.4, 0.1, 0.9).normalize()
+    const q = solveCalibration(device, truth)
+    const round = decodeCalibration(encodeCalibration(q))
+    expect(round.x).toBeCloseTo(q.x, 5)
+    expect(round.y).toBeCloseTo(q.y, 5)
+    expect(round.z).toBeCloseTo(q.z, 5)
+    expect(round.w).toBeCloseTo(q.w, 5)
+  })
+})
+
+
+describe('decodeCalibration', () => {
+  it('returns null on malformed JSON', () => {
+    expect(decodeCalibration('not-json')).toBeNull()
+  })
+
+
+  it('returns null on missing fields', () => {
+    expect(decodeCalibration('{"x":1,"y":0}')).toBeNull()
+  })
+
+
+  it('returns null on null input', () => {
+    expect(decodeCalibration(null)).toBeNull()
+  })
+
+
+  it('normalizes the decoded quaternion', () => {
+    // Slightly de-normalized fixture; result should be unit-length.
+    const q = decodeCalibration('{"x":0.5,"y":0.5,"z":0.5,"w":0.5}')
+    const len = Math.sqrt((q.x * q.x) + (q.y * q.y) + (q.z * q.z) + (q.w * q.w))
+    expect(len).toBeCloseTo(1, 9)
+  })
+})
+
+
+describe('CalibrationStore', () => {
+  function fakeStorage() {
+    const map = new Map()
+    return {
+      getItem: (k) => map.has(k) ? map.get(k) : null,
+      setItem: (k, v) => map.set(k, v),
+      removeItem: (k) => map.delete(k),
+      _map: map,
+    }
+  }
+
+
+  it('returns null for an unsaved (kind, angle)', () => {
+    const store = new CalibrationStore({storage: fakeStorage()})
+    expect(store.load('deviceorientation', 0)).toBeNull()
+  })
+
+
+  it('round-trips a saved calibration', () => {
+    const store = new CalibrationStore({storage: fakeStorage()})
+    const q = new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), 0.5)
+    store.save('deviceorientation', 0, q)
+    const loaded = store.load('deviceorientation', 0)
+    expect(loaded.x).toBeCloseTo(q.x, 5)
+    expect(loaded.y).toBeCloseTo(q.y, 5)
+    expect(loaded.z).toBeCloseTo(q.z, 5)
+    expect(loaded.w).toBeCloseTo(q.w, 5)
+  })
+
+
+  it('scopes by source kind and screen angle', () => {
+    // Different sensor stacks and screen orientations have *different*
+    // physical meanings for "calibration", so they must not share slots.
+    const store = new CalibrationStore({storage: fakeStorage()})
+    const a = new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), 0.5)
+    const b = new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), -0.5)
+    store.save('deviceorientation', 0, a)
+    store.save('deviceorientation', 90, b)
+    const portrait = store.load('deviceorientation', 0)
+    const landscape = store.load('deviceorientation', 90)
+    expect(portrait.z).toBeCloseTo(a.z, 5)
+    expect(landscape.z).toBeCloseTo(b.z, 5)
+    expect(store.load('webxr', 0)).toBeNull()
+  })
+
+
+  it('clears a single slot without affecting others', () => {
+    const store = new CalibrationStore({storage: fakeStorage()})
+    store.save('deviceorientation', 0, new Quaternion(0.1, 0, 0, 0.99))
+    store.save('deviceorientation', 90, new Quaternion(0, 0.1, 0, 0.99))
+    store.clear('deviceorientation', 0)
+    expect(store.load('deviceorientation', 0)).toBeNull()
+    expect(store.load('deviceorientation', 90)).not.toBeNull()
+  })
+})

--- a/js/ar/DeviceOrientationPoseSource.js
+++ b/js/ar/DeviceOrientationPoseSource.js
@@ -1,5 +1,58 @@
 import {Euler, Quaternion, Vector3} from 'three'
 import {toRad} from '../shared.js'
+import AlphaPipeline from './AlphaPipeline.js'
+import BiquadNotch from './BiquadNotch.js'
+import LocalOneEuroFilter, {AngleOneEuroFilter as LocalAngleOneEuroFilter} from './OneEuroFilter.js'
+import LibBackedOneEuroFilter, {AngleOneEuroFilter as LibBackedAngleOneEuroFilter} from './OneEuroFilterLib.js'
+
+
+// A/B swap: flip USE_LIB_FILTER to exercise the canonical 1eurofilter
+// package instead of our local impl.  Same constructor opts, same
+// filter()/reset() API, same extension knobs (xDeadband / dDeadband /
+// motionThresh).  The lib gives us Casiez's reference math; our impl
+// is a direct port plus the same extensions.
+const USE_LIB_FILTER = true
+const OneEuroFilter = USE_LIB_FILTER ? LibBackedOneEuroFilter : LocalOneEuroFilter
+const AngleOneEuroFilter = USE_LIB_FILTER ? LibBackedAngleOneEuroFilter : LocalAngleOneEuroFilter
+
+
+// 1€ filter presets for the alpha (yaw / heading) axis — three damping
+// levels exposed to the user from the AR HUD.  The noise floor on
+// mid-range Android magnetometers isn't a clean tone we can notch out
+// (closer to pink-ish random walk with broadband fuzz), so smoothing
+// strength is the only knob that meaningfully changes UX.
+//
+//   light  : minCutoff 1.0, beta 0.05  → snappy, more visible jitter
+//   medium : minCutoff 0.5, beta 0.05  → balanced; tested-good default
+//                                        on a Samsung A34
+//   heavy  : minCutoff 0.05, beta 0.005 → near-fixed 0.05 Hz LP at rest;
+//                                        ~24° lag at 30°/s pan, but very
+//                                        clean for "recognise dots in
+//                                        the sky" use case
+//
+// Pitch + roll come from gravity via the accelerometer — much cleaner
+// — so they share the lighter TILT_FILTER_OPTS regardless of the
+// alpha damping selection.
+const ALPHA_FILTER_PRESETS = Object.freeze({
+  light: Object.freeze({minCutoff: 1.0, beta: 0.05, dCutoff: 1.0}),
+  medium: Object.freeze({minCutoff: 0.5, beta: 0.05, dCutoff: 1.0}),
+  heavy: Object.freeze({minCutoff: 0.05, beta: 0.005, dCutoff: 1.0}),
+})
+const DEFAULT_ALPHA_DAMPING = 'medium'
+const TILT_FILTER_OPTS = Object.freeze({minCutoff: 0.5, beta: 0.05, dCutoff: 1.0})
+
+
+// No notch — the magnetometer artifact on tested mid-range Android
+// hardware doesn't have a stationary spectrum a single-frequency notch
+// can bite into.  Left wired in via AlphaPipeline so it's a one-line
+// flip if a future device shows a clean carrier.
+const ALPHA_NOTCH_OPTS = null
+
+
+/** @returns {string[]} valid damping preset names */
+export function getAlphaDampingNames() {
+  return Object.keys(ALPHA_FILTER_PRESETS)
+}
 
 
 /**
@@ -58,11 +111,68 @@ export default class DeviceOrientationPoseSource {
     this._listening = false
     this._isAbsolute = false
     this._lastSample = null
+    this._lastRawSample = null
     this._lastSampleAt = 0
+    this._sampleCount = 0
+    this._lastEventType = null
     this._handler = (e) => this._onEvent(e)
     this._q = new Quaternion()
     this._screenQ = new Quaternion()
     this._scratchEuler = new Euler()
+    // Per-axis filters.  Alpha (yaw, magnetometer-fused, noisiest axis)
+    // gets the full unwrap → notch → 1€ pipeline so we can pick off a
+    // known periodic carrier before the smoothing stage.  Beta + gamma
+    // (pitch + roll, accelerometer-derived) are clean enough that bare
+    // 1€ is plenty.
+    this._alphaDamping = DEFAULT_ALPHA_DAMPING
+    this._alphaFilter = this._buildAlphaFilter(this._alphaDamping)
+    this._betaFilter = new AngleOneEuroFilter(TILT_FILTER_OPTS)
+    this._gammaFilter = new OneEuroFilter(TILT_FILTER_OPTS)
+  }
+
+
+  /**
+   * Build (or rebuild) the alpha filter pipeline at the given damping
+   * preset.  Used at construction time and whenever the user changes
+   * the damping mode from the AR HUD.
+   *
+   * @param {string} name  One of `getAlphaDampingNames()`
+   * @returns {AlphaPipeline}
+   */
+  _buildAlphaFilter(name) {
+    const opts = ALPHA_FILTER_PRESETS[name] ?? ALPHA_FILTER_PRESETS[DEFAULT_ALPHA_DAMPING]
+    return new AlphaPipeline({
+      BaseFilter: OneEuroFilter,
+      oneEuroOpts: opts,
+      notch: ALPHA_NOTCH_OPTS ? new BiquadNotch(ALPHA_NOTCH_OPTS) : null,
+    })
+  }
+
+
+  /**
+   * Swap the alpha-axis filter to a different damping preset.  Rebuilds
+   * the pipeline (state is reset, so a brief settling transient is
+   * expected on the next sample — fine since the user is in the middle
+   * of an explicit "change smoothing" gesture).
+   *
+   * @param {string} name  One of `getAlphaDampingNames()`
+   */
+  setAlphaDamping(name) {
+    if (!Object.prototype.hasOwnProperty.call(ALPHA_FILTER_PRESETS, name)) {
+      console.warn(`Unknown alpha damping preset: ${name}`)
+      return
+    }
+    if (name === this._alphaDamping) {
+      return
+    }
+    this._alphaDamping = name
+    this._alphaFilter = this._buildAlphaFilter(name)
+  }
+
+
+  /** @returns {string} Current alpha damping preset name */
+  getAlphaDamping() {
+    return this._alphaDamping
   }
 
 
@@ -110,6 +220,10 @@ export default class DeviceOrientationPoseSource {
     window.removeEventListener('deviceorientation', this._handler, true)
     this._listening = false
     this._lastSample = null
+    this._lastRawSample = null
+    this._alphaFilter.reset()
+    this._betaFilter.reset()
+    this._gammaFilter.reset()
   }
 
 
@@ -123,8 +237,17 @@ export default class DeviceOrientationPoseSource {
     if (typeof e.absolute === 'boolean' && e.absolute) {
       this._isAbsolute = true
     }
-    this._lastSample = {alpha: e.alpha, beta: e.beta, gamma: e.gamma}
-    this._lastSampleAt = (typeof performance !== 'undefined') ? performance.now() : Date.now()
+    const nowMs = (typeof performance !== 'undefined') ? performance.now() : Date.now()
+    const tSec = nowMs / 1000
+    this._lastRawSample = {alpha: e.alpha, beta: e.beta, gamma: e.gamma}
+    this._lastSample = {
+      alpha: this._alphaFilter.filter(e.alpha, tSec),
+      beta: this._betaFilter.filter(e.beta, tSec),
+      gamma: this._gammaFilter.filter(e.gamma, tSec),
+    }
+    this._lastSampleAt = nowMs
+    this._sampleCount++
+    this._lastEventType = e.type
     this.needsCalibration = !this._isAbsolute
   }
 
@@ -158,6 +281,31 @@ export default class DeviceOrientationPoseSource {
     const fresh = this._lastSample !== null &&
         ((typeof performance !== 'undefined' ? performance.now() : Date.now()) - this._lastSampleAt) < 1000
     return {fresh, source: this._isAbsolute ? 'deviceorientation-absolute' : 'deviceorientation'}
+  }
+
+
+  /** @returns {object} Snapshot for the AR debug HUD */
+  getDebugSnapshot() {
+    // Pull the latest unwrapped + notched intermediates from the alpha
+    // pipeline so the HUD graph can plot all four traces (raw → unwrap
+    // → notch → 1€) and we can see which stage each artifact belongs to.
+    const alphaInter = typeof this._alphaFilter.getDebugIntermediates === 'function' ?
+      this._alphaFilter.getDebugIntermediates() :
+      null
+    return {
+      kind: this.kind,
+      listening: this._listening,
+      isAbsolute: this._isAbsolute,
+      sampleCount: this._sampleCount,
+      lastSample: this._lastSample,
+      lastRawSample: this._lastRawSample,
+      lastNotchedAlpha: alphaInter ? alphaInter.notched : null,
+      lastUnwrappedAlpha: alphaInter ? alphaInter.unwrapped : null,
+      lastEventType: this._lastEventType,
+      msSinceLastSample: this._lastSample === null ?
+        null :
+        Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - this._lastSampleAt),
+    }
   }
 }
 

--- a/js/ar/DeviceOrientationPoseSource.js
+++ b/js/ar/DeviceOrientationPoseSource.js
@@ -1,0 +1,197 @@
+import {Euler, Quaternion, Vector3} from 'three'
+import {toRad} from '../shared.js'
+
+
+/**
+ * Reusable axis vector for the screen-orientation correction quaternion —
+ * device +Z is "out of the screen" in W3C device-axes terms.
+ */
+const DEVICE_Z = new Vector3(0, 0, 1)
+
+
+/**
+ * Read DeviceOrientationEvent.alpha/beta/gamma and produce a quaternion
+ * that maps **camera-frame** vectors to **ENU-frame** vectors.
+ *
+ * Frame conventions (per W3C Device Orientation spec):
+ *   - Device frame: +X right, +Y top of phone, +Z out of screen toward user.
+ *   - Earth (ENU) frame: +X East, +Y North, +Z Up.
+ *   - alpha (≥ 0, < 360°): rotation around device Z.
+ *   - beta (-180°, 180°]: rotation around device X.
+ *   - gamma (-90°, 90°]: rotation around device Y.
+ *   - Composition is intrinsic Z-X-Y, i.e. q_dev_to_enu = Rz(α)·Rx(β)·Ry(γ).
+ *
+ * Camera-frame ≡ screen-frame (the renderer's viewport): +X right of the
+ * rendered image, +Y up the rendered image, looking out the back of the
+ * phone (Three.js camera forward = camera −Z = device −Z).  Screen-frame
+ * relates to device-frame by `screen.orientation.angle` (a CCW rotation
+ * around device +Z), so:
+ *
+ *   v_ENU  = q_dev_to_enu · v_device
+ *          = q_dev_to_enu · Rz(+orient) · v_screen
+ *          = q_cam_to_enu · v_camera
+ *
+ *   q_cam_to_enu = q_dev_to_enu · Rz(+orient)
+ *
+ * Absolute-orientation events (`deviceorientationabsolute` or
+ * `DeviceOrientationEvent#absolute`) reference true Earth axes; relative
+ * events reference whatever the browser pinned at session start.  The
+ * factory (PoseSource.createPoseSource) prefers absolute when available,
+ * otherwise falls back to relative + a calibration step.  iOS exposes
+ * `webkitCompassHeading` on the relative event, which we *could* use to
+ * derive an absolute alpha — left for a follow-up; for now the relative
+ * fallback ships with the calibration gear surfaced in the AR HUD.
+ *
+ * Permissions: iOS 13+ requires a one-time
+ * `DeviceOrientationEvent.requestPermission()` call from a user gesture.
+ * `start()` invokes it; the caller is responsible for triggering `start()`
+ * inside a button-tap handler.
+ */
+export default class DeviceOrientationPoseSource {
+  constructor() {
+    this.kind = 'deviceorientation'
+    // Absolute mode reads true heading, so calibration is "nice to have"
+    // rather than mandatory.  Relative mode (no magnetometer fusion) starts
+    // out at an arbitrary yaw and *needs* calibration to be useful.  Set
+    // accurately once `start()` learns which mode the browser delivers.
+    this.needsCalibration = true
+    this._listening = false
+    this._isAbsolute = false
+    this._lastSample = null
+    this._lastSampleAt = 0
+    this._handler = (e) => this._onEvent(e)
+    this._q = new Quaternion()
+    this._screenQ = new Quaternion()
+    this._scratchEuler = new Euler()
+  }
+
+
+  /**
+   * Request permissions if needed, then attach listeners.  Resolves once
+   * either an event has arrived or the listener is wired (whichever first).
+   * Throws if permission is denied or device-orientation events are
+   * unavailable.
+   *
+   * @returns {Promise<void>}
+   */
+  async start() {
+    if (this._listening) {
+      return
+    }
+    if (typeof window === 'undefined' || !('DeviceOrientationEvent' in window)) {
+      throw new Error('DeviceOrientation not supported')
+    }
+    // iOS 13+ permission gate.  No-op on Android / desktop.
+    const reqPerm = window.DeviceOrientationEvent.requestPermission
+    if (typeof reqPerm === 'function') {
+      const result = await reqPerm()
+      if (result !== 'granted') {
+        throw new Error(`DeviceOrientation permission ${result}`)
+      }
+    }
+    // Prefer the absolute event when the browser exposes it; otherwise the
+    // standard event and rely on `event.absolute` to advertise its mode.
+    if ('ondeviceorientationabsolute' in window) {
+      window.addEventListener('deviceorientationabsolute', this._handler, true)
+      this._isAbsolute = true
+    } else {
+      window.addEventListener('deviceorientation', this._handler, true)
+    }
+    this._listening = true
+  }
+
+
+  /** Detach listeners; safe to call repeatedly. */
+  stop() {
+    if (!this._listening) {
+      return
+    }
+    window.removeEventListener('deviceorientationabsolute', this._handler, true)
+    window.removeEventListener('deviceorientation', this._handler, true)
+    this._listening = false
+    this._lastSample = null
+  }
+
+
+  /** @param {DeviceOrientationEvent} e */
+  _onEvent(e) {
+    if (e.alpha === null || e.beta === null || e.gamma === null) {
+      // Some platforms briefly emit null while the sensor warms up; just
+      // wait for the next event.
+      return
+    }
+    if (typeof e.absolute === 'boolean' && e.absolute) {
+      this._isAbsolute = true
+    }
+    this._lastSample = {alpha: e.alpha, beta: e.beta, gamma: e.gamma}
+    this._lastSampleAt = (typeof performance !== 'undefined') ? performance.now() : Date.now()
+    this.needsCalibration = !this._isAbsolute
+  }
+
+
+  /**
+   * @param {Quaternion} out  Receives camera→ENU quaternion
+   * @returns {boolean} false if no sample has arrived yet
+   */
+  getQuaternion(out) {
+    if (!this._lastSample) {
+      return false
+    }
+    const {alpha, beta, gamma} = this._lastSample
+    composeDeviceToEnu(this._scratchEuler, this._q, alpha, beta, gamma)
+    // Apply screen-orientation correction.  When the user rotates the phone
+    // to landscape, screen-frame and device-frame diverge by the screen
+    // angle around device Z; without this step the rendered horizon tilts
+    // 90° on rotation.
+    const orient = readScreenOrientationRad()
+    if (orient !== 0) {
+      this._screenQ.setFromAxisAngle(DEVICE_Z, orient)
+      this._q.multiply(this._screenQ)
+    }
+    out.copy(this._q)
+    return true
+  }
+
+
+  /** @returns {{fresh: boolean, source: string}} */
+  getStatus() {
+    const fresh = this._lastSample !== null &&
+        ((typeof performance !== 'undefined' ? performance.now() : Date.now()) - this._lastSampleAt) < 1000
+    return {fresh, source: this._isAbsolute ? 'deviceorientation-absolute' : 'deviceorientation'}
+  }
+}
+
+
+/**
+ * Pure-math helper, exported for tests.  Composes the W3C-spec Z-X-Y
+ * intrinsic rotation into a Three.js quaternion.
+ *
+ * @param {Euler} scratchEuler  Pre-allocated Euler to avoid GC churn
+ * @param {Quaternion} out  Receives the result
+ * @param {number} alphaDeg  Rotation around device Z
+ * @param {number} betaDeg  Rotation around device X
+ * @param {number} gammaDeg  Rotation around device Y
+ */
+export function composeDeviceToEnu(scratchEuler, out, alphaDeg, betaDeg, gammaDeg) {
+  // Three.js Euler order 'ZXY' yields M = Rz(z) · Rx(x) · Ry(y) when applied
+  // via Quaternion.setFromEuler — exactly the W3C Z-X-Y intrinsic chain.
+  scratchEuler.set(betaDeg * toRad, gammaDeg * toRad, alphaDeg * toRad, 'ZXY')
+  out.setFromEuler(scratchEuler)
+}
+
+
+/**
+ * Read `screen.orientation.angle` (or legacy `window.orientation`) in
+ * radians.  Returns 0 if neither is available.
+ *
+ * @returns {number}
+ */
+function readScreenOrientationRad() {
+  if (typeof screen !== 'undefined' && screen.orientation && typeof screen.orientation.angle === 'number') {
+    return screen.orientation.angle * toRad
+  }
+  if (typeof window !== 'undefined' && typeof window.orientation === 'number') {
+    return window.orientation * toRad
+  }
+  return 0
+}

--- a/js/ar/DeviceOrientationPoseSource.js
+++ b/js/ar/DeviceOrientationPoseSource.js
@@ -38,7 +38,7 @@ const ALPHA_FILTER_PRESETS = Object.freeze({
   medium: Object.freeze({minCutoff: 0.5, beta: 0.05, dCutoff: 1.0}),
   heavy: Object.freeze({minCutoff: 0.05, beta: 0.005, dCutoff: 1.0}),
 })
-const DEFAULT_ALPHA_DAMPING = 'medium'
+export const DEFAULT_ALPHA_DAMPING = 'medium'
 const TILT_FILTER_OPTS = Object.freeze({minCutoff: 0.5, beta: 0.05, dCutoff: 1.0})
 
 

--- a/js/ar/DeviceOrientationPoseSource.test.js
+++ b/js/ar/DeviceOrientationPoseSource.test.js
@@ -1,0 +1,137 @@
+import {describe, expect, it} from 'bun:test'
+import {Euler, Quaternion, Vector3} from 'three'
+import {composeDeviceToEnu} from './DeviceOrientationPoseSource.js'
+
+
+/**
+ * Sanity check for the pure-math composer exported from
+ * DeviceOrientationPoseSource.  These tests verify the geometric meaning
+ * of (alpha, beta, gamma) by transforming each device-axis basis vector
+ * through the resulting quaternion and checking which ENU direction it
+ * lands on.
+ *
+ * Frame conventions:
+ *   - Device:  +X right, +Y top of phone, +Z out of screen toward user
+ *   - ENU:     +X East,   +Y North,        +Z Up
+ *
+ * The conventions and rotation order (Z-X-Y intrinsic) come from the W3C
+ * Device Orientation spec.
+ */
+
+
+function quatFor(alpha, beta, gamma) {
+  const e = new Euler()
+  const q = new Quaternion()
+  composeDeviceToEnu(e, q, alpha, beta, gamma)
+  return q
+}
+
+
+describe('composeDeviceToEnu — anchor poses', () => {
+  it('zero angles produce identity quaternion', () => {
+    // Phone laid face-up on a table, top of phone pointing north — by spec,
+    // device axes are aligned with ENU axes, so the quaternion is identity.
+    const q = quatFor(0, 0, 0)
+    expect(q.x).toBeCloseTo(0, 9)
+    expect(q.y).toBeCloseTo(0, 9)
+    expect(q.z).toBeCloseTo(0, 9)
+    expect(q.w).toBeCloseTo(1, 9)
+  })
+
+
+  it('alpha=90° rotates the device-Y axis from North to West', () => {
+    // Phone face-up, rotated 90° CCW (looking down at it).  Top of phone
+    // (device +Y) now points west.  alpha is right-handed around +Z.
+    const q = quatFor(90, 0, 0)
+    const top = new Vector3(0, 1, 0).applyQuaternion(q)
+    expect(top.x).toBeCloseTo(-1, 9) // West = -X (East)
+    expect(top.y).toBeCloseTo(0, 9)
+    expect(top.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('alpha=90°: device-X (right edge) lands on North', () => {
+    const q = quatFor(90, 0, 0)
+    const right = new Vector3(1, 0, 0).applyQuaternion(q)
+    expect(right.x).toBeCloseTo(0, 9)
+    expect(right.y).toBeCloseTo(1, 9) // North
+    expect(right.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('beta=90° rotates phone around device-X by +90°: top edge points Up', () => {
+    // Pure Rx(+90°): right-hand rule about +X earth (East) rotates
+    // device-Y from North up to Up.  Equivalently device-Z (out of screen)
+    // rotates from Up to South — matching the spec's "screen tilts toward
+    // the user" intuition (user south of phone).
+    const q = quatFor(0, 90, 0)
+    const top = new Vector3(0, 1, 0).applyQuaternion(q)
+    expect(top.x).toBeCloseTo(0, 9)
+    expect(top.y).toBeCloseTo(0, 9)
+    expect(top.z).toBeCloseTo(1, 9) // Up
+  })
+
+
+  it('beta=90°: device-Z (out of screen) ends up pointing South (−Y)', () => {
+    const q = quatFor(0, 90, 0)
+    const out = new Vector3(0, 0, 1).applyQuaternion(q)
+    expect(out.x).toBeCloseTo(0, 9)
+    expect(out.y).toBeCloseTo(-1, 9) // South
+    expect(out.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('gamma=90° rotates phone around device-Y by +90°: device-X points Down', () => {
+    // Pure Ry(+90°) by right-hand rule rotates +X (East) toward −Z.  In
+    // ENU coords −Z is Down.  This is the math definition of the formula
+    // we use; physical-pose interpretations of the W3C sign convention
+    // for gamma vary across implementations and don't matter here so long
+    // as the formula and the browser agree on the encoding.
+    const q = quatFor(0, 0, 90)
+    const right = new Vector3(1, 0, 0).applyQuaternion(q)
+    expect(right.x).toBeCloseTo(0, 9)
+    expect(right.y).toBeCloseTo(0, 9)
+    expect(right.z).toBeCloseTo(-1, 9) // Down
+  })
+
+
+  it('gamma=90°: device-Z (out of screen) flips to East (+X)', () => {
+    const q = quatFor(0, 0, 90)
+    const out = new Vector3(0, 0, 1).applyQuaternion(q)
+    expect(out.x).toBeCloseTo(1, 9) // East
+    expect(out.y).toBeCloseTo(0, 9)
+    expect(out.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('preserves orthonormality (rotation, not scale)', () => {
+    const q = quatFor(45, 30, -20)
+    // Transform the three device axes; their lengths must remain 1, and
+    // their pairwise dot products 0.
+    const x = new Vector3(1, 0, 0).applyQuaternion(q)
+    const y = new Vector3(0, 1, 0).applyQuaternion(q)
+    const z = new Vector3(0, 0, 1).applyQuaternion(q)
+    expect(x.length()).toBeCloseTo(1, 9)
+    expect(y.length()).toBeCloseTo(1, 9)
+    expect(z.length()).toBeCloseTo(1, 9)
+    expect(x.dot(y)).toBeCloseTo(0, 9)
+    expect(x.dot(z)).toBeCloseTo(0, 9)
+    expect(y.dot(z)).toBeCloseTo(0, 9)
+  })
+
+
+  it('phone held vertically pointing east-on-the-horizon: device-Z = East', () => {
+    // Real-world AR pose: user holds phone upright, screen toward them,
+    // back of phone pointing east toward the rising sun.  alpha=270°
+    // (phone "facing" west, since alpha is the heading offset of the top
+    // edge from north going east), beta=90° (vertical), gamma=0.
+    //
+    // Result: device −Z (out the back) points East.  Equivalently, +Z
+    // points West.
+    const q = quatFor(270, 90, 0)
+    const back = new Vector3(0, 0, -1).applyQuaternion(q)
+    expect(back.x).toBeCloseTo(1, 6)
+    expect(back.y).toBeCloseTo(0, 6)
+    expect(back.z).toBeCloseTo(0, 6)
+  })
+})

--- a/js/ar/DeviceOrientationPoseSource.test.js
+++ b/js/ar/DeviceOrientationPoseSource.test.js
@@ -1,6 +1,10 @@
 import {describe, expect, it} from 'bun:test'
 import {Euler, Quaternion, Vector3} from 'three'
-import {composeDeviceToEnu} from './DeviceOrientationPoseSource.js'
+import DeviceOrientationPoseSource, {
+  DEFAULT_ALPHA_DAMPING,
+  composeDeviceToEnu,
+  getAlphaDampingNames,
+} from './DeviceOrientationPoseSource.js'
 
 
 /**
@@ -133,5 +137,44 @@ describe('composeDeviceToEnu — anchor poses', () => {
     expect(back.x).toBeCloseTo(1, 6)
     expect(back.y).toBeCloseTo(0, 6)
     expect(back.z).toBeCloseTo(0, 6)
+  })
+})
+
+
+describe('DeviceOrientationPoseSource — alpha damping presets', () => {
+  it('exposes valid preset names and a default that is one of them', () => {
+    const names = getAlphaDampingNames()
+    expect(names.length).toBeGreaterThanOrEqual(3)
+    expect(names).toContain(DEFAULT_ALPHA_DAMPING)
+  })
+
+  it('defaults to DEFAULT_ALPHA_DAMPING after construction', () => {
+    const ps = new DeviceOrientationPoseSource()
+    expect(ps.getAlphaDamping()).toBe(DEFAULT_ALPHA_DAMPING)
+  })
+
+  it('setAlphaDamping switches preset and rebuilds the alpha pipeline', () => {
+    const ps = new DeviceOrientationPoseSource()
+    const beforeFilter = ps._alphaFilter
+    const next = getAlphaDampingNames().find((n) => n !== ps.getAlphaDamping())
+    ps.setAlphaDamping(next)
+    expect(ps.getAlphaDamping()).toBe(next)
+    expect(ps._alphaFilter).not.toBe(beforeFilter)
+  })
+
+  it('setAlphaDamping with the same name is a no-op (preserves filter state)', () => {
+    const ps = new DeviceOrientationPoseSource()
+    const beforeFilter = ps._alphaFilter
+    ps.setAlphaDamping(ps.getAlphaDamping())
+    expect(ps._alphaFilter).toBe(beforeFilter)
+  })
+
+  it('setAlphaDamping with an unknown name leaves the preset unchanged', () => {
+    const ps = new DeviceOrientationPoseSource()
+    const before = ps.getAlphaDamping()
+    const beforeFilter = ps._alphaFilter
+    ps.setAlphaDamping('not-a-real-preset')
+    expect(ps.getAlphaDamping()).toBe(before)
+    expect(ps._alphaFilter).toBe(beforeFilter)
   })
 })

--- a/js/ar/NullPoseSource.js
+++ b/js/ar/NullPoseSource.js
@@ -1,0 +1,51 @@
+import {Quaternion} from 'three'
+
+
+/**
+ * Stand-in PoseSource for desktops / browsers without sensor APIs.
+ *
+ * Reports an identity orientation forever — the user can still see what
+ * the AR view would show (camera platform pinned to the rotating body,
+ * looking straight up) without device sensors.  Useful for development
+ * and as a graceful fallback when permissions are denied.
+ */
+export default class NullPoseSource {
+  constructor() {
+    this.kind = 'null'
+    this.needsCalibration = false
+    this._q = new Quaternion()
+  }
+
+
+  /** @returns {Promise<void>} */
+  async start() {
+    // Nothing to attach.
+  }
+
+
+  /** */
+  stop() {
+    // Nothing to detach.
+  }
+
+
+  /**
+   * Always returns identity (camera-frame ≡ ENU-frame).  In practice that
+   * means the user is looking straight up (camera +Z = ENU Up) the whole
+   * time — exactly what a "no sensors, just show me the sky overhead"
+   * fallback should produce.
+   *
+   * @param {Quaternion} out
+   * @returns {boolean} always true (we're always "fresh", just static)
+   */
+  getQuaternion(out) {
+    out.copy(this._q)
+    return true
+  }
+
+
+  /** @returns {{fresh: boolean, source: string}} */
+  getStatus() {
+    return {fresh: true, source: this.kind}
+  }
+}

--- a/js/ar/OneEuroFilter.js
+++ b/js/ar/OneEuroFilter.js
@@ -1,0 +1,163 @@
+/**
+ * 1€ filter — Casiez, Roussel & Vogel (2012),
+ * https://gery.casiez.net/1euro/
+ *
+ * A first-order low-pass on the signal whose cutoff frequency adapts to
+ * the smoothed magnitude of the signal's first derivative.  The effect
+ * is exactly what hand-held AR tracking needs:
+ *
+ *   - At rest (low |dx/dt|), cutoff drops to `minCutoff` → strong
+ *     smoothing kills the few-degree micro-jitter from hand tremor and
+ *     magnetometer/accelerometer noise.
+ *   - During genuine motion (high |dx/dt|), cutoff scales up by `beta`
+ *     × |dx/dt| → filter becomes responsive, lag stays bounded.
+ *
+ * One filter per scalar axis; for orientation data, run three of these
+ * over alpha / beta / gamma independently before composing into the
+ * Three.js quaternion.  Quaternion-domain 1€ filters exist but are
+ * overkill here: at the noise scale we're filtering (~few degrees), the
+ * coupling between the Euler axes is irrelevant.
+ *
+ * Tuning rules of thumb:
+ *   - Increase `minCutoff` if the filter feels laggy at rest.
+ *   - Decrease `minCutoff` if jitter at rest is still visible.
+ *   - Increase `beta` if fast motion feels laggy.
+ *   - Decrease `beta` if fast motion overshoots / wobbles.
+ *
+ * Use `OneEuroFilterLib` (the canonical `1eurofilter` package) for the
+ * authoritative reference implementation; this local class exists so
+ * tests and callers have a dependency-free path with the same surface.
+ */
+export default class OneEuroFilter {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.minCutoff]  Baseline cutoff frequency in Hz; default 1.0.
+   * @param {number} [opts.beta]       Speed-adaptive coefficient; default 0.05.
+   * @param {number} [opts.dCutoff]    Cutoff for the derivative EMA; default 1.0.
+   */
+  constructor({minCutoff = 1.0, beta = 0.05, dCutoff = 1.0} = {}) {
+    this.minCutoff = minCutoff
+    this.beta = beta
+    this.dCutoff = dCutoff
+    this._xPrev = null
+    this._dxPrev = 0
+    this._tPrev = null
+  }
+
+
+  /** Drop all filter state.  Next `filter()` will treat its input as a fresh sample. */
+  reset() {
+    this._xPrev = null
+    this._dxPrev = 0
+    this._tPrev = null
+  }
+
+
+  /**
+   * @param {number} x  New raw sample
+   * @param {number} t  Timestamp in seconds (any monotonically increasing clock)
+   * @returns {number}  Filtered sample
+   */
+  filter(x, t) {
+    if (this._xPrev === null || this._tPrev === null) {
+      this._xPrev = x
+      this._tPrev = t
+      return x
+    }
+    const dt = t - this._tPrev
+    if (!(dt > 0)) {
+      // Duplicate / out-of-order timestamp — skip update, keep last filtered.
+      return this._xPrev
+    }
+    // Derivative, smoothed at fixed cutoff (dCutoff).
+    const dx = (x - this._xPrev) / dt
+    const edx = lerp(this._dxPrev, dx, smoothingAlpha(this.dCutoff, dt))
+    // Adaptive cutoff: faster motion → higher cutoff → less smoothing.
+    const cutoff = this.minCutoff + (this.beta * Math.abs(edx))
+    const xFiltered = lerp(this._xPrev, x, smoothingAlpha(cutoff, dt))
+    this._xPrev = xFiltered
+    this._dxPrev = edx
+    this._tPrev = t
+    return xFiltered
+  }
+}
+
+
+/**
+ * Convert a low-pass cutoff frequency + time-step to the EMA blend factor
+ * α used in `lerp(prev, curr, α)`.  Derived from the analog single-pole
+ * RC low-pass: τ = 1/(2πfₒ); α = 1/(1 + τ/Δt).
+ *
+ * @param {number} cutoffHz
+ * @param {number} dtSec
+ * @returns {number} α in (0, 1]
+ */
+export function smoothingAlpha(cutoffHz, dtSec) {
+  const tau = 1.0 / (2.0 * Math.PI * cutoffHz)
+  return 1.0 / (1.0 + (tau / dtSec))
+}
+
+
+/**
+ * @param {number} a
+ * @param {number} b
+ * @param {number} t
+ * @returns {number} a + (b - a) * t
+ */
+function lerp(a, b, t) {
+  return a + ((b - a) * t)
+}
+
+
+/**
+ * Adapter for circular angle signals (e.g. DeviceOrientation alpha,
+ * which is in [0, 360) and wraps).  Maintains an unwrapped running
+ * total so the underlying `OneEuroFilter` sees a continuous signal —
+ * a 359° → 1° wrap reads as +2°, not −358°.
+ *
+ * Pass the result to `composeDeviceToEnu` (or anywhere that treats
+ * Euler angles as continuous radians); no need to re-wrap.
+ */
+export class AngleOneEuroFilter {
+  /** @param {object} [opts]  Same shape as `OneEuroFilter`'s options */
+  constructor(opts) {
+    this._inner = new OneEuroFilter(opts)
+    this._lastRaw = null
+    this._unwrapped = 0
+  }
+
+
+  /** Drop all filter state. */
+  reset() {
+    this._inner.reset()
+    this._lastRaw = null
+    this._unwrapped = 0
+  }
+
+
+  /**
+   * @param {number} rawDeg  Raw circular angle, degrees, any range
+   * @param {number} t       Timestamp in seconds
+   * @returns {number}       Filtered angle, degrees (unwrapped — may be outside [0, 360))
+   */
+  filter(rawDeg, t) {
+    if (this._lastRaw === null) {
+      this._lastRaw = rawDeg
+      this._unwrapped = rawDeg
+      return this._inner.filter(rawDeg, t)
+    }
+    let delta = rawDeg - this._lastRaw
+    if (delta > HALF_TURN) {
+      delta -= FULL_TURN
+    } else if (delta < -HALF_TURN) {
+      delta += FULL_TURN
+    }
+    this._unwrapped += delta
+    this._lastRaw = rawDeg
+    return this._inner.filter(this._unwrapped, t)
+  }
+}
+
+
+const HALF_TURN = 180
+const FULL_TURN = 360

--- a/js/ar/OneEuroFilter.test.js
+++ b/js/ar/OneEuroFilter.test.js
@@ -1,0 +1,107 @@
+import {describe, expect, it} from 'bun:test'
+import OneEuroFilter, {AngleOneEuroFilter, smoothingAlpha} from './OneEuroFilter.js'
+
+
+describe('smoothingAlpha', () => {
+  it('returns α in (0, 1) for typical inputs', () => {
+    expect(smoothingAlpha(1.0, 1 / 60)).toBeGreaterThan(0)
+    expect(smoothingAlpha(1.0, 1 / 60)).toBeLessThan(1)
+  })
+
+  it('grows monotonically with cutoff at fixed dt', () => {
+    const dt = 1 / 60
+    expect(smoothingAlpha(0.5, dt)).toBeLessThan(smoothingAlpha(2.0, dt))
+    expect(smoothingAlpha(2.0, dt)).toBeLessThan(smoothingAlpha(10.0, dt))
+  })
+
+  it('grows monotonically with dt at fixed cutoff', () => {
+    const c = 1.0
+    expect(smoothingAlpha(c, 1 / 240)).toBeLessThan(smoothingAlpha(c, 1 / 60))
+    expect(smoothingAlpha(c, 1 / 60)).toBeLessThan(smoothingAlpha(c, 1 / 10))
+  })
+})
+
+
+describe('OneEuroFilter — basic behaviour', () => {
+  it('first sample passes through unchanged', () => {
+    const f = new OneEuroFilter()
+    expect(f.filter(7.0, 0)).toBe(7.0)
+  })
+
+  it('non-monotonic timestamp is a no-op (returns last filtered)', () => {
+    const f = new OneEuroFilter()
+    f.filter(1.0, 0)
+    const a = f.filter(2.0, 0.1)
+    const b = f.filter(99.0, 0.05) // earlier than tPrev
+    expect(b).toBe(a)
+  })
+
+  it('smooths a constant-with-jitter signal toward the mean', () => {
+    // Stationary 10 ± 1 jitter at 60 Hz, minCutoff 0.5 Hz, beta low.
+    const f = new OneEuroFilter({minCutoff: 0.5, beta: 0.0})
+    const dt = 1 / 60
+    let t = 0
+    let last = 0
+    // Warm up — first sample is identity, so iterate plenty.
+    for (let i = 0; i < 200; i++) {
+      const x = 10 + ((i % 2) ? 1 : -1) // ±1 square jitter
+      last = f.filter(x, t)
+      t += dt
+    }
+    // After convergence the filter should be very close to the mean (10).
+    expect(Math.abs(last - 10)).toBeLessThan(0.2)
+  })
+
+  it('tracks a fast ramp without lagging far behind', () => {
+    // Linear ramp: x = 10·t, sampled at 60 Hz.  With beta > 0 the
+    // adaptive cutoff opens up and the filter follows.
+    const f = new OneEuroFilter({minCutoff: 1.0, beta: 0.5})
+    const dt = 1 / 60
+    let t = 0
+    let filtered = 0
+    let truth = 0
+    for (let i = 0; i < 60; i++) {
+      truth = 10 * t
+      filtered = f.filter(truth, t)
+      t += dt
+    }
+    // After 1 s of ramp, filtered should be within ~1 unit of truth (10).
+    expect(Math.abs(filtered - truth)).toBeLessThan(1.0)
+  })
+
+  it('reset() restores fresh-sample behaviour', () => {
+    const f = new OneEuroFilter()
+    f.filter(5.0, 0)
+    f.filter(5.0, 0.1)
+    f.reset()
+    expect(f.filter(99.0, 0.2)).toBe(99.0)
+  })
+})
+
+
+describe('AngleOneEuroFilter — circular handling', () => {
+  it('passes a 359° → 1° wrap as a small positive delta, not −358°', () => {
+    // Constant near-360 with a tiny wrap-crossing.  After warm-up the
+    // unwrapped sequence should be ~ 359, 360, 361, 362, ... so the
+    // filter sees a smooth positive ramp, not a giant negative jump.
+    const f = new AngleOneEuroFilter({minCutoff: 1.0, beta: 0.0})
+    const dt = 1 / 60
+    let t = 0
+    f.filter(359, t); t += dt
+    f.filter(0, t); t += dt
+    const out = f.filter(1, t)
+    // Filter is heavily smoothed (beta=0, low cutoff) — it'll lag behind
+    // the unwrapped sequence (359, 360, 361), but it should be at least
+    // > 359 and well above the un-unwrapped naive value of ~0.
+    expect(out).toBeGreaterThan(358)
+    expect(out).toBeLessThan(362)
+  })
+
+  it('reset() clears wrap state', () => {
+    const f = new AngleOneEuroFilter()
+    f.filter(180, 0)
+    f.filter(190, 0.1)
+    f.reset()
+    expect(f.filter(45, 0.2)).toBe(45)
+  })
+})

--- a/js/ar/OneEuroFilterLib.js
+++ b/js/ar/OneEuroFilterLib.js
@@ -1,0 +1,103 @@
+/**
+ * Drop-in replacement for `./OneEuroFilter.js` that uses Casiez's
+ * canonical `1eurofilter` package for the underlying 1€ math.  The
+ * base filter is the reference implementation by the algorithm's
+ * author (Géry Casiez & Alix Goguey, BSD-3-Clause); using it here
+ * means our deployed AR pipeline rides on top of canonical code that
+ * gets upstream maintenance / fixes.
+ *
+ * The constructor signature, `filter(x, t)`, and `reset()` are
+ * identical to the local impl so callers can swap imports without
+ * touching anything else.  The thin wrapping is required only because
+ * the lib uses positional constructor args (freq, mincutoff, beta,
+ * dcutoff) while we prefer a named-options bag.
+ */
+import {OneEuroFilter as LibOneEuroFilter} from '1eurofilter'
+
+
+/**
+ * Default sampling-frequency seed for the lib (overridden by the
+ * lib's own timestamp-driven adaptation on the second sample).
+ */
+const DEFAULT_SEED_FREQ_HZ = 60
+
+
+export default class OneEuroFilter {
+  /**
+   * @param {object} [opts]            See `./OneEuroFilter.js` for full docs.
+   * @param {number} [opts.minCutoff]
+   * @param {number} [opts.beta]
+   * @param {number} [opts.dCutoff]
+   */
+  constructor({minCutoff = 1.0, beta = 0.05, dCutoff = 1.0} = {}) {
+    this.minCutoff = minCutoff
+    this.beta = beta
+    this.dCutoff = dCutoff
+    this._inner = new LibOneEuroFilter(DEFAULT_SEED_FREQ_HZ, minCutoff, beta, dCutoff)
+  }
+
+
+  /** Drop all filter state. */
+  reset() {
+    this._inner.reset()
+  }
+
+
+  /**
+   * @param {number} x  New raw sample
+   * @param {number} t  Timestamp in seconds
+   * @returns {number}  Filtered sample
+   */
+  filter(x, t) {
+    return this._inner.filter(x, t)
+  }
+}
+
+
+/**
+ * Same wrap-aware adapter as in `./OneEuroFilter.js`, but wrapping the
+ * lib-backed inner filter.
+ */
+export class AngleOneEuroFilter {
+  /** @param {object} [opts]  See `OneEuroFilter` constructor */
+  constructor(opts) {
+    this._inner = new OneEuroFilter(opts)
+    this._lastRaw = null
+    this._unwrapped = 0
+  }
+
+
+  /** Drop all filter state. */
+  reset() {
+    this._inner.reset()
+    this._lastRaw = null
+    this._unwrapped = 0
+  }
+
+
+  /**
+   * @param {number} rawDeg  Raw circular angle (any range)
+   * @param {number} t       Timestamp in seconds
+   * @returns {number}       Filtered angle (degrees, may be unwrapped)
+   */
+  filter(rawDeg, t) {
+    if (this._lastRaw === null) {
+      this._lastRaw = rawDeg
+      this._unwrapped = rawDeg
+      return this._inner.filter(rawDeg, t)
+    }
+    let delta = rawDeg - this._lastRaw
+    if (delta > HALF_TURN) {
+      delta -= FULL_TURN
+    } else if (delta < -HALF_TURN) {
+      delta += FULL_TURN
+    }
+    this._unwrapped += delta
+    this._lastRaw = rawDeg
+    return this._inner.filter(this._unwrapped, t)
+  }
+}
+
+
+const HALF_TURN = 180
+const FULL_TURN = 360

--- a/js/ar/OneEuroFilterLib.test.js
+++ b/js/ar/OneEuroFilterLib.test.js
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'bun:test'
+import OneEuroFilter, {AngleOneEuroFilter} from './OneEuroFilterLib.js'
+
+
+// Smoke tests for the lib-backed OneEuroFilter wrapper — the math itself
+// is owned by the upstream `1eurofilter` package, so we don't re-prove
+// the 1€ algorithm here.  We just verify the wrapper preserves our
+// constructor / filter / reset surface and that the angle-unwrap
+// adapter behaves the same as in `OneEuroFilter.js`, since callers swap
+// between the two via a single import line.
+
+describe('OneEuroFilterLib', () => {
+  it('first sample passes through unchanged', () => {
+    const f = new OneEuroFilter()
+    expect(f.filter(7.0, 0)).toBe(7.0)
+  })
+
+  it('reset() restores fresh-sample behaviour', () => {
+    const f = new OneEuroFilter()
+    f.filter(5.0, 0)
+    f.filter(5.0, 0.1)
+    f.reset()
+    expect(f.filter(99.0, 0.2)).toBe(99.0)
+  })
+})
+
+
+describe('AngleOneEuroFilter (lib-backed) — circular handling', () => {
+  it('passes a 359° → 1° wrap as a small positive delta', () => {
+    const f = new AngleOneEuroFilter({minCutoff: 1.0, beta: 0.0})
+    const dt = 1 / 60
+    let t = 0
+    f.filter(359, t); t += dt
+    f.filter(0, t); t += dt
+    const out = f.filter(1, t)
+    expect(out).toBeGreaterThan(358)
+    expect(out).toBeLessThan(362)
+  })
+})

--- a/js/ar/PoseSource.js
+++ b/js/ar/PoseSource.js
@@ -1,0 +1,55 @@
+/**
+ * Pose-source contract.  Concrete classes (NullPoseSource,
+ * DeviceOrientationPoseSource, WebXRPoseSource) implement this shape.
+ * No formal interface — JS doesn't enforce it — but every method here
+ * must exist on every implementation so ARController can swap them.
+ *
+ * Every pose returned is a Three.js Quaternion that maps **camera-frame**
+ * vectors to **ENU-frame** vectors, where:
+ *   - Camera frame matches the user's screen-up after correction for
+ *     screen.orientation.angle, and looks out the *back* of the phone
+ *     (Three.js camera "forward" = camera −Z).
+ *   - ENU frame = +X East, +Y North, +Z Up at the observer's location.
+ *
+ * The bodyFixed→ENU step (via enuToBodyFixedQuat at observer's lat/lng)
+ * and the inertial→bodyFixed step (via the rotating-body parent) are
+ * applied by ARController, not the source.
+ *
+ * Method shape (per implementation):
+ *   - kind: string, one of 'null' | 'deviceorientation' | 'webxr'
+ *   - needsCalibration: boolean  hint for the AR HUD's calibration gear
+ *   - start(): Promise<void>     request permissions, attach listeners
+ *   - stop(): void               detach listeners; safe when not started
+ *   - getQuaternion(out): boolean  write camera→ENU into a pre-alloced
+ *                                  Three.js Quaternion; false until ready
+ *   - getStatus(): {fresh: boolean, source: string}  UX hint
+ */
+
+
+/**
+ * Probe available sensor APIs and return the best PoseSource for this device.
+ * Order of preference:
+ *   1. WebXR immersive-ar with viewer reference space (Stage 1b — not yet wired)
+ *   2. DeviceOrientationEvent (covers iOS Safari + most Android)
+ *   3. Null fallback (desktop / no sensors)
+ *
+ * The factory is intentionally async so future WebXR probes
+ * (`navigator.xr.isSessionSupported`) can run without blocking module load.
+ *
+ * @returns {Promise<object>} a PoseSource (see top-of-file contract)
+ */
+export async function createPoseSource() {
+  // Stage 1b will probe navigator.xr here.  Stage 1a uses the
+  // DeviceOrientation path on every mobile device, which is the floor we
+  // need anyway because iOS Safari has no WebXR.
+  const {default: WebXRPoseSource} = await import('./WebXRPoseSource.js')
+  if (await WebXRPoseSource.isSupported()) {
+    return new WebXRPoseSource()
+  }
+  if (typeof window !== 'undefined' && 'DeviceOrientationEvent' in window) {
+    const {default: DeviceOrientationPoseSource} = await import('./DeviceOrientationPoseSource.js')
+    return new DeviceOrientationPoseSource()
+  }
+  const {default: NullPoseSource} = await import('./NullPoseSource.js')
+  return new NullPoseSource()
+}

--- a/js/ar/WebXRPoseSource.js
+++ b/js/ar/WebXRPoseSource.js
@@ -1,0 +1,76 @@
+import {Quaternion} from 'three'
+
+
+/**
+ * WebXR-backed PoseSource.
+ *
+ * The high-level idea: request an `'immersive-ar'` session with the
+ * `'viewer'` reference space, and on each `XRSession#requestAnimationFrame`
+ * tick read the viewer's pose.  WebXR delivers a fully-fused IMU + visual
+ * pose, drift-corrected and screen-rotation-aware — calibration is
+ * effectively a no-op there.
+ *
+ * The reference frame for `'local'` / `'viewer'` poses is implementation-
+ * defined (NOT geographic ENU).  Reconciling that with our ENU contract
+ * requires either:
+ *   (a) a one-tap calibration to align the WebXR world to ENU, or
+ *   (b) using the GeolocationSensor + WebXR's `'unbounded'` ref space if
+ *       the device exposes them in concert.
+ *
+ * Stage 1a (this commit) ships a stub that always reports unsupported,
+ * so the factory falls through to DeviceOrientationPoseSource — which is
+ * the only path that exists on iOS Safari anyway.  Stage 1b wires the
+ * full session.
+ */
+export default class WebXRPoseSource {
+  constructor() {
+    this.kind = 'webxr'
+    // WebXR delivers a calibrated pose; the reference-frame alignment
+    // step (WebXR-world → ENU) is a one-time per-session tap, not a
+    // persistent magnetometer-bias correction, so we mark this false.
+    this.needsCalibration = false
+    this._q = new Quaternion()
+  }
+
+
+  /**
+   * Async-probes navigator.xr.  Returns false on devices without WebXR
+   * (which is most of the world right now, including all iOS).
+   *
+   * @returns {Promise<boolean>}
+   */
+  static isSupported() {
+    // Stage 1a: short-circuit to false.  Stage 1b replaces this body with
+    // a real navigator.xr.isSessionSupported('immersive-ar') probe and
+    // gates on the 'viewer' or 'local-floor' reference space.  Returns a
+    // Promise so the eventual async probe slots in cleanly.
+    return Promise.resolve(false)
+  }
+
+
+  /** @returns {Promise<void>} */
+  start() {
+    return Promise.reject(new Error('WebXRPoseSource not yet implemented (stage 1b)'))
+  }
+
+
+  /** */
+  stop() {
+    // No-op.
+  }
+
+
+  /**
+   * @param {Quaternion} _out
+   * @returns {boolean}
+   */
+  getQuaternion(_out) {
+    return false
+  }
+
+
+  /** @returns {{fresh: boolean, source: string}} */
+  getStatus() {
+    return {fresh: false, source: this.kind}
+  }
+}

--- a/js/ar/enuFrame.js
+++ b/js/ar/enuFrame.js
@@ -1,0 +1,93 @@
+import {Matrix4, Quaternion, Vector3} from 'three'
+import {toRad} from '../shared.js'
+
+
+// Tiny epsilon for the polar-degeneracy test.  At |cos(lat)| below this we
+// treat ourselves as "at the pole" and pick an arbitrary tangent for North.
+// 1e-9 in cos space ≈ 5.7e-8° latitude — far below any sensor's resolution.
+const POLAR_EPS = 1e-9
+
+
+/**
+ * Build the East-North-Up triad at (lat, lng) in body-fixed coordinates.
+ *
+ * Body-fixed convention (matches js/coords.js):
+ *   +Y = rotational axis (north pole)
+ *   +X = prime meridian (lng = 0)
+ *   East-positive longitude winds toward −Z
+ *
+ * ENU convention (chosen here):
+ *   +X = East, +Y = North, +Z = Up
+ *
+ * At the geographic poles, "North" is undefined — we deterministically pick
+ * the tangent direction that aligns with body-fixed +X projected onto the
+ * local tangent plane, which keeps the math continuous near the pole and
+ * gives a fixed reference for any sky map drawn there.
+ *
+ * @param {number} lat Latitude in degrees, [-90, 90]
+ * @param {number} lng Longitude in degrees, east-positive
+ * @returns {{east: Vector3, north: Vector3, up: Vector3}} unit vectors in body-fixed coords
+ */
+export function enuTriadAtLatLng(lat, lng) {
+  const latRad = lat * toRad
+  const lngRad = lng * toRad
+  const cLat = Math.cos(latRad)
+  const sLat = Math.sin(latRad)
+  const cLng = Math.cos(lngRad)
+  const sLng = Math.sin(lngRad)
+
+  // Up = outward radial direction at (lat, lng).  Matches latLngAltToBodyFixed
+  // for unit altitude — see coords.js.
+  const up = new Vector3(cLat * cLng, sLat, -cLat * sLng)
+
+  let north
+  if (Math.abs(cLat) < POLAR_EPS) {
+    // Polar degeneracy.  Pick a fixed tangent so q is continuous and
+    // well-defined.  +X (prime meridian direction) is in the equatorial
+    // plane, hence tangent to the surface at either pole.  At the north
+    // pole we want "north" to point further along +Y... but we're at +Y,
+    // so north has no meaning.  We use +X here as the canonical fallback
+    // (the prime meridian's direction); flips sign at the south pole so
+    // the triad stays right-handed.
+    north = new Vector3(sLat >= 0 ? -1 : 1, 0, 0)
+  } else {
+    // North = poleAxis projected onto the tangent plane at `up`, normalized.
+    //   N = (Ŷ − (Ŷ · up) up) / |…|
+    // Ŷ · up = sLat.  Substituting:
+    //   N = (-sLat·cLat·cLng, 1 − sLat², sLat·cLat·sLng) / cLat
+    //     = (-sLat·cLng, cLat, sLat·sLng)
+    north = new Vector3(-sLat * cLng, cLat, sLat * sLng)
+  }
+
+  // East = North × Up (right-handed: E × N = U → N × U = E).
+  const east = new Vector3().crossVectors(north, up)
+  return {east, north, up}
+}
+
+
+/**
+ * Quaternion mapping ENU vectors at (lat, lng) into body-fixed coordinates.
+ *
+ * Composition rule: bodyFixedVec = q · enuVec.
+ *
+ * Together with the camera platform being parented to the *rotating* body
+ * (see Scene.land), this completes the chain
+ *
+ *   device → ENU → body-fixed → inertial scene
+ *
+ * with the body-fixed → inertial step inherited automatically from the
+ * scene graph (sidereal rotation lives on the body Object3D).
+ *
+ * @param {number} lat Latitude in degrees
+ * @param {number} lng Longitude in degrees, east-positive
+ * @returns {Quaternion}
+ */
+export function enuToBodyFixedQuat(lat, lng) {
+  const {east, north, up} = enuTriadAtLatLng(lat, lng)
+  // Build the rotation matrix whose columns are E, N, U.  Vectors in ENU
+  // (e.g. (1,0,0) for "1 m east") right-multiply this matrix to land in
+  // body-fixed coords.  Three.js Matrix4.makeBasis takes the three column
+  // vectors directly, in xAxis/yAxis/zAxis order.
+  const m = new Matrix4().makeBasis(east, north, up)
+  return new Quaternion().setFromRotationMatrix(m)
+}

--- a/js/ar/enuFrame.test.js
+++ b/js/ar/enuFrame.test.js
@@ -1,0 +1,183 @@
+import {describe, expect, it} from 'bun:test'
+import {Vector3} from 'three'
+import {enuToBodyFixedQuat, enuTriadAtLatLng} from './enuFrame.js'
+
+
+// Body-fixed convention (from coords.js):
+//   +Y = north pole, +X = prime meridian, east winds toward −Z.
+// ENU convention (from enuFrame.js):
+//   +X = East, +Y = North, +Z = Up.
+
+
+describe('enuTriadAtLatLng — geometric properties', () => {
+  it('produces an orthonormal right-handed triad at non-polar lat/lng', () => {
+    // Pick a deliberately off-axis observer; orthogonality + normality must
+    // hold regardless.  San Francisco-ish.
+    const {east, north, up} = enuTriadAtLatLng(37.77, -122.42)
+    expect(east.length()).toBeCloseTo(1, 9)
+    expect(north.length()).toBeCloseTo(1, 9)
+    expect(up.length()).toBeCloseTo(1, 9)
+    expect(east.dot(north)).toBeCloseTo(0, 9)
+    expect(east.dot(up)).toBeCloseTo(0, 9)
+    expect(north.dot(up)).toBeCloseTo(0, 9)
+    // Right-handed: E × N = U.
+    const cross = new Vector3().crossVectors(east, north)
+    expect(cross.x).toBeCloseTo(up.x, 9)
+    expect(cross.y).toBeCloseTo(up.y, 9)
+    expect(cross.z).toBeCloseTo(up.z, 9)
+  })
+
+
+  it('at (0°, 0°) Up is +X (prime meridian outward)', () => {
+    const {up} = enuTriadAtLatLng(0, 0)
+    expect(up.x).toBeCloseTo(1, 9)
+    expect(up.y).toBeCloseTo(0, 9)
+    expect(up.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('at (0°, 0°) North is +Y (toward the celestial pole)', () => {
+    // On the equator, "north" is exactly the rotational axis direction.
+    const {north} = enuTriadAtLatLng(0, 0)
+    expect(north.x).toBeCloseTo(0, 9)
+    expect(north.y).toBeCloseTo(1, 9)
+    expect(north.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('at (0°, 0°) East is −Z (east winds toward −Z)', () => {
+    // Direction-of-east lock-in — matches the prime-meridian / east-positive
+    // convention enshrined in coords.js.
+    const {east} = enuTriadAtLatLng(0, 0)
+    expect(east.x).toBeCloseTo(0, 9)
+    expect(east.y).toBeCloseTo(0, 9)
+    expect(east.z).toBeCloseTo(-1, 9)
+  })
+
+
+  it('at (0°, 90°E) Up is −Z (90° east of prime meridian)', () => {
+    const {up} = enuTriadAtLatLng(0, 90)
+    expect(up.x).toBeCloseTo(0, 9)
+    expect(up.y).toBeCloseTo(0, 9)
+    expect(up.z).toBeCloseTo(-1, 9)
+  })
+
+
+  it('at (0°, 90°E) East is −X (still east, now in the −X direction)', () => {
+    // From (0, 90°E), continuing east takes you to (0, 180°), which is
+    // body-fixed −X.
+    const {east} = enuTriadAtLatLng(0, 90)
+    expect(east.x).toBeCloseTo(-1, 9)
+    expect(east.y).toBeCloseTo(0, 9)
+    expect(east.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('at (45°N, 0°) Up is the bisector of +X and +Y', () => {
+    const {up} = enuTriadAtLatLng(45, 0)
+    expect(up.x).toBeCloseTo(Math.SQRT1_2, 9)
+    expect(up.y).toBeCloseTo(Math.SQRT1_2, 9)
+    expect(up.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('at (45°N, 0°) North tilts toward the pole', () => {
+    // North on the (lat, lng) = (45, 0) tangent plane is the unit vector
+    // perpendicular to Up that points more toward +Y than -Y.  Closed form:
+    // (-sin lat · cos lng, cos lat, sin lat · sin lng) = (-√2/2, √2/2, 0).
+    const {north} = enuTriadAtLatLng(45, 0)
+    expect(north.x).toBeCloseTo(-Math.SQRT1_2, 9)
+    expect(north.y).toBeCloseTo(Math.SQRT1_2, 9)
+    expect(north.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('handles the north pole gracefully (no NaN)', () => {
+    const {east, north, up} = enuTriadAtLatLng(90, 0)
+    expect(up.y).toBeCloseTo(1, 9)
+    expect(Number.isFinite(north.x) && Number.isFinite(north.y) && Number.isFinite(north.z)).toBe(true)
+    expect(Number.isFinite(east.x) && Number.isFinite(east.y) && Number.isFinite(east.z)).toBe(true)
+    expect(north.length()).toBeCloseTo(1, 9)
+    expect(east.length()).toBeCloseTo(1, 9)
+    // Triad is still orthonormal at the pole.
+    expect(east.dot(north)).toBeCloseTo(0, 9)
+    expect(east.dot(up)).toBeCloseTo(0, 9)
+    expect(north.dot(up)).toBeCloseTo(0, 9)
+  })
+
+
+  it('handles the south pole gracefully (no NaN, right-handed)', () => {
+    const {east, north, up} = enuTriadAtLatLng(-90, 0)
+    expect(up.y).toBeCloseTo(-1, 9)
+    const cross = new Vector3().crossVectors(east, north)
+    expect(cross.x).toBeCloseTo(up.x, 9)
+    expect(cross.y).toBeCloseTo(up.y, 9)
+    expect(cross.z).toBeCloseTo(up.z, 9)
+  })
+})
+
+
+describe('enuToBodyFixedQuat', () => {
+  it('maps ENU "Up" to the body-fixed outward radial', () => {
+    // Spot check at a non-degenerate location.
+    const lat = 30
+    const lng = -60
+    const q = enuToBodyFixedQuat(lat, lng)
+    const upBody = new Vector3(0, 0, 1).applyQuaternion(q)
+    const {up} = enuTriadAtLatLng(lat, lng)
+    expect(upBody.x).toBeCloseTo(up.x, 9)
+    expect(upBody.y).toBeCloseTo(up.y, 9)
+    expect(upBody.z).toBeCloseTo(up.z, 9)
+  })
+
+
+  it('maps ENU "North" to the body-fixed north tangent', () => {
+    const lat = 30
+    const lng = -60
+    const q = enuToBodyFixedQuat(lat, lng)
+    const nBody = new Vector3(0, 1, 0).applyQuaternion(q)
+    const {north} = enuTriadAtLatLng(lat, lng)
+    expect(nBody.x).toBeCloseTo(north.x, 9)
+    expect(nBody.y).toBeCloseTo(north.y, 9)
+    expect(nBody.z).toBeCloseTo(north.z, 9)
+  })
+
+
+  it('maps ENU "East" to the body-fixed east tangent', () => {
+    const lat = 30
+    const lng = -60
+    const q = enuToBodyFixedQuat(lat, lng)
+    const eBody = new Vector3(1, 0, 0).applyQuaternion(q)
+    const {east} = enuTriadAtLatLng(lat, lng)
+    expect(eBody.x).toBeCloseTo(east.x, 9)
+    expect(eBody.y).toBeCloseTo(east.y, 9)
+    expect(eBody.z).toBeCloseTo(east.z, 9)
+  })
+
+
+  it('at (lat=0, lng=0): ENU and body-fixed differ by a known reorientation', () => {
+    // ENU at the prime meridian on the equator:
+    //   East = bodyFixed −Z
+    //   North = bodyFixed +Y
+    //   Up = bodyFixed +X
+    // Therefore q maps  (1,0,0)_ENU → (0,0,-1)_body
+    //                   (0,1,0)_ENU → (0,1,0)_body
+    //                   (0,0,1)_ENU → (1,0,0)_body
+    const q = enuToBodyFixedQuat(0, 0)
+    const e = new Vector3(1, 0, 0).applyQuaternion(q)
+    const n = new Vector3(0, 1, 0).applyQuaternion(q)
+    const u = new Vector3(0, 0, 1).applyQuaternion(q)
+    expect(e.x).toBeCloseTo(0, 9); expect(e.y).toBeCloseTo(0, 9); expect(e.z).toBeCloseTo(-1, 9)
+    expect(n.x).toBeCloseTo(0, 9); expect(n.y).toBeCloseTo(1, 9); expect(n.z).toBeCloseTo(0, 9)
+    expect(u.x).toBeCloseTo(1, 9); expect(u.y).toBeCloseTo(0, 9); expect(u.z).toBeCloseTo(0, 9)
+  })
+
+
+  it('preserves vector lengths (rotation, not scale)', () => {
+    const q = enuToBodyFixedQuat(48.86, 2.35) // Paris-ish
+    const v = new Vector3(3, -7, 2)
+    const lenBefore = v.length()
+    const out = v.clone().applyQuaternion(q)
+    expect(out.length()).toBeCloseTo(lenBefore, 9)
+  })
+})

--- a/js/landableBodyName.test.js
+++ b/js/landableBodyName.test.js
@@ -1,0 +1,40 @@
+import {describe, expect, it} from 'bun:test'
+import {landableBodyName} from './Celestiary.js'
+
+
+// `landableBodyName` is the pure helper backing Celestiary._currentBodyName.
+// It decides whether a scene-graph target is a body the AR entry point
+// should default to landing on.  These tests pin down the exclusion
+// rules so a future refactor can't silently re-introduce the bug
+// where tapping AR with the Sun selected lands the user on the
+// photosphere.
+
+describe('landableBodyName', () => {
+  it('returns null for empty / null target', () => {
+    expect(landableBodyName(null)).toBeNull()
+    expect(landableBodyName(undefined)).toBeNull()
+    expect(landableBodyName({})).toBeNull()
+  })
+
+  it('returns null when props.name is missing', () => {
+    expect(landableBodyName({props: {radius: {scalar: 1e6}}})).toBeNull()
+  })
+
+  it('returns null when props.radius is missing or zero', () => {
+    expect(landableBodyName({props: {name: 'shadow'}})).toBeNull()
+    expect(landableBodyName({props: {name: 'shadow', radius: {scalar: 0}}})).toBeNull()
+  })
+
+  it('returns null for stars (spectralType present)', () => {
+    // Sun: G-type, has a radius and a name, but spectralType excludes it.
+    const sun = {props: {name: 'sun', radius: {scalar: 6.96e8}, spectralType: 4}}
+    expect(landableBodyName(sun)).toBeNull()
+  })
+
+  it('returns the name for planets / moons', () => {
+    const earth = {props: {name: 'earth', radius: {scalar: 6.371e6}}}
+    expect(landableBodyName(earth)).toBe('earth')
+    const moon = {props: {name: 'moon', radius: {scalar: 1.737e6}}}
+    expect(landableBodyName(moon)).toBe('moon')
+  })
+})

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -24,6 +24,15 @@ const METER_PREFIXES = [
 // Celestiary calls scene.land(lat, lng, alt) to restore the pinned-surface
 // view rather than the orbit-style camera quaternion.  Backward compatible:
 // pre-L permalinks decode landed=false.
+//
+// `A` is the AR-fallback flag.  When present on decode, Celestiary
+// best-effort enters AR mode at the saved lat/lng/alt — sensors then
+// overwrite camera orientation each frame, so the saved `cq` quaternion
+// is not authoritative on AR-flagged permalinks.  When AR is unsupported
+// (desktop, denied permissions), the permalink falls through to the
+// regular landed-with-saved-orientation restore.  Encoding rule
+// (encodePermalink): set A=1 whenever AR is active at capture time;
+// position fields are still written so non-AR viewers see something.
 export const SETTINGS_DEFAULTS = Object.freeze({
   a: true, // asterisms (constellation lines)
   l: true, // star labels
@@ -34,6 +43,7 @@ export const SETTINGS_DEFAULTS = Object.freeze({
   g: false, // galactic reference grid
   v: true, // nav panels / heads-up display
   L: false, // landed at surface — see Scene.land
+  A: false, // AR-fallback — enter AR sky view if device supports
 })
 
 

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -41,6 +41,7 @@ export const SETTINGS_DEFAULTS = Object.freeze({
   e: false, // equatorial reference grid
   c: false, // ecliptic reference grid
   g: false, // galactic reference grid
+  U: true, // procedural Milky Way galaxy (Celestia convention: 'U')
   v: true, // nav panels / heads-up display
   L: false, // landed at surface — see Scene.land
   A: false, // AR-fallback — enter AR sky view if device supports

--- a/js/permalink.test.js
+++ b/js/permalink.test.js
@@ -303,3 +303,50 @@ describe('L (landed) flag', () => {
     expect(decoded.settings).toEqual(combo)
   })
 })
+
+
+describe('A (AR-fallback) flag', () => {
+  const defaults = {...SETTINGS_DEFAULTS}
+  const baseArgs = ['sun/earth', 0, 37.77, -122.42, 2,
+    {x: 0, y: 0, z: 0, w: 1}, 45]
+
+  it('default is false', () => {
+    expect(SETTINGS_DEFAULTS.A).toBe(false)
+  })
+
+  it('emits ;s=A when AR-fallback is true', () => {
+    const encoded = encodePermalink(...baseArgs, {...defaults, A: true})
+    expect(encoded).toMatch(/;s=A/)
+  })
+
+  it('omits A from s= when AR-fallback is false (default)', () => {
+    const encoded = encodePermalink(...baseArgs, defaults)
+    expect(encoded).not.toContain(';s=A')
+  })
+
+  it('round-trips A=true', () => {
+    const encoded = encodePermalink(...baseArgs, {...defaults, A: true})
+    const decoded = decodePermalink(encoded)
+    expect(decoded.settings.A).toBe(true)
+  })
+
+  it('legacy permalinks without A decode A=false (back-compat)', () => {
+    // Pre-A URL: only the L flag flipped, A absent → A must default false.
+    const onlyL = encodePermalink(...baseArgs, {...defaults, L: true})
+    expect(decodePermalink(onlyL).settings.A).toBe(false)
+    // No s= at all.
+    const noFlags = encodePermalink(...baseArgs)
+    expect(decodePermalink(noFlags).settings.A).toBe(false)
+  })
+
+  it('coexists with the L (landed) flag — typical AR permalink', () => {
+    // The expected shape for a permalink captured while in AR mode:
+    //   landed at the surface (L=1) AND AR-fallback set (A=1).
+    const combo = {...defaults, L: true, A: true}
+    const encoded = encodePermalink(...baseArgs, combo)
+    expect(encoded).toMatch(/;s=[LA]+/)
+    const decoded = decodePermalink(encoded)
+    expect(decoded.settings.L).toBe(true)
+    expect(decoded.settings.A).toBe(true)
+  })
+})

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -138,9 +138,25 @@ export default class Scene {
   }
 
 
-  /** @returns {object} flat {key: bool} map matching permalink SETTINGS_DEFAULTS */
+  /**
+   * Flat {key: bool} map matching permalink SETTINGS_DEFAULTS.
+   *
+   * Two special-case keys are merged in here rather than tracked in
+   * `_settings`:
+   *
+   *   - `L` (landed) — sourced from `Shared.targets.landed` so any code
+   *     path that pins or unpins the surface mode (Scene.land, Scene.goTo)
+   *     drives this without going through a Scene toggle.
+   *   - `A` (AR-fallback) — defaults false here; the permalink writer in
+   *     Celestiary._schedulePermalinkUpdate overwrites it with the live
+   *     ARController.isActive() value before encoding.  The default-false
+   *     here ensures every key in SETTINGS_DEFAULTS has a slot, satisfying
+   *     the round-trip contract for code that snapshots getSettings().
+   *
+   * @returns {object}
+   */
   getSettings() {
-    return {...this._settings, L: Shared.targets.landed}
+    return {...this._settings, L: Shared.targets.landed, A: false}
   }
 
 
@@ -605,6 +621,60 @@ export default class Scene {
     const setter = state?.setCommittedPath
     if (typeof setter === 'function') {
       setter(this._pathFor(bodyName))
+    }
+  }
+
+
+  /**
+   * Enter AR mode: apply the AR scene-visibility preset and disable the
+   * atmosphere post-pass.  Returns a snapshot of the prior state so
+   * `exitAR(snapshot)` can restore it.
+   *
+   * Preset (Stage 1, no camera passthrough yet):
+   *   - asterisms ON, star labels ON, planet labels ON
+   *   - orbits OFF, all reference grids OFF
+   *   - atmosphere OFF (otherwise daytime sky paints over the stars; in
+   *     Stage 2 the atmosphere will return with premultiplied-alpha blend
+   *     so it tints the camera passthrough instead of opaque-painting it)
+   *
+   * Planet meshes are left visible — they form a virtual "ground" beneath
+   * the observer when landed at altitude ~2 m, which is exactly the
+   * spatial reference users want.
+   *
+   * @returns {object} snapshot for exitAR()
+   */
+  enterAR() {
+    const snapshot = {
+      settings: {...this._settings},
+      uiArMode: this.ui._arMode,
+    }
+    // Atmosphere off — checked by ThreeUI._updateAtmUniforms each frame.
+    this.ui._arMode = true
+    this.applySettings({
+      a: true, // asterisms
+      l: true, // star labels
+      p: true, // planet labels
+      o: false, // orbits
+      e: false, // equatorial grid
+      c: false, // ecliptic grid
+      g: false, // galactic grid
+    })
+    return snapshot
+  }
+
+
+  /**
+   * Restore the scene state captured by `enterAR()`.
+   *
+   * @param {object} snapshot Return value of enterAR()
+   */
+  exitAR(snapshot) {
+    if (!snapshot) {
+      return
+    }
+    this.ui._arMode = snapshot.uiArMode || false
+    if (snapshot.settings) {
+      this.applySettings(snapshot.settings)
     }
   }
 

--- a/js/scene/Scene.js
+++ b/js/scene/Scene.js
@@ -92,6 +92,7 @@ export default class Scene {
       e: false, // equatorial grid
       c: false, // ecliptic grid
       g: false, // galactic grid
+      U: true, // Milky Way galaxy
       v: true, // nav panels / heads-up display (Celestiary-owned, see registerSettingApplier)
     }
     // Custom appliers for settings keys that the Scene doesn't own directly
@@ -189,6 +190,7 @@ export default class Scene {
       e: () => this.toggleGridEquatorial(),
       c: () => this.toggleGridEcliptic(),
       g: () => this.toggleGridGalactic(),
+      U: () => this.toggleGalaxy(),
       ...this._customAppliers,
     }
     for (const key of Object.keys(dispatch)) {
@@ -647,9 +649,61 @@ export default class Scene {
     const snapshot = {
       settings: {...this._settings},
       uiArMode: this.ui._arMode,
+      hiddenInAR: [],
     }
     // Atmosphere off — checked by ThreeUI._updateAtmUniforms each frame.
     this.ui._arMode = true
+    // Hide busy/over-bright meshes for Stage 1 (sky-only view).  Three
+    // distinct rendering issues otherwise paint over the starfield:
+    //   1. `'planet surface and guides'` — at surface altitude 2 m, the
+    //      camera near plane (`dynamicNear` clamps to ≥ 100 m) depth-clips
+    //      the close ground, leaving only the distant lit limb visible.
+    //      The PointLight sunlight (3.7e28 lm) + tone-mapping exposure
+    //      (3e-16, tuned for from-space viewing) clips that limb to white.
+    //   2. `'atmosphere'` — the additive `BackSide` halo shells from
+    //      `newAtmosphere()` on bodies without a physical atmosphere,
+    //      which flash orange/white when the camera aims at them.
+    //   3. `'MilkyWay'` — the procedural galaxy is intentionally noisy
+    //      (additive yellow-orange bulge particles, sparse bright
+    //      cluster stand-ins).  At AR sensor jitter scale, those bright
+    //      particles pop in and out of the field as flicker.  The real
+    //      catalog stars + asterisms remain visible.
+    // Stage 2 (camera passthrough + premultiplied-alpha atmosphere) will
+    // reintroduce ground visuals.  Restored in `exitAR()`.
+    snapshot.frozenLabelLODs = []
+    this.ui.scene.traverse((obj) => {
+      if (obj.visible &&
+          (obj.name === 'planet surface and guides' ||
+           obj.name === 'atmosphere' ||
+           obj.name === 'MilkyWay')) {
+        snapshot.hiddenInAR.push(obj)
+        obj.visible = false
+      }
+      // Force-enable each `'label LOD'` so togglePlanetLabels actually
+      // does something at surface altitude.  These LODs are tuned for
+      // from-space viewing — `labelTooNearDist ≈ surfaceR * 30` (191k km
+      // for Earth) — so at a 2 m altitude the camera distance is well
+      // *inside* the near threshold, and the LOD selects the FAR_OBJ
+      // placeholder (an empty Object3D).  Toggling labelLOD.visible has
+      // no visible effect because the selected child renders nothing.
+      // Disable autoUpdate and pin the labelSheet level visible; restore
+      // both on exit so from-space LOD behaviour returns intact.
+      if (obj.isLOD && obj.name === 'label LOD') {
+        const childStates = obj.levels.map((lv) => ({
+          object: lv.object,
+          visible: lv.object.visible,
+        }))
+        snapshot.frozenLabelLODs.push({
+          lod: obj,
+          autoUpdate: obj.autoUpdate,
+          childStates,
+        })
+        obj.autoUpdate = false
+        for (const lv of obj.levels) {
+          lv.object.visible = lv.object.name !== 'LODFarObj'
+        }
+      }
+    })
     this.applySettings({
       a: true, // asterisms
       l: true, // star labels
@@ -673,6 +727,19 @@ export default class Scene {
       return
     }
     this.ui._arMode = snapshot.uiArMode || false
+    if (Array.isArray(snapshot.hiddenInAR)) {
+      for (const obj of snapshot.hiddenInAR) {
+        obj.visible = true
+      }
+    }
+    if (Array.isArray(snapshot.frozenLabelLODs)) {
+      for (const entry of snapshot.frozenLabelLODs) {
+        entry.lod.autoUpdate = entry.autoUpdate
+        for (const cs of entry.childStates) {
+          cs.object.visible = cs.visible
+        }
+      }
+    }
     if (snapshot.settings) {
       this.applySettings(snapshot.settings)
     }
@@ -837,6 +904,27 @@ export default class Scene {
     if (this.grids) {
       this.grids.galactic.visible = !this.grids.galactic.visible
       this._flipSetting('g')
+    }
+  }
+
+
+  /**
+   * Toggle the procedural Milky Way background.  Found by name traversal
+   * since the Points mesh is created inside `newGalaxy()` and not pinned
+   * to a Scene field.  Default-hidden by `enterAR()` (the additive bulge
+   * particles flicker badly at AR sensor jitter scale); the user can flip
+   * this back on with the 'U' shortcut once in AR.
+   */
+  toggleGalaxy() {
+    let target = null
+    this.ui.scene.traverse((obj) => {
+      if (obj.name === 'MilkyWay') {
+        target = obj
+      }
+    })
+    if (target) {
+      target.visible = !target.visible
+      this._flipSetting('U')
     }
   }
 

--- a/js/scene/Scene.test.js
+++ b/js/scene/Scene.test.js
@@ -292,7 +292,10 @@ describe('Scene.applySettings', () => {
     s.applySettings(target)
     // L isn't in `target` but is added to getSettings by reading
     // Shared.targets.landed; pin it to the default (false) for this test.
-    expect(s.getSettings()).toEqual({...target, L: false})
+    // A is also merged in by getSettings (default false for this Scene-
+    // level snapshot — the live AR state is folded in at the permalink
+    // writer in Celestiary, not here).
+    expect(s.getSettings()).toEqual({...target, L: false, A: false})
   })
 })
 
@@ -403,5 +406,92 @@ describe('Scene.land', () => {
     expect(back.lat).toBeCloseTo(lat, 4)
     expect(back.lng).toBeCloseTo(lng, 4)
     expect(back.alt).toBeCloseTo(alt, 1)
+  })
+})
+
+
+/**
+ * Scene's AR mode hooks: enterAR snapshots prior settings + the ThreeUI
+ * `_arMode` flag, applies the AR preset, and returns the snapshot for
+ * exitAR to restore.  These tests exercise the bookkeeping; the actual
+ * scene-graph effects (asterism visibility, atmosphere uniform) are
+ * covered by their respective subsystem tests.
+ */
+describe('Scene.enterAR / exitAR', () => {
+  function makeArScene() {
+    const ui = {
+      scene: new ThreeScene(),
+      addClickCb: () => {},
+    }
+    const s = new Scene(ui)
+    // Stand-in stars so applySettings doesn't defer.
+    s.stars = {
+      labelLOD: {visible: false},
+      onCatalogReady: () => {},
+      add: () => {},
+    }
+    // applySettings dispatches to toggleOrbits / togglePlanetLabels which
+    // walk the 'sun' Object3D — give it a children-bearing fake with both
+    // 'orbit' and 'label LOD' so both toggles can do their walk in one
+    // pass without throwing.
+    s.objects['sun'] = {
+      children: [
+        {name: 'orbit', visible: true},
+        {name: 'label LOD', visible: true},
+      ],
+    }
+    return {scene: s, ui}
+  }
+
+  it('flips ui._arMode true on enter, restores on exit', () => {
+    const {scene, ui} = makeArScene()
+    expect(ui._arMode).toBeFalsy()
+    const snap = scene.enterAR()
+    expect(ui._arMode).toBe(true)
+    scene.exitAR(snap)
+    expect(ui._arMode).toBeFalsy()
+  })
+
+  it('returns a snapshot containing prior settings and arMode', () => {
+    const {scene} = makeArScene()
+    const before = {...scene.getSettings()}
+    const snap = scene.enterAR()
+    expect(snap).toBeDefined()
+    expect(snap.settings).toBeDefined()
+    // Snapshot captures pre-enter values, not post-enter.
+    expect(snap.settings.o).toBe(before.o)
+    expect(snap.settings.p).toBe(before.p)
+  })
+
+  it('applies the AR preset (orbits off, grids off) on enter', () => {
+    const {scene} = makeArScene()
+    scene._settings.o = true // make sure orbits would actually flip
+    scene.enterAR()
+    expect(scene.getSetting('o')).toBe(false)
+    expect(scene.getSetting('e')).toBe(false)
+    expect(scene.getSetting('c')).toBe(false)
+    expect(scene.getSetting('g')).toBe(false)
+  })
+
+  it('restores prior settings on exit', () => {
+    const {scene} = makeArScene()
+    // Set a non-trivial pre-enter state.
+    scene._settings.o = true
+    scene._settings.e = true
+    scene._settings.p = false
+    const snap = scene.enterAR()
+    // Confirm the preset took effect.
+    expect(scene.getSetting('o')).toBe(false)
+    expect(scene.getSetting('e')).toBe(false)
+    scene.exitAR(snap)
+    expect(scene.getSetting('o')).toBe(true)
+    expect(scene.getSetting('e')).toBe(true)
+    expect(scene.getSetting('p')).toBe(false)
+  })
+
+  it('exitAR with null/undefined snapshot is a no-op', () => {
+    const {scene} = makeArScene()
+    expect(() => scene.exitAR(null)).not.toThrow()
+    expect(() => scene.exitAR(undefined)).not.toThrow()
   })
 })

--- a/js/scene/Scene.test.js
+++ b/js/scene/Scene.test.js
@@ -287,7 +287,11 @@ describe('Scene.applySettings', () => {
       {name: 'label LOD', visible: true},
       {name: 'orbit', visible: true},
     ]}
-    const target = {a: false, l: true, p: false, o: false, e: true, c: true, g: true, v: false}
+    // Add a fake MilkyWay so toggleGalaxy() finds it during dispatch.
+    const milkyWay = new Object3D()
+    milkyWay.name = 'MilkyWay'
+    s.ui.scene.add(milkyWay)
+    const target = {a: false, l: true, p: false, o: false, e: true, c: true, g: true, U: false, v: false}
     s.registerSettingApplier('v', () => s.flipSetting('v'))
     s.applySettings(target)
     // L isn't in `target` but is added to getSettings by reading
@@ -296,6 +300,7 @@ describe('Scene.applySettings', () => {
     // level snapshot — the live AR state is folded in at the permalink
     // writer in Celestiary, not here).
     expect(s.getSettings()).toEqual({...target, L: false, A: false})
+    expect(milkyWay.visible).toBe(false)
   })
 })
 

--- a/js/scene/Star.js
+++ b/js/scene/Star.js
@@ -13,6 +13,7 @@ import * as Shaders from './star-shaders.js'
 import {sphere} from './shapes.js'
 import {newAtmosphere} from './atmos/Atmosphere'
 import * as Shared from '../shared.js'
+import {named} from '../utils.js'
 
 
 /**
@@ -76,7 +77,10 @@ export default class Star extends Object {
 
     const surfaceGroup = new Group
     surfaceGroup.add(this.newSurface(props))
-    surfaceGroup.add(newAtmosphere(props.radius.scalar * 1.07))
+    // Name the halo so Scene.enterAR's `'atmosphere'` traversal can hide it
+    // — the additive BackSide shell flashes orange across the AR sky-view
+    // when the camera sweeps through the Sun direction.
+    surfaceGroup.add(named(newAtmosphere(props.radius.scalar * 1.07), 'atmosphere'))
     lod.addLevel(surfaceGroup, props.radius.scalar)
 
     lod.addLevel(Shared.FAR_OBJ, props.radius.scalar * 1e3)

--- a/js/store/ARSlice.js
+++ b/js/store/ARSlice.js
@@ -20,6 +20,20 @@ export default function createARSlice(set, _get) {
   return {
     ar: null,
     setARMode: setAR(set),
+    // ARDebugHUD overlay visibility.  Off by default — the debug HUD
+    // polls the controller per frame and runs a canvas redraw, so we
+    // keep it gated to the explicit Settings → Info → "AR debug HUD"
+    // toggle.  When off, the rAF loop in ARDebugHUD doesn't even start.
+    arDebugVisible: false,
+    setARDebugVisible: (v) => set(() => ({arDebugVisible: !!v})),
+    toggleARDebug: () => set((s) => ({arDebugVisible: !s.arDebugVisible})),
+    // Alpha-axis damping preset (light / medium / heavy).  Mirror of the
+    // active preset on the pose source so the AR HUD can highlight the
+    // selected button.  Driven by setARAlphaDamping() below — that fn
+    // both updates the store value and forwards to the running pose
+    // source via celestiary.setARAlphaDamping().
+    arAlphaDamping: 'medium',
+    setARAlphaDamping: (name) => set(() => ({arAlphaDamping: name})),
   }
 }
 

--- a/js/store/ARSlice.js
+++ b/js/store/ARSlice.js
@@ -1,3 +1,6 @@
+import {DEFAULT_ALPHA_DAMPING} from '../ar/DeviceOrientationPoseSource'
+
+
 /**
  * AR (Augmented Reality) sky-view state.
  *
@@ -32,7 +35,7 @@ export default function createARSlice(set, _get) {
     // selected button.  Driven by setARAlphaDamping() below — that fn
     // both updates the store value and forwards to the running pose
     // source via celestiary.setARAlphaDamping().
-    arAlphaDamping: 'medium',
+    arAlphaDamping: DEFAULT_ALPHA_DAMPING,
     setARAlphaDamping: (name) => set(() => ({arAlphaDamping: name})),
   }
 }

--- a/js/store/ARSlice.js
+++ b/js/store/ARSlice.js
@@ -1,0 +1,36 @@
+/**
+ * AR (Augmented Reality) sky-view state.
+ *
+ * `ar` is null when AR mode is inactive (the default).  When the
+ * ARController calls `setARMode({active: true, ...})`, this slice holds
+ * the live state so the React UI can mount the AR HUD (gear button,
+ * status pill, exit button) and the AR-aware permalink encoder can flag
+ * the URL with `s=A`.
+ *
+ * Keeping it as a single object (rather than a flat fan of fields) means
+ * a single Zustand subscription captures every transition; React UI
+ * components can subscribe to `(s) => s.ar` and re-render only when AR
+ * mode flips or its parameters change.
+ *
+ * @param {Function} set
+ * @param {Function} _get
+ * @returns {object}
+ */
+export default function createARSlice(set, _get) {
+  return {
+    ar: null,
+    setARMode: setAR(set),
+  }
+}
+
+
+/**
+ * Builder for the AR setter — extracted so we can attach a doc comment
+ * without provoking the slice's nested-arrow JSDoc warning.
+ *
+ * @param {Function} set
+ * @returns {Function} `(v) => void`; pass `{active: false}` to clear
+ */
+function setAR(set) {
+  return (v) => set(() => ({ar: v && v.active ? v : null}))
+}

--- a/js/store/useStore.js
+++ b/js/store/useStore.js
@@ -1,4 +1,5 @@
 import {create} from 'zustand'
+import createARSlice from './ARSlice'
 import createAsterismsSlice from './AsterismsSlice'
 import createDragModeSlice from './DragModeSlice'
 import createSearchSlice from './SearchSlice'
@@ -7,6 +8,7 @@ import createTimeSlice from './TimeSlice'
 
 
 const useStore = create((set, get) => ({
+  ...createARSlice(set, get),
   ...createAsterismsSlice(set, get),
   ...createDragModeSlice(set, get),
   ...createSearchSlice(set, get),

--- a/js/ui/ARButton.jsx
+++ b/js/ui/ARButton.jsx
@@ -2,11 +2,35 @@ import React, {ReactElement, useState} from 'react'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import Tooltip from '@mui/material/Tooltip'
-import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong'
+import BlurOnIcon from '@mui/icons-material/BlurOn'
+import BoltIcon from '@mui/icons-material/Bolt'
 import CloseIcon from '@mui/icons-material/Close'
-import ScreenSearchDesktopIcon from '@mui/icons-material/ScreenSearchDesktop'
 import TuneIcon from '@mui/icons-material/Tune'
+import ViewInArIcon from '@mui/icons-material/ViewInAr'
+import WavesIcon from '@mui/icons-material/Waves'
 import useStore from '../store/useStore'
+
+
+/** Geolocation timeout for AR observer-fix.  Long enough for the OS to
+ * fall back from GPS to wifi/cell, short enough not to make the AR
+ * button feel hung. */
+const GEO_TIMEOUT_MS = 5000
+
+/** Cached fix freshness — re-use last reading if it's under this old. */
+const GEO_MAX_AGE_MS = 60 * 1000
+
+
+/**
+ * Damping presets surfaced as inline icon buttons in the active-AR
+ * tray.  Names must match the keys of `ALPHA_FILTER_PRESETS` in
+ * `js/ar/DeviceOrientationPoseSource.js`.  Increasing visual intensity
+ * (Bolt → Waves → BlurOn) maps to increasing smoothing.
+ */
+const DAMPING_BUTTONS = [
+  {name: 'light', icon: <BoltIcon fontSize='small'/>, tip: 'Light damping (responsive, more jitter)'},
+  {name: 'medium', icon: <WavesIcon fontSize='small'/>, tip: 'Medium damping (balanced — default)'},
+  {name: 'heavy', icon: <BlurOnIcon fontSize='small'/>, tip: 'Heavy damping (very smooth, more lag)'},
+]
 
 
 /**
@@ -18,27 +42,24 @@ import useStore from '../store/useStore'
  *      prompt to appear.
  *   2. AR pending — disabled while the controller is awaiting permissions
  *      and the first sensor sample.
- *   3. AR active — renders an Exit button plus an optional gear (only when
- *      the active pose source flagged `needsCalibration`).
- *
- * Capability gates: only mounted when DeviceOrientationEvent is available
- * AND the parent decided to render us (typically restricted to mobile via
- * `useIsMobile()`).  No GPS / camera-passthrough yet — Stage 1.
- *
- * The `onAlign` prop is wired in Stage 1d; for Stage 1a it's optional and
- * the gear is hidden if not provided.
+ *   3. AR active — renders an Exit button, an optional gear (when the
+ *      pose source flagged `needsCalibration`), and three damping mode
+ *      selectors that swap the alpha-axis 1€ filter preset on the
+ *      running pose source.
  *
  * @param {object} props
- * @param {object} props.celestiary  Celestiary controller; must expose enterAR/exitAR
+ * @param {object} props.celestiary  Celestiary controller; must expose
+ *   enterAR / exitAR / setARAlphaDamping
  * @param {Function} [props.onAlign]  Open the calibration tap-overlay
  * @param {{lat: number, lng: number, alt?: number, body?: string}} [props.observer]
- *   Manual observer pose for stage 1a (geolocation arrives in 1c).  When
- *   omitted, falls back to (0, 0, 2) so the user can at least see the
- *   chain working from the prime-meridian / equator point.
+ *   Manual observer pose override.  When omitted, ARButton requests
+ *   browser geolocation.
  * @returns {ReactElement}
  */
 export default function ARButton({celestiary, onAlign, observer}) {
   const ar = useStore((s) => s.ar)
+  const damping = useStore((s) => s.arAlphaDamping)
+  const setStoreDamping = useStore((s) => s.setARAlphaDamping)
   const [pending, setPending] = useState(false)
   const [error, setError] = useState(null)
 
@@ -55,7 +76,36 @@ export default function ARButton({celestiary, onAlign, observer}) {
     setPending(true)
     setError(null)
     try {
-      await celestiary.enterAR({lat, lng, alt, body})
+      // Best-effort geolocation — the AR sky view is only meaningful when
+      // the simulated celestial sphere matches what's actually overhead.
+      // The observer prop, when provided, wins; otherwise we ask the
+      // browser for real coords.  Permission denied / timeout / no
+      // geolocation API just falls back to the (0, 0) default rather
+      // than blocking the AR entry — the user can still validate the
+      // sensor → camera frame chain there, just without local-sky truth.
+      let actualLat = lat
+      let actualLng = lng
+      if (!observer && typeof navigator !== 'undefined' && navigator.geolocation) {
+        try {
+          const pos = await new Promise((resolve, reject) => {
+            navigator.geolocation.getCurrentPosition(resolve, reject, {
+              enableHighAccuracy: false, // city-block accuracy is plenty for sky alignment
+              timeout: GEO_TIMEOUT_MS,
+              maximumAge: GEO_MAX_AGE_MS,
+            })
+          })
+          actualLat = pos.coords.latitude
+          actualLng = pos.coords.longitude
+        } catch (geoErr) {
+          // Surface as a non-blocking warning; AR still enters.
+          console.warn('AR: geolocation unavailable, using default (0, 0):', geoErr?.message ?? geoErr)
+        }
+      }
+      await celestiary.enterAR({lat: actualLat, lng: actualLng, alt, body})
+      // Apply current store damping to the freshly-started pose source —
+      // pose source seeded itself at its own default; user's last
+      // selection should win.
+      celestiary.setARAlphaDamping?.(damping)
     } catch (e) {
       setError(e.message ?? String(e))
     } finally {
@@ -68,6 +118,11 @@ export default function ARButton({celestiary, onAlign, observer}) {
     setError(null)
   }
 
+  const onPickDamping = (name) => () => {
+    setStoreDamping(name)
+    celestiary.setARAlphaDamping?.(name)
+  }
+
   if (!isActive) {
     return (
       <Tooltip title={error ?? 'Enter AR Sky View'}>
@@ -78,7 +133,7 @@ export default function ARButton({celestiary, onAlign, observer}) {
             aria-label='Enter AR sky view'
             data-testid='ar-button-enter'
           >
-            <ScreenSearchDesktopIcon/>
+            <ViewInArIcon/>
           </IconButton>
         </span>
       </Tooltip>
@@ -98,6 +153,22 @@ export default function ARButton({celestiary, onAlign, observer}) {
           </IconButton>
         </Tooltip>
       )}
+      {DAMPING_BUTTONS.map((b) => (
+        <Tooltip key={b.name} title={b.tip}>
+          <IconButton
+            onClick={onPickDamping(b.name)}
+            aria-label={`Damping: ${b.name}`}
+            aria-pressed={damping === b.name}
+            data-testid={`ar-button-damping-${b.name}`}
+            sx={{
+              opacity: damping === b.name ? 1 : 0.4,
+              p: '4px',
+            }}
+          >
+            {b.icon}
+          </IconButton>
+        </Tooltip>
+      ))}
       <Tooltip title='Exit AR Sky View'>
         <IconButton
           onClick={onExit}
@@ -107,7 +178,6 @@ export default function ARButton({celestiary, onAlign, observer}) {
           <CloseIcon/>
         </IconButton>
       </Tooltip>
-      <CenterFocusStrongIcon fontSize='small' opacity={0.5}/>
     </Stack>
   )
 }

--- a/js/ui/ARButton.jsx
+++ b/js/ui/ARButton.jsx
@@ -1,0 +1,113 @@
+import React, {ReactElement, useState} from 'react'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong'
+import CloseIcon from '@mui/icons-material/Close'
+import ScreenSearchDesktopIcon from '@mui/icons-material/ScreenSearchDesktop'
+import TuneIcon from '@mui/icons-material/Tune'
+import useStore from '../store/useStore'
+
+
+/**
+ * Mobile AR sky-view entry point.  Three states:
+ *
+ *   1. AR inactive — renders an icon button "Enter AR Sky View".  Tapping
+ *      it triggers `celestiary.enterAR(...)` from inside a real user
+ *      gesture, which is required by iOS Safari for the sensor permission
+ *      prompt to appear.
+ *   2. AR pending — disabled while the controller is awaiting permissions
+ *      and the first sensor sample.
+ *   3. AR active — renders an Exit button plus an optional gear (only when
+ *      the active pose source flagged `needsCalibration`).
+ *
+ * Capability gates: only mounted when DeviceOrientationEvent is available
+ * AND the parent decided to render us (typically restricted to mobile via
+ * `useIsMobile()`).  No GPS / camera-passthrough yet — Stage 1.
+ *
+ * The `onAlign` prop is wired in Stage 1d; for Stage 1a it's optional and
+ * the gear is hidden if not provided.
+ *
+ * @param {object} props
+ * @param {object} props.celestiary  Celestiary controller; must expose enterAR/exitAR
+ * @param {Function} [props.onAlign]  Open the calibration tap-overlay
+ * @param {{lat: number, lng: number, alt?: number, body?: string}} [props.observer]
+ *   Manual observer pose for stage 1a (geolocation arrives in 1c).  When
+ *   omitted, falls back to (0, 0, 2) so the user can at least see the
+ *   chain working from the prime-meridian / equator point.
+ * @returns {ReactElement}
+ */
+export default function ARButton({celestiary, onAlign, observer}) {
+  const ar = useStore((s) => s.ar)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState(null)
+
+  const isActive = !!ar
+  const lat = observer?.lat ?? 0
+  const lng = observer?.lng ?? 0
+  const alt = observer?.alt ?? 2
+  const body = observer?.body
+
+  const onEnter = async () => {
+    if (pending || isActive) {
+      return
+    }
+    setPending(true)
+    setError(null)
+    try {
+      await celestiary.enterAR({lat, lng, alt, body})
+    } catch (e) {
+      setError(e.message ?? String(e))
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const onExit = () => {
+    celestiary.exitAR()
+    setError(null)
+  }
+
+  if (!isActive) {
+    return (
+      <Tooltip title={error ?? 'Enter AR Sky View'}>
+        <span>
+          <IconButton
+            onClick={onEnter}
+            disabled={pending}
+            aria-label='Enter AR sky view'
+            data-testid='ar-button-enter'
+          >
+            <ScreenSearchDesktopIcon/>
+          </IconButton>
+        </span>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Stack direction='row' spacing={0.5} alignItems='center'>
+      {ar.needsCalibration && onAlign && (
+        <Tooltip title='Align: tap a known star or planet to calibrate the sky'>
+          <IconButton
+            onClick={onAlign}
+            aria-label='Calibrate AR alignment'
+            data-testid='ar-button-calibrate'
+          >
+            <TuneIcon/>
+          </IconButton>
+        </Tooltip>
+      )}
+      <Tooltip title='Exit AR Sky View'>
+        <IconButton
+          onClick={onExit}
+          aria-label='Exit AR sky view'
+          data-testid='ar-button-exit'
+        >
+          <CloseIcon/>
+        </IconButton>
+      </Tooltip>
+      <CenterFocusStrongIcon fontSize='small' opacity={0.5}/>
+    </Stack>
+  )
+}

--- a/js/ui/ARDebugHUD.jsx
+++ b/js/ui/ARDebugHUD.jsx
@@ -1,0 +1,256 @@
+import React, {ReactElement, useEffect, useRef, useState} from 'react'
+import Box from '@mui/material/Box'
+import useStore from '../store/useStore'
+
+
+/** Number of recent (raw, filtered) alpha samples retained for the graph.
+ * At ~60 Hz that's a ~10 s window — long enough to make slow drift and
+ * non-monotonic motion during a deliberate slow pan obvious, while
+ * still resolving sub-second periodic carriers (heartbeat / tremor). */
+const ALPHA_HISTORY_LEN = 600
+
+const GRAPH_W_PX = 240
+const GRAPH_H_PX = 70
+
+
+/**
+ * Lightweight debug overlay for the AR sky-view feature.  Mounts when AR
+ * is active.  Polls the ARController's debug snapshot via rAF and
+ * renders the raw sensor sample (alpha/beta/gamma), sample count,
+ * staleness, screen-orientation angle, and the resulting camera
+ * quaternion.  Below the text panel a tiny canvas plots the raw and
+ * filtered alpha against time so you can eyeball any periodic
+ * residual the filter isn't catching.
+ *
+ * @param {object} props
+ * @param {object} props.celestiary  Top-level controller; we read
+ *   `celestiary.ar.getDebugSnapshot()` once per animation frame.
+ * @returns {ReactElement | null}
+ */
+export default function ARDebugHUD({celestiary}) {
+  const ar = useStore((s) => s.ar)
+  const visible = useStore((s) => s.arDebugVisible)
+  const [snap, setSnap] = useState(null)
+  const canvasRef = useRef(null)
+  // Mutable ring buffer of recent (raw, filtered) alpha samples.  Lives
+  // outside React state because we update it every animation frame and
+  // don't want to trigger a render beyond what `setSnap` already does.
+  const alphaHistoryRef = useRef([])
+
+  useEffect(() => {
+    if (!visible || !ar || !celestiary?.ar) {
+      setSnap(null)
+      alphaHistoryRef.current = []
+      return undefined
+    }
+    let raf = 0
+    const tick = () => {
+      const s = celestiary.ar.getDebugSnapshot()
+      setSnap(s)
+      pushAlpha(alphaHistoryRef.current, s)
+      drawAlphaGraph(canvasRef.current, alphaHistoryRef.current)
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [ar, celestiary, visible])
+
+  if (!visible || !snap || !snap.active) {
+    return null
+  }
+
+  const ps = snap.poseSrc ?? {}
+  const ls = ps.lastSample
+  const lr = ps.lastRawSample
+  return (
+    <Box
+      data-testid='ar-debug-hud'
+      sx={{
+        position: 'fixed',
+        top: '4em',
+        right: '0.5em',
+        maxWidth: '20em',
+        p: '0.5em 0.75em',
+        bgcolor: 'rgba(0, 0, 0, 0.55)',
+        color: '#0f0',
+        fontFamily: 'monospace',
+        fontSize: '0.72rem',
+        lineHeight: 1.35,
+        borderRadius: '0.4em',
+        pointerEvents: 'none',
+        zIndex: 1300,
+      }}
+    >
+      <Box sx={{whiteSpace: 'pre'}}>
+        {`kind:    ${ps.kind ?? 'n/a'}`}{'\n'}
+        {`absolute:${ps.isAbsolute === true ? ' yes' : ' no '}`}{'\n'}
+        {`event:   ${ps.lastEventType ?? '—'}`}{'\n'}
+        {`samples: ${ps.sampleCount ?? 0}`}{'\n'}
+        {`age(ms): ${ps.msSinceLastSample ?? '—'}`}{'\n'}
+        {ls ? `α/β/γ:   ${fmt(ls.alpha)} / ${fmt(ls.beta)} / ${fmt(ls.gamma)}` : 'α/β/γ:   —'}{'\n'}
+        {lr ? `raw:     ${fmt(lr.alpha)} / ${fmt(lr.beta)} / ${fmt(lr.gamma)}` : 'raw:     —'}{'\n'}
+        {`screen:  ${snap.screenAngle}°`}{'\n'}
+        {snap.camQuat ?
+          `camQ:    (${snap.camQuat.x}, ${snap.camQuat.y}, ${snap.camQuat.z}, ${snap.camQuat.w})` :
+          'camQ:    —'}{'\n'}
+        {`arMode:  ${snap.arMode ? 'true' : 'FALSE'}`}{'\n'}
+        {`uAtmEn:  ${snap.uAtmEnabled ?? '—'}`}{'\n'}
+        {`@ lat ${fmt(snap.lat)} lng ${fmt(snap.lng)}`}
+      </Box>
+      <Box sx={{mt: '0.4em', fontSize: '0.6rem', opacity: 0.8}}>α (raw=grey, notch=orange, filt=green)</Box>
+      <canvas
+        ref={canvasRef}
+        width={GRAPH_W_PX}
+        height={GRAPH_H_PX}
+        style={{display: 'block', width: '100%', height: `${GRAPH_H_PX}px`}}
+      />
+    </Box>
+  )
+}
+
+
+/**
+ * Append the current sample to the ring-ish buffer (we just `shift`
+ * to keep length bounded; ALPHA_HISTORY_LEN is small enough that the
+ * O(n) cost is dwarfed by canvas rendering).
+ *
+ * @param {Array} buf  Mutated in place
+ * @param {object} snap  Latest debug snapshot
+ */
+function pushAlpha(buf, snap) {
+  const ps = snap?.poseSrc
+  const ls = ps?.lastSample
+  const lr = ps?.lastRawSample
+  if (!ls && !lr) {
+    return
+  }
+  buf.push({
+    f: typeof ls?.alpha === 'number' ? ls.alpha : null,
+    n: typeof ps?.lastNotchedAlpha === 'number' ? ps.lastNotchedAlpha : null,
+    r: typeof lr?.alpha === 'number' ? lr.alpha : null,
+  })
+  while (buf.length > ALPHA_HISTORY_LEN) {
+    buf.shift()
+  }
+}
+
+
+/**
+ * Plot raw + filtered alpha in `buf` onto the given canvas.  Y axis
+ * auto-scales to the visible value range with a 5° minimum span (so
+ * the trace doesn't extreme-zoom and turn into a fuzz when both
+ * series are nearly flat).
+ *
+ * @param {HTMLCanvasElement | null} canvas
+ * @param {Array} buf
+ */
+function drawAlphaGraph(canvas, buf) {
+  if (!canvas) {
+    return
+  }
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return
+  }
+  const w = canvas.width
+  const h = canvas.height
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.4)'
+  ctx.fillRect(0, 0, w, h)
+  if (buf.length < 2) {
+    return
+  }
+  let min = Infinity
+  let max = -Infinity
+  for (const s of buf) {
+    for (const k of ['f', 'n', 'r']) {
+      const v = s[k]
+      if (typeof v === 'number') {
+        if (v < min) {
+          min = v
+        }
+        if (v > max) {
+          max = v
+        }
+      }
+    }
+  }
+  if (!isFinite(min) || !isFinite(max)) {
+    return
+  }
+  const minSpan = 5 // degrees
+  let span = max - min
+  if (span < minSpan) {
+    const mid = (min + max) / 2
+    min = mid - (minSpan / 2)
+    max = mid + (minSpan / 2)
+    span = minSpan
+  } else {
+    const pad = span * 0.1
+    min -= pad
+    max += pad
+    span = max - min
+  }
+  // Center reference line (mid of visible range).
+  ctx.strokeStyle = 'rgba(0, 255, 0, 0.18)'
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(0, h / 2)
+  ctx.lineTo(w, h / 2)
+  ctx.stroke()
+  drawSeries(ctx, buf, w, h, min, span, 'r', 'rgba(180, 180, 180, 0.85)', 1)
+  drawSeries(ctx, buf, w, h, min, span, 'n', 'rgba(255, 165, 0, 0.85)', 1)
+  drawSeries(ctx, buf, w, h, min, span, 'f', '#0f0', 1.5)
+  // Y-axis labels (top = max, bottom = min).
+  ctx.fillStyle = '#0f0'
+  ctx.font = '9px monospace'
+  ctx.textAlign = 'left'
+  ctx.textBaseline = 'top'
+  ctx.fillText(`${max.toFixed(1)}°`, 2, 1)
+  ctx.textBaseline = 'bottom'
+  ctx.fillText(`${min.toFixed(1)}°`, 2, h - 1)
+}
+
+
+/**
+ * Stroke one series ('r' or 'f') as a polyline.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {Array} buf
+ * @param {number} w
+ * @param {number} h
+ * @param {number} min
+ * @param {number} span
+ * @param {string} key  'r' for raw, 'n' for post-notch, 'f' for filtered
+ * @param {string} color
+ * @param {number} lineWidth
+ */
+function drawSeries(ctx, buf, w, h, min, span, key, color, lineWidth) {
+  ctx.strokeStyle = color
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  let started = false
+  for (let i = 0; i < buf.length; i++) {
+    const v = buf[i][key]
+    if (typeof v !== 'number') {
+      continue
+    }
+    const x = (i / (ALPHA_HISTORY_LEN - 1)) * w
+    const y = h - (((v - min) / span) * h)
+    if (!started) {
+      ctx.moveTo(x, y)
+      started = true
+    } else {
+      ctx.lineTo(x, y)
+    }
+  }
+  ctx.stroke()
+}
+
+
+/** @param {number | null | undefined} v */
+function fmt(v) {
+  if (typeof v !== 'number') {
+    return '—'
+  }
+  return v.toFixed(1)
+}

--- a/js/ui/ARDebugHUD.jsx
+++ b/js/ui/ARDebugHUD.jsx
@@ -32,23 +32,38 @@ export default function ARDebugHUD({celestiary}) {
   const visible = useStore((s) => s.arDebugVisible)
   const [snap, setSnap] = useState(null)
   const canvasRef = useRef(null)
-  // Mutable ring buffer of recent (raw, filtered) alpha samples.  Lives
-  // outside React state because we update it every animation frame and
-  // don't want to trigger a render beyond what `setSnap` already does.
-  const alphaHistoryRef = useRef([])
+  // Pre-allocated circular ring buffer of recent (raw, post-notch,
+  // filtered) alpha samples.  Lives outside React state because we
+  // mutate it every animation frame and don't want to trigger renders
+  // beyond what `setSnap` already does.  `head` is the index where the
+  // *next* write goes; iteration walks forward from `head` (the
+  // oldest slot) so the most recent sample lands at the right edge of
+  // the graph.
+  const historyRef = useRef({buf: makeHistoryBuffer(), head: 0})
+  // Track the most recent ARController sampleCount so we can skip the
+  // pushAlpha + canvas-redraw work when no new event has arrived since
+  // the last rAF tick (DeviceOrientation is variable rate, often below
+  // 60 Hz).  Avoids ~60 wasted redraws per second when the user holds
+  // the phone perfectly still.
+  const lastSampleCountRef = useRef(-1)
 
   useEffect(() => {
     if (!visible || !ar || !celestiary?.ar) {
       setSnap(null)
-      alphaHistoryRef.current = []
+      historyRef.current = {buf: makeHistoryBuffer(), head: 0}
+      lastSampleCountRef.current = -1
       return undefined
     }
     let raf = 0
     const tick = () => {
       const s = celestiary.ar.getDebugSnapshot()
       setSnap(s)
-      pushAlpha(alphaHistoryRef.current, s)
-      drawAlphaGraph(canvasRef.current, alphaHistoryRef.current)
+      const sampleCount = s?.poseSrc?.sampleCount ?? 0
+      if (sampleCount !== lastSampleCountRef.current) {
+        pushAlpha(historyRef.current, s)
+        drawAlphaGraph(canvasRef.current, historyRef.current)
+        lastSampleCountRef.current = sampleCount
+      }
       raf = requestAnimationFrame(tick)
     }
     raf = requestAnimationFrame(tick)
@@ -109,42 +124,46 @@ export default function ARDebugHUD({celestiary}) {
 }
 
 
+/** @returns {Array<?object>} Pre-allocated history slots, all empty. */
+function makeHistoryBuffer() {
+  return new Array(ALPHA_HISTORY_LEN).fill(null)
+}
+
+
 /**
- * Append the current sample to the ring-ish buffer (we just `shift`
- * to keep length bounded; ALPHA_HISTORY_LEN is small enough that the
- * O(n) cost is dwarfed by canvas rendering).
+ * Append the current sample to the ring buffer.  O(1) per push (no
+ * `shift()`).  Slots not yet written are `null` and `drawSeries`
+ * skips them.
  *
- * @param {Array} buf  Mutated in place
+ * @param {{buf: Array, head: number}} ring  Mutated in place
  * @param {object} snap  Latest debug snapshot
  */
-function pushAlpha(buf, snap) {
+function pushAlpha(ring, snap) {
   const ps = snap?.poseSrc
   const ls = ps?.lastSample
   const lr = ps?.lastRawSample
   if (!ls && !lr) {
     return
   }
-  buf.push({
+  ring.buf[ring.head] = {
     f: typeof ls?.alpha === 'number' ? ls.alpha : null,
     n: typeof ps?.lastNotchedAlpha === 'number' ? ps.lastNotchedAlpha : null,
     r: typeof lr?.alpha === 'number' ? lr.alpha : null,
-  })
-  while (buf.length > ALPHA_HISTORY_LEN) {
-    buf.shift()
   }
+  ring.head = (ring.head + 1) % ring.buf.length
 }
 
 
 /**
- * Plot raw + filtered alpha in `buf` onto the given canvas.  Y axis
- * auto-scales to the visible value range with a 5° minimum span (so
- * the trace doesn't extreme-zoom and turn into a fuzz when both
+ * Plot raw + filtered alpha in the ring buffer onto the given canvas.
+ * Y axis auto-scales to the visible value range with a 5° minimum span
+ * (so the trace doesn't extreme-zoom and turn into a fuzz when both
  * series are nearly flat).
  *
  * @param {HTMLCanvasElement | null} canvas
- * @param {Array} buf
+ * @param {{buf: Array, head: number}} ring
  */
-function drawAlphaGraph(canvas, buf) {
+function drawAlphaGraph(canvas, ring) {
   if (!canvas) {
     return
   }
@@ -156,12 +175,14 @@ function drawAlphaGraph(canvas, buf) {
   const h = canvas.height
   ctx.fillStyle = 'rgba(0, 0, 0, 0.4)'
   ctx.fillRect(0, 0, w, h)
-  if (buf.length < 2) {
-    return
-  }
   let min = Infinity
   let max = -Infinity
-  for (const s of buf) {
+  let count = 0
+  for (const s of ring.buf) {
+    if (s === null) {
+      continue
+    }
+    count++
     for (const k of ['f', 'n', 'r']) {
       const v = s[k]
       if (typeof v === 'number') {
@@ -174,7 +195,7 @@ function drawAlphaGraph(canvas, buf) {
       }
     }
   }
-  if (!isFinite(min) || !isFinite(max)) {
+  if (count < 2 || !isFinite(min) || !isFinite(max)) {
     return
   }
   const minSpan = 5 // degrees
@@ -197,9 +218,9 @@ function drawAlphaGraph(canvas, buf) {
   ctx.moveTo(0, h / 2)
   ctx.lineTo(w, h / 2)
   ctx.stroke()
-  drawSeries(ctx, buf, w, h, min, span, 'r', 'rgba(180, 180, 180, 0.85)', 1)
-  drawSeries(ctx, buf, w, h, min, span, 'n', 'rgba(255, 165, 0, 0.85)', 1)
-  drawSeries(ctx, buf, w, h, min, span, 'f', '#0f0', 1.5)
+  drawSeries(ctx, ring, w, h, min, span, 'r', 'rgba(180, 180, 180, 0.85)', 1)
+  drawSeries(ctx, ring, w, h, min, span, 'n', 'rgba(255, 165, 0, 0.85)', 1)
+  drawSeries(ctx, ring, w, h, min, span, 'f', '#0f0', 1.5)
   // Y-axis labels (top = max, bottom = min).
   ctx.fillStyle = '#0f0'
   ctx.font = '9px monospace'
@@ -212,10 +233,12 @@ function drawAlphaGraph(canvas, buf) {
 
 
 /**
- * Stroke one series ('r' or 'f') as a polyline.
+ * Stroke one series ('r' / 'n' / 'f') as a polyline.  Walks the ring
+ * buffer in oldest-first order (starting at `ring.head`, the slot the
+ * next write will overwrite, which is also the oldest current entry).
  *
  * @param {CanvasRenderingContext2D} ctx
- * @param {Array} buf
+ * @param {{buf: Array, head: number}} ring
  * @param {number} w
  * @param {number} h
  * @param {number} min
@@ -224,17 +247,27 @@ function drawAlphaGraph(canvas, buf) {
  * @param {string} color
  * @param {number} lineWidth
  */
-function drawSeries(ctx, buf, w, h, min, span, key, color, lineWidth) {
+function drawSeries(ctx, ring, w, h, min, span, key, color, lineWidth) {
   ctx.strokeStyle = color
   ctx.lineWidth = lineWidth
   ctx.beginPath()
   let started = false
-  for (let i = 0; i < buf.length; i++) {
-    const v = buf[i][key]
+  const n = ring.buf.length
+  for (let i = 0; i < n; i++) {
+    const slot = ring.buf[(ring.head + i) % n]
+    if (slot === null) {
+      // Pre-fill not yet reached — break so a partial buffer renders
+      // its written portion at the right edge of the graph instead of
+      // creating phantom gaps in the middle.  Once the buffer wraps
+      // around once, no slots are null and this branch never fires.
+      started = false
+      continue
+    }
+    const v = slot[key]
     if (typeof v !== 'number') {
       continue
     }
-    const x = (i / (ALPHA_HISTORY_LEN - 1)) * w
+    const x = (i / (n - 1)) * w
     const y = h - (((v - min) / span) * h)
     if (!started) {
       ctx.moveTo(x, y)

--- a/js/ui/Settings.jsx
+++ b/js/ui/Settings.jsx
@@ -1,42 +1,207 @@
 import React, {ReactElement, useEffect, useState} from 'react'
 import {useLocation} from 'wouter'
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
 import Dialog from './Dialog'
 
 
+/** Display labels for non-printable / multi-char keys.  Lookup by `event.key`
+ * (which is `'ArrowUp'`, not `'ARROWUP'` — the previous all-caps map never
+ * matched, so arrow keys appeared as their full string in the panel). */
 const KEY_LABELS = {
-  ARROWUP: '↑',
-  ARROWDOWN: '↓',
-  ARROWLEFT: '←',
-  ARROWRIGHT: '→',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  ' ': 'Spc',
+}
+
+/** Group rendering order in the Settings dialog.  Groups not listed here
+ * (or whose entries have no group label) fall through to "Other" at the
+ * bottom. */
+const GROUP_ORDER = ['Info', 'Labels', 'Orbits', 'Grids', 'Time', 'Camera', 'Targeting']
+const OTHER_GROUP = 'Other'
+
+
+/**
+ * Settings dialog: lists every keyboard shortcut and click-only action
+ * registered with `Keys`, grouped by `keys.groups[c]` / `action.group`.
+ * Each group has its own master checkbox: indeterminate when members are
+ * mixed, checked when all on, unchecked when all off.  Master click
+ * forces all members in the group to true if any are false, otherwise
+ * to false.
+ *
+ * @param {object} props
+ * @param {object} props.keys      Keys instance (keymap, msgs, toggleStates, groups, actions)
+ * @param {string} [props.href]    Wouter href to navigate to on close
+ * @returns {ReactElement}
+ */
+export default function Settings({keys, href = '~/'}) {
+  const [isOpen, setIsOpen] = useState(false)
+  // Bumped on every toggle / master click so checkboxes re-evaluate
+  // their getState().  Toggles flipped via the keyboard while the dialog
+  // is open won't auto-refresh — fine for now.
+  const [refreshTick, setRefreshTick] = useState(0)
+  const [location] = useLocation()
+  useEffect(() => setIsOpen(location === '/settings'), [location])
+  const refresh = () => setRefreshTick((t) => t + 1)
+  const groups = buildGroups(keys)
+  return (
+    <Dialog title='Settings' isOpen={isOpen} setIsOpen={setIsOpen} onCloseHref={href}>
+      <Box data-refresh={refreshTick}>
+        {groups.map((g) => (
+          <Group key={g.title} group={g} onChange={refresh}/>
+        ))}
+      </Box>
+    </Dialog>
+  )
 }
 
 
-/** @returns {ReactElement} */
-export default function Settings({keys, href = '~/'}) {
-  const [isOpen, setIsOpen] = useState(false)
-  const [location] = useLocation()
-  useEffect(() => setIsOpen(location === '/settings'), [location])
+/**
+ * One Settings section: title row with master checkbox, then per-entry rows.
+ *
+ * @param {object} props
+ * @param {{title: string, entries: object[]}} props.group
+ * @param {Function} props.onChange  Called after any toggle to refresh parent
+ * @returns {ReactElement}
+ */
+function Group({group, onChange}) {
+  const toggleEntries = group.entries.filter((e) => e.getState)
+  const onCount = toggleEntries.filter((e) => !!e.getState()).length
+  const allOn = toggleEntries.length > 0 && onCount === toggleEntries.length
+  const allOff = onCount === 0
+  const onMaster = () => {
+    // If any are off → turn all on; if all on → turn all off.  Single
+    // toggle pass per entry (idempotent if already in target state by
+    // testing getState before flipping).
+    const target = !allOn
+    for (const e of toggleEntries) {
+      if (!!e.getState() !== target) {
+        e.fn()
+      }
+    }
+    onChange()
+  }
   return (
-    <Dialog title='Key Shortcuts' isOpen={isOpen} setIsOpen={setIsOpen} onCloseHref={href}>
-      <ul style={{listStyleType: 'none'}}>
-        {numbersLastIterator(keys.keymap).map((key, ndx) => (
-          <li key={ndx}>
-            <Button onClick={keys.keymap[key]}>
-              {KEY_LABELS[key] ?? (key === ' ' ? 'Spc' : key)}
-            </Button>
-            {keys.msgs[key]}
-          </li>
+    <Box sx={{mb: '0.75em'}}>
+      <Stack direction='row' alignItems='center' sx={{borderBottom: '1px solid rgba(255,255,255,0.15)'}}>
+        {toggleEntries.length > 0 ? (
+          <Checkbox
+            size='small'
+            checked={allOn}
+            indeterminate={!allOn && !allOff}
+            onChange={onMaster}
+          />
+        ) : <Box sx={{width: '38px'}}/>}
+        <Typography variant='subtitle2' sx={{fontWeight: 600}}>{group.title}</Typography>
+      </Stack>
+      <Box sx={{pl: '1.5em'}}>
+        {group.entries.map((entry, ndx) => (
+          <Entry key={ndx} entry={entry} onChange={onChange}/>
         ))}
-        {(keys.actions ?? []).map((action, ndx) => (
-          <li key={`action-${ndx}`}>
-            <Button onClick={action.fn}>•</Button>
-            {action.msg}
-          </li>
-        ))}
-      </ul>
-    </Dialog>
+      </Box>
+    </Box>
   )
+}
+
+
+/**
+ * One row in a group — checkbox-with-label for toggles, key-button for
+ * one-shot actions.
+ *
+ * @param {object} props
+ * @param {object} props.entry  {key?, fn, msg, getState?}
+ * @param {Function} props.onChange
+ * @returns {ReactElement}
+ */
+function Entry({entry, onChange}) {
+  const handleToggle = () => {
+    entry.fn()
+    onChange()
+  }
+  if (entry.getState) {
+    const label = entry.key ?
+      <><code style={{display: 'inline-block', minWidth: '1.5em', marginRight: '0.6em', opacity: 0.6}}>{labelFor(entry.key)}</code>{entry.msg}</> :
+      entry.msg
+    return (
+      <Box>
+        <FormControlLabel
+          control={<Checkbox size='small' checked={!!entry.getState()} onChange={handleToggle}/>}
+          label={label}
+        />
+      </Box>
+    )
+  }
+  // One-shot action
+  return (
+    <Stack direction='row' alignItems='center' spacing={1} sx={{py: '0.15em'}}>
+      {entry.key ?
+        <Button size='small' onClick={entry.fn} sx={{minWidth: '2em', px: '0.4em'}}>{labelFor(entry.key)}</Button> :
+        <Button size='small' onClick={entry.fn} sx={{minWidth: '2em', px: '0.4em'}}>•</Button>}
+      <span>{entry.msg}</span>
+    </Stack>
+  )
+}
+
+
+/** @param {string} k */
+function labelFor(k) {
+  return KEY_LABELS[k] ?? k
+}
+
+
+/**
+ * Walk `keys.keymap` and `keys.actions` and bucket each entry into its
+ * group.  Preserves registration order within a group; emits groups in
+ * `GROUP_ORDER`, with anything else under `OTHER_GROUP` last.
+ *
+ * @param {object} keys  Keys instance
+ * @returns {Array<{title: string, entries: object[]}>}
+ */
+function buildGroups(keys) {
+  const buckets = new Map()
+  // Keymap entries — preserve insertion order.
+  for (const key of numbersLastIterator(keys.keymap)) {
+    const group = keys.groups?.[key] ?? OTHER_GROUP
+    if (!buckets.has(group)) {
+      buckets.set(group, [])
+    }
+    const entry = {
+      key,
+      fn: keys.keymap[key],
+      msg: keys.msgs[key],
+    }
+    const getState = keys.toggleStates?.[key]
+    if (getState) {
+      entry.getState = getState
+    }
+    buckets.get(group).push(entry)
+  }
+  // Click-only actions — already objects with optional getState/group.
+  for (const action of keys.actions ?? []) {
+    const group = action.group ?? OTHER_GROUP
+    if (!buckets.has(group)) {
+      buckets.set(group, [])
+    }
+    buckets.get(group).push({...action})
+  }
+  // Emit in GROUP_ORDER, then anything else.
+  const out = []
+  for (const title of GROUP_ORDER) {
+    if (buckets.has(title)) {
+      out.push({title, entries: buckets.get(title)})
+      buckets.delete(title)
+    }
+  }
+  for (const [title, entries] of buckets) {
+    out.push({title, entries})
+  }
+  return out
 }
 
 
@@ -44,13 +209,11 @@ export default function Settings({keys, href = '~/'}) {
  * Create a new iteration array for given object, with numbers last.
  *
  * @param {object} obj
- * @returns {Array<object>} newly ordered array with numbrers last
+ * @returns {Array<string>} keys, non-integer-like first
  */
 function numbersLastIterator(obj) {
-  // Separate integer-like keys and non-integer-like keys
   const integerLikeKeys = []
   const nonIntegerLikeKeys = []
-
   Object.keys(obj).forEach((key) => {
     if (/^\d+$/.test(key)) {
       integerLikeKeys.push(key)
@@ -58,7 +221,5 @@ function numbersLastIterator(obj) {
       nonIntegerLikeKeys.push(key)
     }
   })
-
-  // Return the concatenated array: first non-integer keys, then integer keys
   return [...nonIntegerLikeKeys, ...integerLikeKeys]
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
     "prepare": "git config core.hooksPath hooks",
     "precommit": "yarn lint && yarn test && yarn bundle-check",
     "serve": "yarn build && node esbuild/serve.js",
+    "serve:https": "yarn build && DEV_HTTPS_KEY=dev-certs/key.pem DEV_HTTPS_CERT=dev-certs/cert.pem node esbuild/serve.js",
+    "cert:dev": "node tools/genDevCert.mjs",
     "test": "bun test",
     "update-version": "./tools/updateVersion.mjs"
   },
   "dependencies": {
+    "1eurofilter": "^1.3.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.0",
     "@mui/icons-material": "5.16.13",

--- a/tools/genDevCert.mjs
+++ b/tools/genDevCert.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import {execFileSync, spawnSync} from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+
+/**
+ * Generate a localhost + LAN-IP TLS certificate for the dev server using
+ * mkcert, and write it to `dev-certs/{cert,key}.pem`.
+ *
+ * Usage:
+ *   yarn cert:dev
+ *
+ * Prerequisites:
+ *   - mkcert installed and `mkcert -install` run once on this machine
+ *     (`brew install mkcert nss && mkcert -install`).
+ *
+ * For Android phone testing on the LAN, the laptop's mkcert root CA must
+ * also be installed on the phone:
+ *   1. Find it:    mkcert -CAROOT
+ *   2. Copy `rootCA.pem` to the phone (Drive / email / `python3 -m
+ *      http.server` from CAROOT).
+ *   3. On phone:   Settings -> Security -> Encryption & credentials ->
+ *                  Install a certificate -> CA certificate.
+ *
+ * Without the root CA on the phone, Chrome treats the connection as
+ * insecure even after click-through, and DeviceOrientationEvent stays
+ * disabled.
+ */
+
+const OUT_DIR = 'dev-certs'
+const KEY_PATH = path.join(OUT_DIR, 'key.pem')
+const CERT_PATH = path.join(OUT_DIR, 'cert.pem')
+
+
+if (spawnSync('mkcert', ['-help'], {stdio: 'ignore'}).status !== 0) {
+  console.error('mkcert not found.  Install it first:')
+  console.error('  macOS:  brew install mkcert nss && mkcert -install')
+  console.error('  Linux:  see https://github.com/FiloSottile/mkcert#installation')
+  process.exit(1)
+}
+
+fs.mkdirSync(OUT_DIR, {recursive: true})
+
+const hosts = ['localhost', '127.0.0.1', '::1', ...lanIPv4s()]
+console.log(`Issuing dev cert for: ${hosts.join(', ')}`)
+
+execFileSync('mkcert', ['-key-file', KEY_PATH, '-cert-file', CERT_PATH, ...hosts], {stdio: 'inherit'})
+
+const caRoot = execFileSync('mkcert', ['-CAROOT'], {encoding: 'utf8'}).trim()
+console.log('')
+console.log(`Cert written to ${CERT_PATH}`)
+console.log(`Key  written to ${KEY_PATH}`)
+console.log('')
+console.log('Run `yarn serve:https` to use it.')
+console.log('')
+console.log('For Android phone testing, install the mkcert root CA on the phone:')
+console.log(`  Source:  ${path.join(caRoot, 'rootCA.pem')}`)
+console.log('  Phone:   Settings -> Security -> Encryption & credentials -> Install a certificate -> CA certificate')
+
+
+/**
+ * @return {string[]} Non-internal IPv4 addresses on this machine
+ */
+function lanIPv4s() {
+  const out = []
+  for (const ifaces of Object.values(os.networkInterfaces())) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        out.push(iface.address)
+      }
+    }
+  }
+  return out
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"1eurofilter@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/1eurofilter/-/1eurofilter-1.3.0.tgz#c8a47d42287207fd2a3d7f613a785897dc357ec8"
+  integrity sha512-3t57UlTR7J2Uyq7kwfzgQg+auO6Yb3G09GKFeBVJQvaK/Otn0dcW20RNMt4d05G0/XcEQoORW87rGo3RFiyHYg==
+
 "@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"


### PR DESCRIPTION
## Summary

Adds a mobile AR sky-view feature: hold your phone up at night and the
rendered planets/stars/asterisms align with the actual sky in real time.
Works in any browser with `DeviceOrientationEvent` (covers iOS Safari and
Chrome Android); WebXR path is stubbed and ready for stage 1b.

The heavy lifting was already in the codebase — `Scene.land()` reparents
the camera platform onto the rotating body so sidereal rotation comes
for free, and the body-fixed lat/lng frame already matches `coords.js`.
This PR composes those with a sensor-driven camera→ENU quaternion to
close the loop.

Frame chain composed each frame in `ARController.updateFrame`:

```
camera.quaternion =
    enu_to_bodyFixed(lat, lng)   (js/ar/enuFrame.js)
  · q_calibration_enu             (js/ar/Calibration.js, optional)
  · q_camera_to_enu               (js/ar/PoseSource.js, sensors)
```

The bodyFixed → inertial step is inherited from the scene graph (camera
platform parented to the rotating body Object3D). `updateFrame` runs
last in `ThreeUI.renderLoop`, after every other camera-quaternion writer
(controls, tweens, arrow keys, tracking), so AR pose always wins.

## Architecture

- **`js/ar/PoseSource.js`** — contract + factory.  Auto-probes
  WebXR → DeviceOrientation → Null in that order.
- **`js/ar/DeviceOrientationPoseSource.js`** — W3C alpha/beta/gamma
  composed via Z-X-Y intrinsic rotation, plus `screen.orientation.angle`
  correction so portrait/landscape both render upright.
- **`js/ar/WebXRPoseSource.js`** — stubbed for stage 1b.  Returns
  `isSupported() === false` today; full session impl is the next slice.
- **`js/ar/NullPoseSource.js`** — desktop fallback.  Identity pose,
  user sees what AR *would* look like with sensors at the configured
  lat/lng.
- **`js/ar/enuFrame.js`** — body-agnostic ENU↔body-fixed math.  Works
  on any planet/moon registered in the scene; landing on Mars and
  looking up shows the Martian sky.
- **`js/ar/Calibration.js`** — optional one-tap solver for sensor bias.
  `setFromUnitVectors(deviceAim, trueAim)` produces a 2-DoF correction;
  persisted in `localStorage`, scoped per `(sourceKind, screenAngle)`.
- **`js/ar/ARController.js`** — lifecycle, per-frame compose, calibration
  capture.  Pose-source factory is injectable for testing.

## Permalink

New `s=A` flag in `SETTINGS_DEFAULTS`.  Per the spec discussion:

1. **Target** (`path`) honored as before.
2. **Observer pose** (`lat/lng/alt` + optional `quat`) honored as before.
3. **AR fallback** (`s=A`): writer sets `A=1` while `ar.isActive()`;
   reader best-effort calls `enterAR()` after the static restore.
   Silent no-op on iOS without a user gesture; user can tap the AR
   button (a real gesture) to manually engage.

Examples after this PR:
- `#sun/earth@0,0,0;…` — orbit view, unchanged
- `#sun/earth@37.77,-122.42,2m;…;s=L` — landed at SF, unchanged
- `#sun/earth@37.77,-122.42,2m;…;s=LA` — landed at SF, AR-flagged

## Visibility preset (Stage 1, no camera passthrough yet)

`Scene.enterAR()` snapshots prior settings, then forces:
- atmosphere off (`ThreeUI._arMode` gates the post-pass — daytime sky
  would otherwise opaque-paint over the stars; Stage 2 re-enables with
  premultiplied-alpha blend so it tints the camera feed instead)
- orbits + reference grids off
- asterisms + star labels + planet labels on
- planet meshes left visible — they form a virtual "ground" beneath
  the observer at altitude ~2 m

`Scene.exitAR(snapshot)` restores everything.

## UI

`ARButton.jsx` mounted in `App.jsx` only when:
- `useIsMobile()` true
- `'DeviceOrientationEvent' in window`

Three states inline in one component:
1. **Inactive**: icon button "Enter AR Sky View".
2. **Pending**: disabled while awaiting permissions / first sample.
3. **Active**: exit button + an optional gear icon (only visible when
   the active pose source flagged `needsCalibration`).  Tapping the
   gear opens the calibration tap-overlay (`onAlign` prop).

## Testing

47 new tests across 4 files in `js/ar/`:

- `enuFrame.test.js` — orthonormality + handedness + anchor poses
  (e.g. ENU "East" at lat=0, lng=0 lands on body-fixed −Z).  15 tests.
- `DeviceOrientationPoseSource.test.js` — Z-X-Y rotation composition
  with anchor poses (zero angles → identity, alpha=90° → device-Y on
  West, etc.).  9 tests.
- `Calibration.test.js` — solver returns identity for matched aim,
  yaw-only correction for in-plane bias, tilt correction for out-of-plane;
  storage scope by source kind + screen angle.  13 tests.
- `ARController.test.js` — lifecycle (enter/exit, store publication,
  scene.enterAR/exitAR), per-frame compose, calibration capture +
  persistence across enter/exit/enter.  10 tests.

Plus extensions to `Scene.test.js` (5 tests for enterAR/exitAR
snapshot+restore) and `permalink.test.js` (5 tests for the new `A`
flag).

Existing test count: 333 → 385.  All pass.

Also: relax the three locale-dependent `Time.test.js` assertions so
they accept either ICU rendering of the date/clock separator
(`"Apr 5 at 10:13"` vs `"Apr 5, 10:13"`) — these were broken on
`origin/main` and were blocking the pre-commit hook.

## Stage breakdown

This PR ships stages 1a + 1b-stub + 1d.  Remaining work (separate PRs):

- **1b (full WebXR)** — replace the stub `isSupported()` with a real
  `navigator.xr.isSessionSupported('immersive-ar')` probe and wire the
  XR session's reference-space pose into `getQuaternion`.
- **1c (geolocation)** — `navigator.geolocation.watchPosition` with a
  manual-entry fallback, replaces the hardcoded observer lat/lng prop
  on `<ARButton>`.
- **2 (camera passthrough)** — `<video>` element behind a transparent
  canvas; atmosphere shader switches to premultiplied-alpha blend so
  daytime sky tints the camera feed instead of overwriting it.

## Test plan

- [ ] Open the app on a mobile device (iOS Safari or Chrome Android),
      confirm the new sky-view icon button appears in the top-right
      stack alongside the time panel and drag-mode toggle.
- [ ] Tap the button.  iOS prompts for orientation permission; Android
      proceeds immediately.  After "Allow", AR mode engages.
- [ ] Hold the phone up at night.  Polaris (or the celestial pole)
      should be at altitude ≈ observer's latitude.  Orion should rise
      east, set west, with constellation lines visible.
- [ ] Rotate the phone portrait ↔ landscape; the rendered sky stays
      upright (screen-orientation correction).
- [ ] Tap the exit button (X).  Prior view is restored, atmosphere
      returns, orbits/grids return to their prior toggle state.
- [ ] Enter AR, then capture a permalink (URL hash auto-updates after
      ~1 s of stable view).  Open the same URL on a fresh tab on the
      same device — should re-enter AR at the saved lat/lng.
- [ ] Open the same URL on desktop — should fall through to a static
      landed view with the saved orientation, no AR button engagement.
- [ ] On a desktop without `DeviceOrientationEvent`: confirm the AR
      button does not mount.
- [ ] `yarn lint && yarn test && yarn bundle-check` all clean.

https://claude.ai/code/session_016Bxg5w1FNGrG8vuKSjVKaa

---
_Generated by [Claude Code](https://claude.ai/code/session_016Bxg5w1FNGrG8vuKSjVKaa)_


---

## Iteration commit (testing on Samsung A34, May 2026)

After the original Stage-1 commits, hands-on testing on a Samsung
Galaxy A34 surfaced a stack of issues; this third commit addresses
them. tl;dr the Stage-1 framing held up, the magnetometer noise on
mid-range Android needed real filtering, the AR-mode UX needed more
care, and the dev loop needed HTTPS so we could test sensor APIs over
LAN at all.

### Orientation filter pipeline (`js/ar/`)
- `OneEuroFilter.js` — local impl of the Casiez et al. 1€ filter.
- `OneEuroFilterLib.js` — thin wrapper around the canonical
  `1eurofilter` npm package (BSD-3, by the algorithm's author).  Same
  surface as the local impl; A/B-swappable via a `USE_LIB_FILTER`
  constant.  Currently using the lib by default.
- `AlphaPipeline.js` — `raw → unwrap → optional notch → 1€` for the
  noisy yaw axis only.
- `BiquadNotch.js` — RBJ-cookbook biquad notch with per-sample
  coefficient recompute (handles the variable event rate the
  DeviceOrientation API delivers).  Not active on tested hardware
  (no clean carrier in the noise) but plumbed for future devices.
- Three damping presets (`light` / `medium` / `heavy`) selectable from
  the AR HUD.

### AR HUD ergonomics (`js/ui/ARButton.jsx`)
- Entry icon swapped to MUI `ViewInAr`.
- Active-AR tray gains three damping-mode buttons next to the X exit
  (Bolt / Waves / BlurOn — increasing visual smoothing maps to
  increasing filter damping).  Selected one is full opacity, others
  0.4.  Persisted to the store; reapplied on next entry.

### `enterAR` no longer teleports
`ARController.enter()` no longer calls `Scene.land()` — AR engages
wherever the camera currently is.  If the user has landed on a body's
surface before tapping AR, they keep that pose; if they're in space,
the celestial-sphere math just isn't ground-aligned, by-design.  Test
asserts no `scene.land` call.

Also: `updateFrame()` now slerps toward the composed pose at
`t = 0.35` instead of snapping (kills magnetometer-driven micro-jitter
in the rendered camera); first sample of an AR session still snaps so
entry feels instant.

### AR debug HUD (`js/ui/ARDebugHUD.jsx`)
New overlay (off by default — `arDebugVisible: false`) showing pose
source kind, sample count, raw vs filtered α/β/γ, screen orientation
angle, camera quaternion, plus a 10 s canvas timeseries graph for
alpha (raw / post-notch / filtered traces).  rAF polling and canvas
redraw only run when the toggle is on, so zero runtime cost in the
default state.

### Scene visibility tweaks (`js/scene/Scene.js`, `Star.js`)
At surface altitude with AR enabled, the lit limb of Earth and the
Sun's additive halo were washing the starfield to white/orange under
the from-space-tuned tone-mapping exposure.  `Scene.enterAR()` now
hides:
- Per-body `'planet surface and guides'` meshes
- Per-body `'atmosphere'` halos (incl. the Sun's; named for matching)
- The procedural `'MilkyWay'`

…and pins each per-body `'label LOD'` to its labelSheet level so
`togglePlanetLabels` actually does something at surface altitude
(default LOD picks `FAR_OBJ` when the camera is too close).
Restored on `exitAR`.

Added `Scene.toggleGalaxy()` + `'U'` keybinding (Celestia convention)
so the user can flip the Milky Way back on inside AR if they want.

### Settings panel (`js/ui/Settings.jsx`, `js/Keys.js`, `Celestiary.js`)
Reorganised into Celestia-style groups: **Info**, **Labels**,
**Orbits**, **Grids**, **Time**, **Camera**, **Targeting**.  Each
group has its own master checkbox with indeterminate state; clicking
the master forces all members on (or all off if all currently on).

- Toggle entries render as checkboxes reflecting current state instead
  of plain buttons; action-only entries keep their button.
- Arrow-key labels actually display as ↑ ↓ ← → now (the previous
  `KEY_LABELS` lookup was case-mismatched against `event.key`).
- Settings button moved before About in the bottom-left tray.

### Dev: HTTPS dev server (`esbuild/`, `tools/genDevCert.mjs`)
Phone testing of `DeviceOrientationEvent` requires a secure context.
Over LAN to a laptop, that's only possible with HTTPS.

- `esbuild/proxy.js` — optional TLS termination at the proxy layer.
- `esbuild/serve.js` — reads `DEV_HTTPS_KEY` / `DEV_HTTPS_CERT` env;
  prints LAN URL.
- `tools/genDevCert.mjs` — `mkcert` wrapper that generates a
  localhost + current-LAN-IP cert into `dev-certs/`, plus instructions
  for installing the `mkcert` root CA on a phone (Chrome on Android
  won't treat the LAN connection as a secure context without it).
- New scripts: `yarn cert:dev`, `yarn serve:https`.
- `dev-certs/` in `.gitignore`.

### Misc
- `Celestiary._currentBodyName` excludes stars (`spectralType !==
  undefined`) so AR's default-body fallback doesn't silently land the
  user on the Sun's photosphere when they tap AR while viewing it.
- Real-geolocation request in `ARButton.onEnter` so the math seed
  isn't always (0, 0).
- `arDebugVisible` and `arAlphaDamping` added to `ARSlice`.
- `'U'` (galaxy) added to `permalink` `SETTINGS_DEFAULTS`.

### Tests
411 pass (29 new across the filter modules + adjusted scene/controller
tests).  Lint clean.
