### PR TITLE
Remove conditional skip from production deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,9 +15,6 @@ permissions:
 
 jobs:
   deploy:
-    # Skip silently when the cross-repo deploy key hasn't been configured
-    # yet, so first-time setup doesn't fail the workflow.
-    if: ${{ secrets.CELESTIARY_GITHUB_IO_DEPLOY_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary
Removes the conditional check that was silently skipping the production deployment workflow when the deploy key secret was not configured. This allows the workflow to proceed regardless of whether the deployment credentials have been set up.

## Changes
- Removed the `if` condition that checked for `secrets.CELESTIARY_GITHUB_IO_DEPLOY_KEY` before running the deploy job
- The workflow will now attempt to run the deployment steps without this guard clause

## Notes
This change means the workflow will no longer silently skip on first-time setup when the deploy key hasn't been configured. Subsequent steps in the workflow will need to handle missing credentials appropriately, or the deploy key should be configured before this workflow is triggered.

https://claude.ai/code/session_01KJ3SXjNcUjMC8atyxnWfDd