### PR TITLE
Add automated production deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,39 @@
+name: Deploy production (celestiary.github.io)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Skip silently when the cross-repo deploy key hasn't been configured
+    # yet, so first-time setup doesn't fail the workflow.
+    if: ${{ secrets.CELESTIARY_GITHUB_IO_DEPLOY_KEY != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: ./.github/actions/build
+        with:
+          base-path: /
+
+      - name: Push built site to celestiary.github.io gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        with:
+          repository-name: celestiary/celestiary.github.io
+          branch: gh-pages
+          folder: docs
+          ssh-key: ${{ secrets.CELESTIARY_GITHUB_IO_DEPLOY_KEY }}
+          clean: true
+          commit-message: "sync from celestiary/web@${{ github.sha }}"
+          git-config-name: github-actions[bot]
+          git-config-email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ Edits in the source directory will be available in the app on a page refresh.
 For larger changes, it's also a good idea to step through the guide pages (in /guide) to make sure they'll all working.
 
 ## Deploy
-The app runs at https://celestiary.github.io/ and is in the celestiary.github.io repo.  From it grab the changes from the web repo and then push them:
+The app is served at https://celestiary.github.io/ (user page, short URL) and
+https://celestiary.github.io/web/ (project page).  Both deploy automatically
+on push to `main` from this repo:
 
-```
-git pull upstream main
-git push
-```
+- `.github/workflows/gh-pages.yml` builds with `BASE_PATH=/web/` and pushes
+  to this repo's `gh-pages` branch root, serving the project page.
+- `.github/workflows/deploy-prod.yml` builds with `BASE_PATH=/` and pushes
+  to `celestiary/celestiary.github.io`'s `gh-pages` branch via an SSH deploy
+  key (secret `CELESTIARY_GITHUB_IO_DEPLOY_KEY`), serving the user page.
+
+PR previews land at `celestiary.github.io/web/pr-preview/pr-NNN/` via
+`.github/workflows/pr-preview.yml`.
 
 ## Performance
 A first-time session downloads ~3-5MB, mostly of the stars data.  Planet textures are lazy-fetched as the user moves around the scene, but will bring that upwards to ~10MB in full.


### PR DESCRIPTION
## Summary
Adds automated deployment of the built site to the production `celestiary.github.io` repository on every push to `main`, and updates deployment documentation to reflect the new workflow.

## Changes
- **New workflow**: `.github/workflows/deploy-prod.yml` automatically builds the site with `BASE_PATH=/` and deploys to the `celestiary/celestiary.github.io` repository's `gh-pages` branch via SSH deploy key
- **Updated documentation**: `README.md` now explains both deployment paths:
  - Project page at `celestiary.github.io/web/` (via existing `gh-pages.yml`)
  - User page at `celestiary.github.io/` (via new `deploy-prod.yml`)
  - PR previews at `celestiary.github.io/web/pr-preview/pr-NNN/` (via existing `pr-preview.yml`)

## Implementation Details
- Workflow is conditional on the `CELESTIARY_GITHUB_IO_DEPLOY_KEY` secret being configured, allowing graceful handling during initial setup
- Uses `JamesIves/github-pages-deploy-action@v4.8.0` to push built artifacts to the external repository
- Includes proper git configuration for automated commits
- Concurrency group prevents simultaneous deployments

https://claude.ai/code/session_01UidMryu4p3799b8osxdtPR